### PR TITLE
feat(recurring): sync name and category from a linked transaction to the series

### DIFF
--- a/backend/app/services/recurring_service.py
+++ b/backend/app/services/recurring_service.py
@@ -176,8 +176,9 @@ async def stop_recurring(db: AsyncSession, org_id: int, recurring_id: int) -> in
     r.is_active = False
     removed = await _remove_pending_transactions(db, org_id, recurring_id)
 
-    # Clear the now-defunct recurring link on surviving (settled) rows so the
-    # "Recurring" badge disappears, mirroring delete's ON DELETE SET NULL.
+    # Clear the now-defunct recurring link on all surviving rows (settled, plus
+    # any past-dated pending) so the "Recurring" badge disappears, mirroring
+    # delete's ON DELETE SET NULL.
     await db.execute(
         update(Transaction)
         .where(

--- a/backend/app/services/recurring_service.py
+++ b/backend/app/services/recurring_service.py
@@ -7,7 +7,7 @@ next_due_date has passed. Advances next_due_date based on frequency.
 import datetime
 
 import structlog
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -175,6 +175,17 @@ async def stop_recurring(db: AsyncSession, org_id: int, recurring_id: int) -> in
 
     r.is_active = False
     removed = await _remove_pending_transactions(db, org_id, recurring_id)
+
+    # Clear the now-defunct recurring link on surviving (settled) rows so the
+    # "Recurring" badge disappears, mirroring delete's ON DELETE SET NULL.
+    await db.execute(
+        update(Transaction)
+        .where(
+            Transaction.recurring_id == recurring_id,
+            Transaction.org_id == org_id,
+        )
+        .values(recurring_id=None)
+    )
 
     await db.commit()
     return removed

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -616,8 +616,17 @@ async def update_transaction(
     # Settled siblings keep their snapshot values. See spec
     # specs/recurring-transaction-field-sync.md.
     if tx.recurring_id is not None:
+        type_changed = body.type is not None and tx.type != old_type
         desc_changed = body.description is not None and tx.description != old_description
-        cat_changed = body.category_id is not None and tx.category_id != old_category_id
+        # Suppress category propagation when this edit also changed the row's
+        # type: the template's type is independent and is never propagated, so
+        # writing a type-incompatible category onto it would corrupt future
+        # generations. Name propagation is unaffected.
+        cat_changed = (
+            body.category_id is not None
+            and tx.category_id != old_category_id
+            and not type_changed
+        )
         if desc_changed or cat_changed:
             await _propagate_fields_to_series(
                 db,

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -399,8 +399,9 @@ async def _propagate_fields_to_series(
         )
         .values(**values)
     )
-    # Core update() also bumps each pending sibling's updated_at via onupdate;
-    # harmless and expected.
+    # The pending-sibling update below bumps each row's updated_at via the
+    # column's onupdate; harmless and expected. (RecurringTransaction has no
+    # updated_at, so its update above changes only the named fields.)
     await db.execute(
         update(Transaction)
         .where(

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -14,13 +14,14 @@ import datetime
 from decimal import Decimal, InvalidOperation
 
 import structlog
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.account import Account
 from app.models.category import Category, CategoryType
+from app.models.recurring import RecurringTransaction
 from app.models.tag import Tag, TransactionTag
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.schemas.tag import TagResponse
@@ -371,6 +372,44 @@ async def create_transaction(
     return result.scalar_one()
 
 
+async def _propagate_fields_to_series(
+    db: AsyncSession,
+    org_id: int,
+    recurring_id: int,
+    *,
+    description: str | None,
+    category_id: int | None,
+) -> None:
+    """Sync name/category from an edited recurring-linked transaction to its
+    template and all PENDING sibling instances. Pass only the fields that
+    actually changed; None means leave that field untouched. SETTLED instances
+    are intentionally never modified (historical fact). Caller commits."""
+    values: dict = {}
+    if description is not None:
+        values["description"] = description
+    if category_id is not None:
+        values["category_id"] = category_id
+    if not values:
+        return
+    await db.execute(
+        update(RecurringTransaction)
+        .where(
+            RecurringTransaction.id == recurring_id,
+            RecurringTransaction.org_id == org_id,
+        )
+        .values(**values)
+    )
+    await db.execute(
+        update(Transaction)
+        .where(
+            Transaction.recurring_id == recurring_id,
+            Transaction.org_id == org_id,
+            Transaction.status == TransactionStatus.PENDING,
+        )
+        .values(**values)
+    )
+
+
 async def update_transaction(
     db: AsyncSession, org_id: int, transaction_id: int, body: TransactionUpdate
 ) -> Transaction:
@@ -452,6 +491,7 @@ async def update_transaction(
     old_type = tx.type
     old_status = tx.status
     old_category_id = tx.category_id
+    old_description = tx.description
 
     new_account_id = body.account_id if body.account_id is not None else old_account_id
     new_status = TransactionStatus(body.status) if body.status is not None else old_status
@@ -567,6 +607,22 @@ async def update_transaction(
                 partner_id=partner.id,
                 old_amount=str(pre_edit_amount),
                 new_amount=str(tx.amount),
+            )
+
+    # Sync name/category forward to the recurring series (template + pending
+    # siblings) when this row belongs to one and the field actually changed.
+    # Settled siblings keep their snapshot values. See spec
+    # specs/recurring-transaction-field-sync.md.
+    if tx.recurring_id is not None:
+        desc_changed = body.description is not None and tx.description != old_description
+        cat_changed = body.category_id is not None and tx.category_id != old_category_id
+        if desc_changed or cat_changed:
+            await _propagate_fields_to_series(
+                db,
+                org_id,
+                tx.recurring_id,
+                description=tx.description if desc_changed else None,
+                category_id=tx.category_id if cat_changed else None,
             )
 
     await db.commit()

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -379,38 +379,64 @@ async def _propagate_fields_to_series(
     *,
     description: str | None,
     category_id: int | None,
+    tx_type: TransactionType,
 ) -> None:
     """Sync name/category from an edited recurring-linked transaction to its
-    template and all PENDING sibling instances. Pass only the fields that
-    actually changed; None means leave that field untouched. SETTLED instances
-    are intentionally never modified (historical fact). Caller commits."""
-    values: dict[str, object] = {}
+    template and PENDING sibling instances. Pass only the fields that actually
+    changed; None means leave that field untouched.
+
+    `description` is type-independent: it propagates to the template and ALL
+    PENDING siblings. `category_id` is type-dependent: a (type, category) pair
+    validated for one type may be invalid for another, so it propagates ONLY to
+    rows whose type matches the edited row's `tx_type` (the type its new
+    category was validated against). This prevents corrupting a template or a
+    sibling whose type has diverged via a per-occurrence edit.
+
+    SETTLED instances are never modified (historical fact). Concurrency: two
+    edits to different siblings race last-writer-wins on the template, which is
+    acceptable (no invariant at stake). Callers holding sibling ORM objects must
+    expire/re-select afterward; `update_transaction` re-selects the edited row
+    post-commit. Caller commits."""
     if description is not None:
-        values["description"] = description
+        await db.execute(
+            update(RecurringTransaction)
+            .where(
+                RecurringTransaction.id == recurring_id,
+                RecurringTransaction.org_id == org_id,
+            )
+            .values(description=description)
+        )
+        await db.execute(
+            update(Transaction)
+            .where(
+                Transaction.recurring_id == recurring_id,
+                Transaction.org_id == org_id,
+                Transaction.status == TransactionStatus.PENDING,
+            )
+            .values(description=description)
+        )
     if category_id is not None:
-        values["category_id"] = category_id
-    if not values:
-        return
-    await db.execute(
-        update(RecurringTransaction)
-        .where(
-            RecurringTransaction.id == recurring_id,
-            RecurringTransaction.org_id == org_id,
+        # RecurringTransaction.type is stored as the lowercase string value
+        # ("income"/"expense"); Transaction.type is the TransactionType enum.
+        await db.execute(
+            update(RecurringTransaction)
+            .where(
+                RecurringTransaction.id == recurring_id,
+                RecurringTransaction.org_id == org_id,
+                RecurringTransaction.type == tx_type.value,
+            )
+            .values(category_id=category_id)
         )
-        .values(**values)
-    )
-    # The pending-sibling update below bumps each row's updated_at via the
-    # column's onupdate; harmless and expected. (RecurringTransaction has no
-    # updated_at, so its update above changes only the named fields.)
-    await db.execute(
-        update(Transaction)
-        .where(
-            Transaction.recurring_id == recurring_id,
-            Transaction.org_id == org_id,
-            Transaction.status == TransactionStatus.PENDING,
+        await db.execute(
+            update(Transaction)
+            .where(
+                Transaction.recurring_id == recurring_id,
+                Transaction.org_id == org_id,
+                Transaction.status == TransactionStatus.PENDING,
+                Transaction.type == tx_type,
+            )
+            .values(category_id=category_id)
         )
-        .values(**values)
-    )
 
 
 async def update_transaction(
@@ -617,17 +643,8 @@ async def update_transaction(
     # Settled siblings keep their snapshot values. See spec
     # specs/recurring-transaction-field-sync.md.
     if tx.recurring_id is not None:
-        type_changed = body.type is not None and tx.type != old_type
         desc_changed = body.description is not None and tx.description != old_description
-        # Suppress category propagation when this edit also changed the row's
-        # type: the template's type is independent and is never propagated, so
-        # writing a type-incompatible category onto it would corrupt future
-        # generations. Name propagation is unaffected.
-        cat_changed = (
-            body.category_id is not None
-            and tx.category_id != old_category_id
-            and not type_changed
-        )
+        cat_changed = body.category_id is not None and tx.category_id != old_category_id
         if desc_changed or cat_changed:
             await _propagate_fields_to_series(
                 db,
@@ -635,6 +652,7 @@ async def update_transaction(
                 tx.recurring_id,
                 description=tx.description if desc_changed else None,
                 category_id=tx.category_id if cat_changed else None,
+                tx_type=tx.type,
             )
 
     await db.commit()

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -384,7 +384,7 @@ async def _propagate_fields_to_series(
     template and all PENDING sibling instances. Pass only the fields that
     actually changed; None means leave that field untouched. SETTLED instances
     are intentionally never modified (historical fact). Caller commits."""
-    values: dict = {}
+    values: dict[str, object] = {}
     if description is not None:
         values["description"] = description
     if category_id is not None:
@@ -399,6 +399,8 @@ async def _propagate_fields_to_series(
         )
         .values(**values)
     )
+    # Core update() also bumps each pending sibling's updated_at via onupdate;
+    # harmless and expected.
     await db.execute(
         update(Transaction)
         .where(

--- a/backend/tests/services/test_recurring_field_sync.py
+++ b/backend/tests/services/test_recurring_field_sync.py
@@ -176,3 +176,24 @@ async def test_edit_from_settled_instance_still_propagates(db_session):
     assert (await db_session.get(RecurringTransaction, rid)).description == "Renamed"
     assert (await db_session.get(Transaction, pending)).description == "Renamed"
     assert (await db_session.get(Transaction, settled)).description == "Renamed"
+
+
+async def test_edit_name_and_category_together_propagate(db_session):
+    seed = await _seed(db_session)
+    rid = await _add_template(db_session, seed)
+    p1 = await _add_instance(db_session, seed, rid, status=TransactionStatus.PENDING)
+
+    await transaction_service.update_transaction(
+        db_session,
+        seed["org_id"],
+        p1,
+        TransactionUpdate(description="Gym Plus", category_id=seed["exp_cat2"]),
+    )
+
+    db_session.expire_all()
+    tmpl = await db_session.get(RecurringTransaction, rid)
+    assert tmpl.description == "Gym Plus"
+    assert tmpl.category_id == seed["exp_cat2"]
+    inst = await db_session.get(Transaction, p1)
+    assert inst.description == "Gym Plus"
+    assert inst.category_id == seed["exp_cat2"]

--- a/backend/tests/services/test_recurring_field_sync.py
+++ b/backend/tests/services/test_recurring_field_sync.py
@@ -24,7 +24,7 @@ from app.models.category import CategoryType
 from app.models.recurring import Frequency, RecurringTransaction
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.schemas.transaction import TransactionUpdate
-from app.services import transaction_service
+from app.services import recurring_service, transaction_service
 
 pytestmark = pytest.mark.asyncio
 
@@ -197,3 +197,40 @@ async def test_edit_name_and_category_together_propagate(db_session):
     inst = await db_session.get(Transaction, p1)
     assert inst.description == "Gym Plus"
     assert inst.category_id == seed["exp_cat2"]
+
+
+async def test_stop_clears_recurring_link_on_survivors(db_session):
+    seed = await _seed(db_session)
+    rid = await _add_template(db_session, seed)
+    settled = await _add_instance(
+        db_session, seed, rid, status=TransactionStatus.SETTLED,
+        dt=date.today() - timedelta(days=10),
+    )
+    future_pending = await _add_instance(
+        db_session, seed, rid, status=TransactionStatus.PENDING,
+        dt=date.today() + timedelta(days=10),
+    )
+
+    await recurring_service.stop_recurring(db_session, seed["org_id"], rid)
+
+    db_session.expire_all()
+    survivor = await db_session.get(Transaction, settled)
+    assert survivor is not None
+    assert survivor.recurring_id is None
+    assert (await db_session.get(Transaction, future_pending)) is None
+
+
+async def test_delete_clears_recurring_link_on_survivors(db_session):
+    seed = await _seed(db_session)
+    rid = await _add_template(db_session, seed)
+    settled = await _add_instance(
+        db_session, seed, rid, status=TransactionStatus.SETTLED,
+        dt=date.today() - timedelta(days=10),
+    )
+
+    await recurring_service.delete_recurring(db_session, seed["org_id"], rid)
+
+    db_session.expire_all()
+    survivor = await db_session.get(Transaction, settled)
+    assert survivor is not None
+    assert survivor.recurring_id is None

--- a/backend/tests/services/test_recurring_field_sync.py
+++ b/backend/tests/services/test_recurring_field_sync.py
@@ -225,6 +225,83 @@ async def test_category_not_propagated_when_type_also_changed(db_session):
     assert edited.category_id == inc_id
 
 
+async def test_category_not_propagated_from_type_diverged_instance(db_session):
+    from app.models.category import Category, CategoryType
+    seed = await _seed(db_session)
+    rid = await _add_template(db_session, seed)  # expense template, exp_cat
+    diverged = await _add_instance(db_session, seed, rid, status=TransactionStatus.PENDING)
+    sibling = await _add_instance(db_session, seed, rid, status=TransactionStatus.PENDING)
+    inc1 = Category(org_id=seed["org_id"], name="Salary", slug="salary", type=CategoryType.INCOME)
+    inc2 = Category(org_id=seed["org_id"], name="Bonus", slug="bonus", type=CategoryType.INCOME)
+    db_session.add_all([inc1, inc2])
+    await db_session.commit()
+    inc1_id, inc2_id = inc1.id, inc2.id
+
+    # Diverge `diverged` to income (type + compatible income category together).
+    await transaction_service.update_transaction(
+        db_session, seed["org_id"], diverged,
+        TransactionUpdate(type="income", category_id=inc1_id),
+    )
+    # Now edit ONLY its category to another income category (no type change).
+    await transaction_service.update_transaction(
+        db_session, seed["org_id"], diverged, TransactionUpdate(category_id=inc2_id),
+    )
+
+    db_session.expire_all()
+    # Expense template + expense sibling must NOT receive the income category.
+    assert (await db_session.get(RecurringTransaction, rid)).category_id == seed["exp_cat"]
+    assert (await db_session.get(Transaction, sibling)).category_id == seed["exp_cat"]
+    # The edited (income) row itself changes.
+    assert (await db_session.get(Transaction, diverged)).category_id == inc2_id
+
+
+async def test_category_propagation_skips_type_diverged_sibling(db_session):
+    from app.models.category import Category, CategoryType
+    seed = await _seed(db_session)
+    rid = await _add_template(db_session, seed)  # expense template, exp_cat
+    normal = await _add_instance(db_session, seed, rid, status=TransactionStatus.PENDING)
+    diverged_sib = await _add_instance(db_session, seed, rid, status=TransactionStatus.PENDING)
+    inc = Category(org_id=seed["org_id"], name="Salary", slug="salary", type=CategoryType.INCOME)
+    db_session.add(inc)
+    await db_session.commit()
+    inc_id = inc.id
+
+    # Diverge the sibling to income.
+    await transaction_service.update_transaction(
+        db_session, seed["org_id"], diverged_sib,
+        TransactionUpdate(type="income", category_id=inc_id),
+    )
+    # Edit the NORMAL expense instance's category.
+    await transaction_service.update_transaction(
+        db_session, seed["org_id"], normal, TransactionUpdate(category_id=seed["exp_cat2"]),
+    )
+
+    db_session.expire_all()
+    # Template (expense) + the normal expense row get the new expense category.
+    assert (await db_session.get(RecurringTransaction, rid)).category_id == seed["exp_cat2"]
+    assert (await db_session.get(Transaction, normal)).category_id == seed["exp_cat2"]
+    # The income-diverged sibling is NOT overwritten with an expense category.
+    assert (await db_session.get(Transaction, diverged_sib)).category_id == inc_id
+
+
+async def test_unchanged_resave_does_not_propagate(db_session):
+    seed = await _seed(db_session)
+    rid = await _add_template(db_session, seed)  # description "Gym"
+    p1 = await _add_instance(db_session, seed, rid, status=TransactionStatus.PENDING, description="Gym")
+    # Drift the template so that, IF propagation wrongly fired, it would overwrite this.
+    tmpl = await db_session.get(RecurringTransaction, rid)
+    tmpl.description = "Drifted"
+    await db_session.commit()
+    # Re-save with the SAME description (no real change) plus an amount edit.
+    await transaction_service.update_transaction(
+        db_session, seed["org_id"], p1,
+        TransactionUpdate(description="Gym", amount=Decimal("12.00")),
+    )
+    db_session.expire_all()
+    # description didn't change → propagation must not have fired → drift preserved.
+    assert (await db_session.get(RecurringTransaction, rid)).description == "Drifted"
+
+
 async def test_stop_clears_recurring_link_on_survivors(db_session):
     seed = await _seed(db_session)
     rid = await _add_template(db_session, seed)

--- a/backend/tests/services/test_recurring_field_sync.py
+++ b/backend/tests/services/test_recurring_field_sync.py
@@ -1,0 +1,178 @@
+"""Editing a recurring-linked transaction syncs name/category forward.
+
+- name/category edit on any linked instance updates the template AND all
+  PENDING sibling instances
+- SETTLED instances are never touched
+- amount-only edits do not propagate
+- editing a non-origin (settled) instance still propagates to the series
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.recurring import Frequency, RecurringTransaction
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.schemas.transaction import TransactionUpdate
+from app.services import transaction_service
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db: AsyncSession) -> dict:
+    org = Organization(name="T", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db.add(at)
+    await db.flush()
+    acct = Account(
+        org_id=org.id, name="Main", account_type_id=at.id,
+        balance=Decimal("0"), currency="EUR",
+    )
+    db.add(acct)
+    await db.flush()
+    exp = Category(org_id=org.id, name="Gym", slug="gym", type=CategoryType.EXPENSE)
+    exp2 = Category(org_id=org.id, name="Health", slug="health", type=CategoryType.EXPENSE)
+    db.add_all([exp, exp2])
+    await db.commit()
+    return {
+        "org_id": org.id, "account_id": acct.id,
+        "exp_cat": exp.id, "exp_cat2": exp2.id,
+    }
+
+
+async def _add_template(db: AsyncSession, seed: dict) -> int:
+    r = RecurringTransaction(
+        org_id=seed["org_id"], account_id=seed["account_id"],
+        category_id=seed["exp_cat"], description="Gym", amount=Decimal("30.00"),
+        type="expense", frequency=Frequency.MONTHLY, next_due_date=date.today(),
+        auto_settle=False, is_active=True,
+    )
+    db.add(r)
+    await db.commit()
+    return r.id
+
+
+async def _add_instance(
+    db: AsyncSession, seed: dict, recurring_id: int, *, status: TransactionStatus,
+    description: str = "Gym", category_id: int | None = None, dt: date | None = None,
+) -> int:
+    when = dt or date.today()
+    tx = Transaction(
+        org_id=seed["org_id"], account_id=seed["account_id"],
+        category_id=category_id or seed["exp_cat"], description=description,
+        amount=Decimal("30.00"), type=TransactionType.EXPENSE, status=status,
+        date=when,
+        settled_date=when if status == TransactionStatus.SETTLED else None,
+        recurring_id=recurring_id,
+    )
+    db.add(tx)
+    await db.commit()
+    return tx.id
+
+
+async def test_edit_name_propagates_to_template_and_pending(db_session):
+    seed = await _seed(db_session)
+    rid = await _add_template(db_session, seed)
+    p1 = await _add_instance(db_session, seed, rid, status=TransactionStatus.PENDING)
+    p2 = await _add_instance(db_session, seed, rid, status=TransactionStatus.PENDING)
+    settled = await _add_instance(
+        db_session, seed, rid, status=TransactionStatus.SETTLED,
+        dt=date.today() - timedelta(days=10),
+    )
+
+    await transaction_service.update_transaction(
+        db_session, seed["org_id"], p1, TransactionUpdate(description="Gym Membership"),
+    )
+
+    db_session.expire_all()
+    assert (await db_session.get(RecurringTransaction, rid)).description == "Gym Membership"
+    assert (await db_session.get(Transaction, p1)).description == "Gym Membership"
+    assert (await db_session.get(Transaction, p2)).description == "Gym Membership"
+    assert (await db_session.get(Transaction, settled)).description == "Gym"
+
+
+async def test_edit_category_propagates_to_template_and_pending(db_session):
+    seed = await _seed(db_session)
+    rid = await _add_template(db_session, seed)
+    p1 = await _add_instance(db_session, seed, rid, status=TransactionStatus.PENDING)
+    settled = await _add_instance(
+        db_session, seed, rid, status=TransactionStatus.SETTLED,
+        dt=date.today() - timedelta(days=10),
+    )
+
+    await transaction_service.update_transaction(
+        db_session, seed["org_id"], p1, TransactionUpdate(category_id=seed["exp_cat2"]),
+    )
+
+    db_session.expire_all()
+    assert (await db_session.get(RecurringTransaction, rid)).category_id == seed["exp_cat2"]
+    assert (await db_session.get(Transaction, p1)).category_id == seed["exp_cat2"]
+    assert (await db_session.get(Transaction, settled)).category_id == seed["exp_cat"]
+
+
+async def test_amount_only_edit_does_not_propagate(db_session):
+    seed = await _seed(db_session)
+    rid = await _add_template(db_session, seed)
+    p1 = await _add_instance(db_session, seed, rid, status=TransactionStatus.PENDING)
+
+    await transaction_service.update_transaction(
+        db_session, seed["org_id"], p1, TransactionUpdate(amount=Decimal("99.00")),
+    )
+
+    db_session.expire_all()
+    tmpl = await db_session.get(RecurringTransaction, rid)
+    assert tmpl.description == "Gym"
+    assert tmpl.amount == Decimal("30.00")
+
+
+async def test_edit_from_settled_instance_still_propagates(db_session):
+    seed = await _seed(db_session)
+    rid = await _add_template(db_session, seed)
+    pending = await _add_instance(db_session, seed, rid, status=TransactionStatus.PENDING)
+    settled = await _add_instance(
+        db_session, seed, rid, status=TransactionStatus.SETTLED,
+        dt=date.today() - timedelta(days=10),
+    )
+
+    await transaction_service.update_transaction(
+        db_session, seed["org_id"], settled, TransactionUpdate(description="Renamed"),
+    )
+
+    db_session.expire_all()
+    assert (await db_session.get(RecurringTransaction, rid)).description == "Renamed"
+    assert (await db_session.get(Transaction, pending)).description == "Renamed"
+    assert (await db_session.get(Transaction, settled)).description == "Renamed"

--- a/backend/tests/services/test_recurring_field_sync.py
+++ b/backend/tests/services/test_recurring_field_sync.py
@@ -199,6 +199,32 @@ async def test_edit_name_and_category_together_propagate(db_session):
     assert inst.category_id == seed["exp_cat2"]
 
 
+async def test_category_not_propagated_when_type_also_changed(db_session):
+    from app.models.category import Category, CategoryType
+    seed = await _seed(db_session)
+    rid = await _add_template(db_session, seed)
+    p1 = await _add_instance(db_session, seed, rid, status=TransactionStatus.PENDING)
+
+    inc = Category(org_id=seed["org_id"], name="Bonus", slug="bonus", type=CategoryType.INCOME)
+    db_session.add(inc)
+    await db_session.commit()
+    inc_id = inc.id
+
+    await transaction_service.update_transaction(
+        db_session, seed["org_id"], p1,
+        TransactionUpdate(type="income", category_id=inc_id),
+    )
+
+    db_session.expire_all()
+    tmpl = await db_session.get(RecurringTransaction, rid)
+    # Template keeps its original expense category and type; no corrupting cross-type write.
+    assert tmpl.category_id == seed["exp_cat"]
+    assert tmpl.type == "expense"
+    # The edited row itself did change (its own type/category), but that's local.
+    edited = await db_session.get(Transaction, p1)
+    assert edited.category_id == inc_id
+
+
 async def test_stop_clears_recurring_link_on_survivors(db_session):
     seed = await _seed(db_session)
     rid = await _add_template(db_session, seed)

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -182,6 +182,19 @@ export default function DocsPage() {
               intentional: the template only schedules what has not
               happened yet.
             </p>
+            <p>
+              Transactions generated from a recurring template are
+              independent copies. Editing the name or category of any
+              one of them updates the template and every upcoming (not
+              yet settled) occurrence, so the series stays consistent
+              going forward. Amounts and dates stay per occurrence, so
+              you can adjust a single month without changing the rest.
+              Settled past entries are never rewritten. Deleting a
+              single transaction never removes other occurrences. Only
+              stopping or deleting the recurring template removes its
+              pending future occurrences, and settled history is always
+              kept.
+            </p>
 
             <h3>Marking transactions as a transfer pair</h3>
             <p>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1526,12 +1526,22 @@ function TransactionsPageContent() {
                           {!editPartner && (
                             <div className="mt-3" data-testid={`edit-recurring-row-${tx.id}`}>
                               {tx.recurring_id !== null ? (
-                                <span
-                                  className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-[11px] text-text-muted"
-                                  data-testid={`edit-recurring-chip-${tx.id}`}
-                                >
-                                  Recurring
-                                </span>
+                                <div className="flex flex-col gap-1">
+                                  <span
+                                    title="Generated from a recurring series. Name and category stay in sync with the series."
+                                    className="inline-flex w-fit items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-[11px] text-text-muted"
+                                    data-testid={`edit-recurring-chip-${tx.id}`}
+                                  >
+                                    Recurring
+                                  </span>
+                                  <p
+                                    className="text-[11px] text-text-muted"
+                                    data-testid={`edit-recurring-sync-hint-${tx.id}`}
+                                  >
+                                    Editing the name or category also updates this
+                                    recurring series and its upcoming occurrences.
+                                  </p>
+                                </div>
                               ) : (
                                 <div className="flex flex-wrap items-center gap-3">
                                   <label className="inline-flex items-center gap-2 text-xs text-text-secondary">

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1824,12 +1824,22 @@ function TransactionsPageContent() {
                             {!editPartner && (
                               <div data-testid={`edit-recurring-row-mobile-${tx.id}`}>
                                 {tx.recurring_id !== null ? (
-                                  <span
-                                    className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-xs text-text-muted"
-                                    data-testid={`edit-recurring-chip-mobile-${tx.id}`}
-                                  >
-                                    Recurring
-                                  </span>
+                                  <div className="flex flex-col gap-1">
+                                    <span
+                                      title="Generated from a recurring series. Name and category stay in sync with the series."
+                                      className="inline-flex w-fit items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-xs text-text-muted"
+                                      data-testid={`edit-recurring-chip-mobile-${tx.id}`}
+                                    >
+                                      Recurring
+                                    </span>
+                                    <p
+                                      className="text-[11px] text-text-muted"
+                                      data-testid={`edit-recurring-sync-hint-mobile-${tx.id}`}
+                                    >
+                                      Editing the name or category also updates this
+                                      recurring series and its upcoming occurrences.
+                                    </p>
+                                  </div>
                                 ) : (
                                   <div className="flex flex-col gap-2">
                                     <label className="inline-flex items-center gap-2 text-sm text-text-secondary">

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1528,7 +1528,6 @@ function TransactionsPageContent() {
                               {tx.recurring_id !== null ? (
                                 <div className="flex flex-col gap-1">
                                   <span
-                                    title="Generated from a recurring series. Name and category stay in sync with the series."
                                     className="inline-flex w-fit items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-[11px] text-text-muted"
                                     data-testid={`edit-recurring-chip-${tx.id}`}
                                   >
@@ -1826,7 +1825,6 @@ function TransactionsPageContent() {
                                 {tx.recurring_id !== null ? (
                                   <div className="flex flex-col gap-1">
                                     <span
-                                      title="Generated from a recurring series. Name and category stay in sync with the series."
                                       className="inline-flex w-fit items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-xs text-text-muted"
                                       data-testid={`edit-recurring-chip-mobile-${tx.id}`}
                                     >

--- a/frontend/tests/app/transactions-recurring-sync-hint.test.tsx
+++ b/frontend/tests/app/transactions-recurring-sync-hint.test.tsx
@@ -129,5 +129,15 @@ describe("TransactionsPage — recurring edit sync hint + badge tooltip", () => 
       "title",
       "Generated from a recurring series. Name and category stay in sync with the series.",
     );
+
+    expect(
+      await screen.findByTestId("edit-recurring-sync-hint-mobile-101"),
+    ).toHaveTextContent(
+      "Editing the name or category also updates this recurring series and its upcoming occurrences.",
+    );
+    expect(screen.getByTestId("edit-recurring-chip-mobile-101")).toHaveAttribute(
+      "title",
+      "Generated from a recurring series. Name and category stay in sync with the series.",
+    );
   });
 });

--- a/frontend/tests/app/transactions-recurring-sync-hint.test.tsx
+++ b/frontend/tests/app/transactions-recurring-sync-hint.test.tsx
@@ -111,8 +111,8 @@ beforeEach(() => {
   });
 });
 
-describe("TransactionsPage — recurring edit sync hint + badge tooltip", () => {
-  it("recurring row edit form: shows forward-sync hint and tooltip on the chip", async () => {
+describe("TransactionsPage — recurring edit sync hint", () => {
+  it("recurring row edit form: shows forward-sync hint next to the chip", async () => {
     const tx = makeTx({ id: 101, description: "Netflix", recurring_id: 7 });
     setupApiFetch([tx]);
     render(<TransactionsPage />);
@@ -125,19 +125,15 @@ describe("TransactionsPage — recurring edit sync hint + badge tooltip", () => 
     ).toHaveTextContent(
       "Editing the name or category also updates this recurring series and its upcoming occurrences.",
     );
-    expect(screen.getByTestId("edit-recurring-chip-101")).toHaveAttribute(
-      "title",
-      "Generated from a recurring series. Name and category stay in sync with the series.",
-    );
+    expect(screen.getByTestId("edit-recurring-chip-101")).toBeInTheDocument();
 
     expect(
       await screen.findByTestId("edit-recurring-sync-hint-mobile-101"),
     ).toHaveTextContent(
       "Editing the name or category also updates this recurring series and its upcoming occurrences.",
     );
-    expect(screen.getByTestId("edit-recurring-chip-mobile-101")).toHaveAttribute(
-      "title",
-      "Generated from a recurring series. Name and category stay in sync with the series.",
-    );
+    expect(
+      screen.getByTestId("edit-recurring-chip-mobile-101"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/tests/app/transactions-recurring-sync-hint.test.tsx
+++ b/frontend/tests/app/transactions-recurring-sync-hint.test.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import TransactionsPage from "@/app/transactions/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+import { waitForStableTxList } from "../utils/wait-for-stable-tx-list";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/transactions",
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const USER = {
+  id: 1, username: "user", email: "user@example.com",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner" as const, org_id: 1, org_name: "Org",
+  billing_cycle_day: 1, is_superadmin: false, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const ACCT_A = {
+  id: 100, name: "Checking A", account_type_id: 1,
+  account_type_name: "Checking", account_type_slug: "checking",
+  balance: 0, currency: "EUR", is_active: true,
+  close_day: null, is_default: true,
+};
+
+const CATEGORY_GROCERIES = {
+  id: 11, name: "Groceries", type: "expense" as const,
+  parent_id: null, parent_name: null, description: null,
+  slug: "groceries", is_system: false, transaction_count: 0,
+};
+
+type Tx = {
+  id: number;
+  account_id: number;
+  account_name: string;
+  category_id: number;
+  category_name: string;
+  description: string;
+  amount: number;
+  type: "income" | "expense";
+  status: "settled" | "pending";
+  linked_transaction_id: number | null;
+  recurring_id: number | null;
+  date: string;
+  settled_date: string | null;
+  is_imported: boolean;
+};
+
+function makeTx(over: Partial<Tx> = {}): Tx {
+  return {
+    id: 1,
+    account_id: ACCT_A.id,
+    account_name: ACCT_A.name,
+    category_id: CATEGORY_GROCERIES.id,
+    category_name: CATEGORY_GROCERIES.name,
+    description: "Coffee",
+    amount: 12.5,
+    type: "expense",
+    status: "settled",
+    linked_transaction_id: null,
+    recurring_id: null,
+    date: "2026-05-01",
+    settled_date: null,
+    is_imported: false,
+    ...over,
+  };
+}
+
+function setupApiFetch(txs: Tx[]) {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
+    if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
+    if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
+    if (url.startsWith("/api/v1/transactions") && method === "GET") return txs as never;
+    return null as never;
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(useAuth).mockReturnValue({
+    user: USER as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+});
+
+describe("TransactionsPage — recurring edit sync hint + badge tooltip", () => {
+  it("recurring row edit form: shows forward-sync hint and tooltip on the chip", async () => {
+    const tx = makeTx({ id: 101, description: "Netflix", recurring_id: 7 });
+    setupApiFetch([tx]);
+    render(<TransactionsPage />);
+
+    await waitForStableTxList();
+    fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
+
+    expect(
+      await screen.findByTestId("edit-recurring-sync-hint-101"),
+    ).toHaveTextContent(
+      "Editing the name or category also updates this recurring series and its upcoming occurrences.",
+    );
+    expect(screen.getByTestId("edit-recurring-chip-101")).toHaveAttribute(
+      "title",
+      "Generated from a recurring series. Name and category stay in sync with the series.",
+    );
+  });
+});

--- a/specs/recurring-transaction-field-sync.md
+++ b/specs/recurring-transaction-field-sync.md
@@ -1,0 +1,170 @@
+# Recurring ↔ transaction field sync (name + category)
+
+**Date:** 2026-06-03
+**Status:** Spec — ready for implementation plan
+**Branch target:** new feature branch off `main`
+
+## Problem
+
+A recurring template and the transactions it generates are fully decoupled
+after generation. Each generated instance is a **snapshot copy** of the
+template's fields at generation time (`recurring_service.py:303-314`), linked
+back only by the informational FK `transactions.recurring_id`
+(`transaction.py:90-92`, `ON DELETE SET NULL`). Editing a transaction's name or
+category never writes back to the template
+(`transaction_service._apply_field_updates`), and the "Recurring" badge in the
+transaction list is purely decorative — it doesn't navigate anywhere and gives
+no hint that an edit will (or won't) affect the series.
+
+The owner edited a recurring-generated transaction's name and was confused that
+the change didn't reflect on the recurring template. The link between an
+instance and its origin series is invisible and inert, which reads as a bug even
+though the decoupling is intentional.
+
+Separately, the owner initially believed deleting a single transaction also
+removes future occurrences. **It does not** — single and bulk delete only remove
+the selected rows (`transaction_service.py:706-867`); future *pending* instances
+are removed only when the **template** is stopped or deleted
+(`_remove_pending_transactions`, `recurring_service.py:147-161`), and settled
+history is always preserved. This behavior is **correct and stays as-is** — it
+is explicitly out of scope to change.
+
+## Goal
+
+Add a surgical, additive link so that editing a recurring-linked transaction's
+**name or category** propagates forward to the series, and so the "Recurring"
+badge honestly reflects whether the series still exists. No rearchitecture; the
+FK already exists. Document the behavior internally and in the user-facing
+manual, and add UI affordances so the sync is discoverable rather than
+surprising.
+
+Tags are **deferred** to a follow-up (the template has no tag support today —
+that requires a join table + migration + generation copy + recurring-side UI).
+
+## Decisions (from brainstorm 2026-06-03)
+
+- **Ripple scope:** edit propagates to the **template + all PENDING linked
+  instances**. SETTLED (past) instances are left untouched (historical fact).
+- **Trigger source:** propagation fires from **any** linked transaction (any row
+  carrying `recurring_id`), not only a designated origin. No new "origin"
+  tracking is needed.
+- **Fields in scope:** `description` (name) and `category_id` **only**. Amount,
+  account, type, date, status are NOT propagated — they legitimately vary per
+  occurrence.
+- **Tags:** out of scope for this pass; file as a follow-up.
+- **Badge on stop:** clear the link (`recurring_id = NULL`) on surviving rows
+  when a template is stopped, mirroring delete's existing FK behavior. (Chosen
+  over keep-link-and-read-`is_active`, which preserves history but needs a new
+  response field + frontend logic.)
+- **Delete behavior:** unchanged. Single/bulk transaction delete never cascades
+  to other instances or the template.
+
+## Current behavior (baseline)
+
+- **Generation** (`recurring_service.py:303-314`): copies template
+  `account_id`, `category_id`, `description`, `amount`, `type` into a new
+  `Transaction` and sets `recurring_id = template.id`. Snapshot — no live
+  reference.
+- **Transaction edit** (`transaction_service.update_transaction`,
+  `:374-604`): `description` applied via `_apply_field_updates` (`:493`);
+  `category_id` applied at `:494-495`; `old_category_id` captured at `:454`.
+  `recurring_id` is never read or modified. `PUT /transactions/{id}` is the
+  **only** mutation path — bulk endpoints are delete-only
+  (`routers/transactions.py:473`).
+- **Template edit** (`recurring_service.update_recurring`, `:97-144`): affects
+  only future generations; existing instances keep their snapshot values.
+- **Stop** (`stop_recurring`, `:164-180`): sets `is_active = False`, deletes
+  PENDING future instances (`date >= today`), keeps the template row. Surviving
+  rows keep `recurring_id` → badge persists.
+- **Delete** (`delete_recurring`, `:183-200`): removes PENDING future instances,
+  deletes the template row → FK `SET NULL` clears `recurring_id` on survivors →
+  badge already disappears.
+- **Frontend badge** (`transactions/page.tsx:1528-1534`, `:1816-1822`): static
+  "Recurring" chip shown when `recurring_id !== null`. No tooltip, no navigation.
+
+## Proposed behavior
+
+### 1. Field propagation (backend)
+
+In `update_transaction`, after the per-leg field updates are applied
+(`transaction_service.py:493-499`):
+
+- Capture the pre-update `description` (alongside the existing `old_category_id`
+  at `:454`).
+- If `tx.recurring_id is not None`, determine which in-scope fields **actually
+  changed**:
+  - name changed: `body.description is not None and new_description != old_description`
+  - category changed: `body.category_id is not None and new_category_id != old_category_id`
+- For each changed field, within the same DB transaction:
+  - Update the template row (`recurring_transactions.description` /
+    `.category_id`) for that `recurring_id` + `org_id`.
+  - Bulk-update all PENDING linked instances:
+    `UPDATE transactions SET <field> WHERE recurring_id = X AND org_id = Y AND status = PENDING`.
+    (The directly-edited row may be included harmlessly; its value is already
+    set.)
+- No change → no writes (editing amount-only, or re-saving an unchanged name,
+  touches nothing).
+- A category propagation must keep the existing
+  `validate_category_for_type` guard semantics already enforced on the edited
+  row; the template/instances inherit the same validated `category_id`.
+
+### 2. Badge clears on stop (backend)
+
+In `stop_recurring`, after `_remove_pending_transactions`, set
+`recurring_id = NULL` on all remaining rows for that `recurring_id` + `org_id`
+(same effect delete gets for free via the FK). `delete_recurring` is unchanged.
+
+### 3. Frontend affordances
+
+- **Edit-form hint:** when the transaction being edited has `recurring_id` set,
+  render an inline note near the name/category fields:
+  *"Editing the name or category also updates this recurring series and its
+  upcoming occurrences."*
+- **Badge tooltip:** the "Recurring" chip gains a tooltip:
+  *"Generated from a recurring series. Name and category stay in sync with the
+  series."*
+
+No cross-page live update is needed — the transactions list and `/recurring`
+each refetch on navigation, so propagated values and the cleared badge appear
+naturally.
+
+### 4. Documentation
+
+- **Internal:** this spec committed under `specs/`; a short code comment at the
+  propagation hook; a `codebase_shape.md` changelog note.
+- **User-facing:** add/extend a "Recurring transactions" explainer in the in-app
+  manual (Next.js `/docs`) covering: instances are independent snapshots;
+  editing name/category syncs forward to the template and pending occurrences;
+  amounts and dates are per-occurrence; deleting a single transaction never
+  removes other occurrences; stopping or deleting the series removes only
+  *pending future* occurrences and preserves settled history. Exact `/docs` page
+  to be confirmed during planning. (No em-dashes in customer copy per house
+  style.)
+
+## Out of scope
+
+- Tag propagation (follow-up: needs `recurring_transaction_tags` join +
+  migration + generation copy + recurring-side UI).
+- Amount/account/type/date/status propagation.
+- Any change to single/bulk transaction delete semantics.
+- "This occurrence vs. all" calendar-style scope prompts on edit.
+- Navigation from a transaction to its template (badge stays informational +
+  tooltip only).
+
+## Testing
+
+**Backend**
+- Edit name on a generated instance → template `description` updated; all PENDING
+  linked instances updated; SETTLED instances unchanged.
+- Edit category likewise (`category_id`), respecting type/category compatibility.
+- Edit amount only → no propagation to template or instances.
+- Re-save unchanged name/category → no writes.
+- Propagation from a non-origin generated instance still updates the series
+  (any-linked-transaction rule).
+- `stop_recurring` → surviving linked rows have `recurring_id = NULL` (badge
+  cleared); pending future removed; settled preserved.
+- `delete_recurring` → badge cleared (regression guard for existing FK behavior).
+
+**Frontend**
+- Edit-form hint renders only when `recurring_id` is set.
+- "Recurring" badge tooltip present.


### PR DESCRIPTION
Editing a recurring-linked transaction's **name or category** now syncs forward to its recurring template and all pending (not-yet-settled) occurrences, so the series stays consistent. Settled history is never rewritten, and amount/date/account/type stay per-occurrence.

- **Backend:** `transaction_service._propagate_fields_to_series` updates the template + `status==PENDING` siblings (org-scoped) when name/category actually change; hooked into `update_transaction` before its commit. Category propagation is suppressed when the same edit also changes the row's type (avoids writing a type-incompatible category onto the template). Lives in `transaction_service` to avoid the `recurring_service` import cycle.
- **Stop behavior:** `stop_recurring` now clears `recurring_id` on surviving rows so the "Recurring" badge disappears, mirroring delete's FK `ON DELETE SET NULL`. Single/bulk transaction delete behavior is unchanged.
- **Frontend:** the transactions edit form (desktop + mobile) gains a badge tooltip and an inline hint explaining the sync.
- **Docs:** in-app manual gains a recurring-behavior explainer.

Tags propagation deferred (templates have no tag support yet; would need a join table + migration). Spec: `specs/recurring-transaction-field-sync.md`.