### PR TITLE
fix(categories): merge forecast items on delete-reassign collision

### DIFF
--- a/backend/app/services/category_service.py
+++ b/backend/app/services/category_service.py
@@ -1270,14 +1270,36 @@ async def delete_category_with_migration(
         )
         .values(category_id=target.id)
     )
-    fpi_updated = await db.execute(
-        update(ForecastPlanItem)
-        .where(
+    # Forecast plan items carry a unique constraint on
+    # (plan_id, category_id, type) (uq_forecast_item_plan_cat_type), so a
+    # blind FK rewrite collides whenever the target already owns an item for
+    # the same plan+type. Mirror the category_rules merge below: re-point
+    # source items that don't collide; for those that do, sum the source's
+    # planned_amount into the target's existing item and drop the source
+    # item. Both source and target items are unique per (plan, type), so the
+    # mapping is 1:1.
+    source_items = (await db.scalars(
+        select(ForecastPlanItem).where(
             ForecastPlanItem.org_id == org_id,
             ForecastPlanItem.category_id == cat.id,
         )
-        .values(category_id=target.id)
-    )
+    )).all()
+    target_items_by_key = {
+        (it.plan_id, it.type): it
+        for it in (await db.scalars(
+            select(ForecastPlanItem).where(
+                ForecastPlanItem.org_id == org_id,
+                ForecastPlanItem.category_id == target.id,
+            )
+        )).all()
+    }
+    for item in source_items:
+        existing = target_items_by_key.get((item.plan_id, item.type))
+        if existing is None:
+            item.category_id = target.id
+        else:
+            existing.planned_amount += item.planned_amount
+            await db.delete(item)
 
     # Re-point the source's learned auto-categorization rules to the target
     # so removing a category does not silently drop its learning state.
@@ -1323,7 +1345,7 @@ async def delete_category_with_migration(
 
     migrated_tx = tx_updated.rowcount or 0
     migrated_rec = rec_updated.rowcount or 0
-    migrated_fpi = fpi_updated.rowcount or 0
+    migrated_fpi = len(source_items)
 
     audit_service.add_audit_event_to_session(
         db,

--- a/backend/app/services/category_service.py
+++ b/backend/app/services/category_service.py
@@ -1277,29 +1277,32 @@ async def delete_category_with_migration(
     # source items that don't collide; for those that do, sum the source's
     # planned_amount into the target's existing item and drop the source
     # item. Both source and target items are unique per (plan, type), so the
-    # mapping is 1:1.
-    source_items = (await db.scalars(
-        select(ForecastPlanItem).where(
-            ForecastPlanItem.org_id == org_id,
-            ForecastPlanItem.category_id == cat.id,
-        )
-    )).all()
-    target_items_by_key = {
-        (it.plan_id, it.type): it
-        for it in (await db.scalars(
+    # mapping is 1:1. Skip the queries entirely when the source has no
+    # forecast items (the common transaction/recurring-only delete).
+    source_items: list[ForecastPlanItem] = []
+    if breakdown.forecast_item_count:
+        source_items = list(await db.scalars(
             select(ForecastPlanItem).where(
                 ForecastPlanItem.org_id == org_id,
-                ForecastPlanItem.category_id == target.id,
+                ForecastPlanItem.category_id == cat.id,
             )
-        )).all()
-    }
-    for item in source_items:
-        existing = target_items_by_key.get((item.plan_id, item.type))
-        if existing is None:
-            item.category_id = target.id
-        else:
-            existing.planned_amount += item.planned_amount
-            await db.delete(item)
+        ))
+        target_items_by_key = {
+            (it.plan_id, it.type): it
+            for it in (await db.scalars(
+                select(ForecastPlanItem).where(
+                    ForecastPlanItem.org_id == org_id,
+                    ForecastPlanItem.category_id == target.id,
+                )
+            )).all()
+        }
+        for item in source_items:
+            existing = target_items_by_key.get((item.plan_id, item.type))
+            if existing is None:
+                item.category_id = target.id
+            else:
+                existing.planned_amount += item.planned_amount
+                await db.delete(item)
 
     # Re-point the source's learned auto-categorization rules to the target
     # so removing a category does not silently drop its learning state.

--- a/backend/tests/routers/test_categories_c0.py
+++ b/backend/tests/routers/test_categories_c0.py
@@ -221,18 +221,22 @@ async def _add_recurring(
 
 async def _add_forecast_item(
     factory, *, org_id: int, category_id: int, item_type: ForecastItemType,
-    planned_amount: str = "100.00",
+    planned_amount: str = "100.00", period_start: datetime.date | None = None,
 ) -> int:
     async with factory() as db:
-        # Need a billing period and plan first.
+        # Need a billing period and plan first. ``period_start`` lets a test
+        # target a specific period (hence a distinct plan); when omitted we
+        # reuse/create the org's current-month period.
         from app.models.billing import BillingPeriod
+        start = period_start or datetime.date.today().replace(day=1)
         period = await db.scalar(
-            select(BillingPeriod).where(BillingPeriod.org_id == org_id)
+            select(BillingPeriod).where(
+                BillingPeriod.org_id == org_id,
+                BillingPeriod.start_date == start,
+            )
         )
         if period is None:
-            period = BillingPeriod(
-                org_id=org_id, start_date=datetime.date.today().replace(day=1),
-            )
+            period = BillingPeriod(org_id=org_id, start_date=start)
             db.add(period)
             await db.flush()
         plan = await db.scalar(
@@ -471,6 +475,68 @@ async def test_delete_sums_forecast_item_colliding_with_targets_existing_item(
             select(Category).where(Category.id == seed["groceries_id"])
         )
         assert gone is None
+
+
+@pytest.mark.asyncio
+async def test_delete_mixes_repoint_and_merge_across_plans(session_factory):
+    """Across two plans, the source has one item the target collides with
+    (merge) and one the target does not (re-point). Both source items are
+    handled in a single operation and counted; the target ends up with the
+    summed item in plan A and the re-pointed item in plan B.
+    """
+    seed = await _seed_basic(session_factory)
+    plan_a = datetime.date(2020, 1, 1)
+    plan_b = datetime.date(2020, 2, 1)
+    # Plan A: both source and target have an EXPENSE item -> collision/merge.
+    await _add_forecast_item(
+        session_factory,
+        org_id=seed["org_id"], category_id=seed["groceries_id"],
+        item_type=ForecastItemType.EXPENSE, planned_amount="100.00",
+        period_start=plan_a,
+    )
+    target_a_id = await _add_forecast_item(
+        session_factory,
+        org_id=seed["org_id"], category_id=seed["restaurants_id"],
+        item_type=ForecastItemType.EXPENSE, planned_amount="25.00",
+        period_start=plan_a,
+    )
+    # Plan B: only the source has an item -> re-point.
+    source_b_id = await _add_forecast_item(
+        session_factory,
+        org_id=seed["org_id"], category_id=seed["groceries_id"],
+        item_type=ForecastItemType.EXPENSE, planned_amount="50.00",
+        period_start=plan_b,
+    )
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.delete(
+            f"/api/v1/categories/{seed['groceries_id']}"
+            f"?target_category_id={seed['restaurants_id']}"
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["migrated_forecast_item_count"] == 2
+
+    async with session_factory() as db:
+        # Plan A: merged into the target's existing item, summed.
+        merged = await db.scalar(
+            select(ForecastPlanItem).where(ForecastPlanItem.id == target_a_id)
+        )
+        assert merged.category_id == seed["restaurants_id"]
+        assert merged.planned_amount == Decimal("125.00")
+        # Plan B: source item re-pointed to the target, amount unchanged.
+        repointed = await db.scalar(
+            select(ForecastPlanItem).where(ForecastPlanItem.id == source_b_id)
+        )
+        assert repointed.category_id == seed["restaurants_id"]
+        assert repointed.planned_amount == Decimal("50.00")
+        # Nothing left on the deleted source.
+        orphans = (await db.scalars(
+            select(ForecastPlanItem).where(
+                ForecastPlanItem.category_id == seed["groceries_id"],
+            )
+        )).all()
+        assert orphans == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_categories_c0.py
+++ b/backend/tests/routers/test_categories_c0.py
@@ -221,6 +221,7 @@ async def _add_recurring(
 
 async def _add_forecast_item(
     factory, *, org_id: int, category_id: int, item_type: ForecastItemType,
+    planned_amount: str = "100.00",
 ) -> int:
     async with factory() as db:
         # Need a billing period and plan first.
@@ -247,7 +248,7 @@ async def _add_forecast_item(
             await db.flush()
         item = ForecastPlanItem(
             plan_id=plan.id, org_id=org_id, category_id=category_id,
-            type=item_type, planned_amount=Decimal("100.00"),
+            type=item_type, planned_amount=Decimal(planned_amount),
             source=ItemSource.HISTORY,
         )
         db.add(item)
@@ -407,6 +408,65 @@ async def test_delete_subcategory_with_target_migrates_dependents(session_factor
         )
         assert fpi.category_id == seed["restaurants_id"]
         # Source category gone.
+        gone = await db.scalar(
+            select(Category).where(Category.id == seed["groceries_id"])
+        )
+        assert gone is None
+
+
+@pytest.mark.asyncio
+async def test_delete_sums_forecast_item_colliding_with_targets_existing_item(
+    session_factory,
+):
+    """When source and target both have a forecast item for the same
+    (plan, type), migrating the source FK would violate
+    uq_forecast_item_plan_cat_type. The service must merge: sum the
+    source's planned_amount into the target's existing item and drop the
+    source item, instead of 500ing on a 1062 duplicate-key error.
+    """
+    seed = await _seed_basic(session_factory)
+    # Source (groceries) forecast item: EXPENSE, 100.
+    await _add_forecast_item(
+        session_factory,
+        org_id=seed["org_id"], category_id=seed["groceries_id"],
+        item_type=ForecastItemType.EXPENSE, planned_amount="100.00",
+    )
+    # Target (restaurants) forecast item in the SAME plan, SAME type: 25.
+    target_fpi_id = await _add_forecast_item(
+        session_factory,
+        org_id=seed["org_id"], category_id=seed["restaurants_id"],
+        item_type=ForecastItemType.EXPENSE, planned_amount="25.00",
+    )
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.delete(
+            f"/api/v1/categories/{seed['groceries_id']}"
+            f"?target_category_id={seed['restaurants_id']}"
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["migrated_forecast_item_count"] == 1
+
+    async with session_factory() as db:
+        # Target keeps a single item for the (plan, type), amounts summed.
+        items = (await db.scalars(
+            select(ForecastPlanItem).where(
+                ForecastPlanItem.org_id == seed["org_id"],
+                ForecastPlanItem.category_id == seed["restaurants_id"],
+                ForecastPlanItem.type == ForecastItemType.EXPENSE,
+            )
+        )).all()
+        assert len(items) == 1
+        assert items[0].id == target_fpi_id
+        assert items[0].planned_amount == Decimal("125.00")
+        # No forecast item left dangling on the deleted source.
+        orphans = (await db.scalars(
+            select(ForecastPlanItem).where(
+                ForecastPlanItem.category_id == seed["groceries_id"],
+            )
+        )).all()
+        assert orphans == []
         gone = await db.scalar(
             select(Category).where(Category.id == seed["groceries_id"])
         )


### PR DESCRIPTION
## Problem

Deleting a category with reassignment returned **"Delete failed"** in the UI. Production logs traced it to a 500 on `DELETE /api/v1/categories/{id}?target_category_id={target}`:

```
pymysql.err.IntegrityError: (1062, "Duplicate entry '7-410-expense'
   for key 'forecast_plan_items.uq_forecast_item_plan_cat_type'")
[SQL: UPDATE forecast_plan_items SET category_id=410 WHERE org_id=1 AND category_id=2367]
```

`delete_category_with_migration` migrated forecast items with a blind bulk `UPDATE` of `category_id`. But `forecast_plan_items` is unique on `(plan_id, category_id, type)`. When the source and target categories both have an item for the same plan+type, the rewrite collides and the whole request 500s. ("No child categories" is unrelated — the failure is in the forecast migration.) This is the #383 × #384 interaction; #384 gave forecast items their per-(plan, category, type) uniqueness and the #383 migration path never deduped against it.

## Fix

Mirror the existing `category_rules` collision handling immediately below the failing block: re-point source items that don't collide, and for those that do, **sum** the source's `planned_amount` into the target's existing item and drop the source item. Source and target items are each unique per (plan, type), so the mapping is 1:1.

Transactions and recurring transactions have no such unique constraint, so their bulk updates are unaffected.