### PR TITLE
feat(reports): TableWidget pagination via shared component + per-page selector

### DIFF
--- a/frontend/components/reports/widgets/TableWidget.tsx
+++ b/frontend/components/reports/widgets/TableWidget.tsx
@@ -4,8 +4,9 @@
  * Table widget — sortable, paginated rows. Columns are
  * ``dimensions`` (categorical) followed by one column per entry in
  * ``config.measures`` (numeric). Click a header to sort ascending /
- * descending; click again to flip. Pagination kicks in past 50 rows
- * with a fixed 50-rows-per-page chunk.
+ * descending; click again to flip. Pagination kicks in when more than
+ * one page of rows exists (default page size: 25, matching the shared
+ * system default; user-selectable via the per-page dropdown).
  *
  * **Spec ambiguity resolved (PR3, 2026-05-22):** each ``measures``
  * entry is its own column with its OWN aggregation. A report can mix
@@ -28,6 +29,8 @@ import type {
   CanvasFilters,
   TableWidget as TableWidgetType,
 } from "@/lib/reports/types";
+import Pagination from "@/components/ui/Pagination";
+import { pageCount } from "@/lib/hooks/use-table-state";
 import WidgetCsvButton from "./WidgetCsvButton";
 import type { CsvCell } from "@/lib/reports/csv";
 
@@ -37,7 +40,7 @@ interface Props {
   editMode?: boolean;
 }
 
-const PAGE_SIZE = 50;
+const DEFAULT_PAGE_SIZE = 25;
 
 export default function TableWidget({ widget, canvasFilters, editMode }: Props) {
   const measures = widget.config.measures.map((m) => m.measure);
@@ -57,6 +60,7 @@ export default function TableWidget({ widget, canvasFilters, editMode }: Props) 
   const [sortKey, setSortKey] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
 
   const sortedRows = useMemo(() => {
     if (!sortKey) return rows;
@@ -74,11 +78,11 @@ export default function TableWidget({ widget, canvasFilters, editMode }: Props) 
     return copy;
   }, [rows, sortKey, sortDir]);
 
-  const totalPages = Math.max(1, Math.ceil(sortedRows.length / PAGE_SIZE));
+  const totalPages = pageCount(sortedRows.length, pageSize);
   const safePage = Math.min(page, totalPages - 1);
   const pagedRows = sortedRows.slice(
-    safePage * PAGE_SIZE,
-    safePage * PAGE_SIZE + PAGE_SIZE,
+    safePage * pageSize,
+    safePage * pageSize + pageSize,
   );
 
   function toggleSort(key: string) {
@@ -255,34 +259,18 @@ export default function TableWidget({ widget, canvasFilters, editMode }: Props) 
           </table>
         )}
       </div>
-      {sortedRows.length > PAGE_SIZE && (
-        <div
-          data-testid="table-widget-pagination"
-          className="mt-2 flex items-center justify-between text-xs text-text-muted"
-        >
-          <span>
-            Page {safePage + 1} of {totalPages} · {sortedRows.length} rows
-          </span>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              data-testid="table-widget-prev-page"
-              disabled={safePage === 0}
-              onClick={() => setPage((p) => Math.max(0, p - 1))}
-              className="rounded border border-border px-2 py-0.5 hover:bg-bg-elevated disabled:opacity-40"
-            >
-              Prev
-            </button>
-            <button
-              type="button"
-              data-testid="table-widget-next-page"
-              disabled={safePage >= totalPages - 1}
-              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-              className="rounded border border-border px-2 py-0.5 hover:bg-bg-elevated disabled:opacity-40"
-            >
-              Next
-            </button>
-          </div>
+      {pageCount(sortedRows.length, pageSize) > 1 && (
+        <div data-testid="table-widget-pagination" className="mt-2">
+          <Pagination
+            page={safePage + 1}
+            pageSize={pageSize}
+            total={sortedRows.length}
+            onPageChange={(n) => setPage(n - 1)}
+            onPageSizeChange={(n) => {
+              setPageSize(n);
+              setPage(0);
+            }}
+          />
         </div>
       )}
     </div>

--- a/frontend/components/reports/widgets/TableWidget.tsx
+++ b/frontend/components/reports/widgets/TableWidget.tsx
@@ -259,7 +259,7 @@ export default function TableWidget({ widget, canvasFilters, editMode }: Props) 
           </table>
         )}
       </div>
-      {pageCount(sortedRows.length, pageSize) > 1 && (
+      {totalPages > 1 && (
         <div data-testid="table-widget-pagination" className="mt-2">
           <Pagination
             page={safePage + 1}

--- a/frontend/tests/components/reports/widgets/table-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/table-widget.test.tsx
@@ -369,7 +369,10 @@ describe("TableWidget", () => {
     );
 
     // Change per-page to 10.
-    fireEvent.change(screen.getByRole("combobox"), { target: { value: "10" } });
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "Per page" }),
+      { target: { value: "10" } },
+    );
 
     // Should snap back to page 1 — Cat 0 visible again.
     await waitFor(() =>

--- a/frontend/tests/components/reports/widgets/table-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/table-widget.test.tsx
@@ -117,7 +117,10 @@ describe("TableWidget", () => {
     });
   });
 
-  it("renders pagination when rows exceed PAGE_SIZE (50)", async () => {
+  it("renders pagination when rows exceed the page size", async () => {
+    // 75 rows with the default page size of 25 => 3 pages, so pagination is shown.
+    // The shared Pagination component uses accessible button names ("Next page" /
+    // "Previous page") rather than data-testid attributes, so we query by role.
     const rows = Array.from({ length: 75 }, (_, i) => ({
       category: `Cat ${i}`,
       value: i,
@@ -133,7 +136,9 @@ describe("TableWidget", () => {
     expect(
       screen.getByTestId("table-widget-pagination"),
     ).toBeInTheDocument();
-    expect(screen.getByTestId("table-widget-next-page")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Next page" }),
+    ).toBeInTheDocument();
   });
 
   it("renders a Total row that sums all rows of a sum measure", async () => {
@@ -156,8 +161,8 @@ describe("TableWidget", () => {
   });
 
   it("sums ALL rows in the total even across multiple pages", async () => {
-    // 75 rows, value = 1 each => grand total 75, even though only 50
-    // are visible on the first page.
+    // 75 rows, value = 1 each => grand total 75, even though only 25
+    // (the default page size) are visible on the first page.
     const rows = Array.from({ length: 75 }, (_, i) => ({
       category: `Cat ${i}`,
       value: 1,
@@ -339,5 +344,73 @@ describe("TableWidget", () => {
 
     await screen.findByText("Food");
     expect(screen.queryByTestId("widget-csv-export")).toBeNull();
+  });
+
+  it("per-page selector limits visible rows and resets to the first page", async () => {
+    // 30 rows; default page size 25 shows the first 25 on page 1.
+    // Switching to 10 per page should show only 10 rows and reset to page 1.
+    const rows = Array.from({ length: 30 }, (_, i) => ({
+      category: `Cat ${i}`,
+      value: i,
+    }));
+    runQueryMock.mockResolvedValueOnce({
+      rows,
+      meta: { row_count: 30, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<TableWidget widget={makeWidget()} />);
+
+    // Wait for data and confirm 25 rows visible on the first page.
+    await screen.findByText("Cat 0");
+    // Advance to page 2 before changing page size so we can confirm reset.
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+    await waitFor(() =>
+      expect(screen.queryByText("Cat 0")).not.toBeInTheDocument(),
+    );
+
+    // Change per-page to 10.
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "10" } });
+
+    // Should snap back to page 1 — Cat 0 visible again.
+    await waitFor(() =>
+      expect(screen.getByText("Cat 0")).toBeInTheDocument(),
+    );
+    // Cat 10 should NOT be visible (only rows 0–9 on first page of 10).
+    expect(screen.queryByText("Cat 10")).not.toBeInTheDocument();
+  });
+
+  it("Next and Previous buttons navigate in-memory rows", async () => {
+    // 30 rows with default page size 25: page 1 shows Cat 0..24, page 2 shows Cat 25..29.
+    const rows = Array.from({ length: 30 }, (_, i) => ({
+      category: `Cat ${i}`,
+      value: i,
+    }));
+    runQueryMock.mockResolvedValueOnce({
+      rows,
+      meta: { row_count: 30, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<TableWidget widget={makeWidget()} />);
+
+    await screen.findByText("Cat 0");
+    // Previous should be disabled on page 1.
+    expect(screen.getByRole("button", { name: "Previous page" })).toBeDisabled();
+
+    // Navigate to page 2.
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+    await waitFor(() =>
+      expect(screen.getByText("Cat 25")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Cat 0")).not.toBeInTheDocument();
+
+    // Next should now be disabled (last page).
+    expect(screen.getByRole("button", { name: "Next page" })).toBeDisabled();
+
+    // Navigate back.
+    fireEvent.click(screen.getByRole("button", { name: "Previous page" }));
+    await waitFor(() =>
+      expect(screen.getByText("Cat 0")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Cat 25")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

Spec PR4 (independent of the #389 backend contract — the report table stays **in-memory**, data from the report query). Re-skins the Report Table widget's pagination to the shared `Pagination` component from #388.

- Replaces the bespoke prev/next footer + fixed 50/page with the shared `<Pagination>`: per-page selector (10/25/50/100), Previous/Next, "Page X of Y · N total".
- Page size is now stateful, **default 25** (matches the system-wide default; changes the widget's previous hard-coded 50). Changing per-page resets to the first page.
- Sort UI is unchanged (same headers, `data-testid`s, indicators); only pagination was re-skinned. CSV export still operates on the full sorted set. `safePage` clamping preserved.

## Tests

`table-widget.test.tsx` 15/15 (13 existing + 2 new: per-page selector limits rows + resets to page 1; Next/Previous navigate). Updated the old pagination assertions to target the shared component's accessible button names + wording (sort assertions untouched). Full `tests/components/reports/` 88/88 green, tsc clean.

## Context

Independent of #389 (which is landing first). The remaining fronts (admin orgs/subscriptions/audit/rate-limit-overrides, system/settings tables, transactions migration) reuse #389's `resolve_order_by`/`ListEnvelope` contract and are queued behind its merge.