### PR TITLE
feat(transactions): server-side list contract + shared pagination and sort

### DIFF
--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -97,7 +97,7 @@ async def list_transactions(
     ),
     sort_by: str | None = Query(default=None),
     sort_dir: str | None = Query(default=None),
-    limit: int = Query(default=50, le=200),
+    limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
 ):
     tag_list = (

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -15,6 +15,7 @@ from app.models.account import Account
 from app.models.transaction import TransactionType
 from app.models.user import User
 from app.rate_limit import get_client_ip
+from app.schemas.common import ListEnvelope
 from app.schemas.import_batch import (
     BatchTransactionsRequest,
     BatchTransactionsResponse,
@@ -62,7 +63,7 @@ suggestions_logger = structlog.stdlib.get_logger(
 router = APIRouter(prefix="/api/v1/transactions", tags=["transactions"])
 
 
-@router.get("", response_model=list[TransactionResponse])
+@router.get("", response_model=ListEnvelope[TransactionResponse])
 async def list_transactions(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -94,6 +95,8 @@ async def list_transactions(
             "requires every named tag; 'any' requires at least one."
         ),
     ),
+    sort_by: str | None = Query(default=None),
+    sort_dir: str | None = Query(default=None),
     limit: int = Query(default=50, le=200),
     offset: int = Query(default=0, ge=0),
 ):
@@ -105,22 +108,32 @@ async def list_transactions(
         [t for t in (s.strip() for s in tags_exclude.split(",")) if t]
         if tags_exclude else None
     )
-    txns = await svc.list_transactions(
-        db, current_user.org_id,
-        account_id=account_id,
-        category_id=category_id,
-        tx_type=tx_type,
-        status=status,
-        date_from=date_from,
-        date_to=date_to,
-        search=search,
-        tags=tag_list,
-        tags_exclude=excl_list,
-        tag_match=tag_match,
+    try:
+        items, total = await svc.list_transactions(
+            db, current_user.org_id,
+            account_id=account_id,
+            category_id=category_id,
+            tx_type=tx_type,
+            status=status,
+            date_from=date_from,
+            date_to=date_to,
+            search=search,
+            tags=tag_list,
+            tags_exclude=excl_list,
+            tag_match=tag_match,
+            sort_by=sort_by,
+            sort_dir=sort_dir,
+            limit=limit,
+            offset=offset,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=exc.detail) from exc
+    return ListEnvelope[TransactionResponse](
+        items=[svc.to_response(tx) for tx in items],
+        total=total,
         limit=limit,
         offset=offset,
     )
-    return [svc.to_response(tx) for tx in txns]
 
 
 @router.post("", response_model=TransactionResponse, status_code=201)

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -1862,6 +1862,9 @@ async def list_transactions(
         tags=tags, tags_exclude=tags_exclude, tag_match=tag_match,
     )
 
+    # org_id is supplied twice on purpose: once as the pre-scoped WHERE on the
+    # base query, and again as a param so the category/tag subqueries inside
+    # _apply_transaction_filters can org-scope their own lookups.
     page_q = _apply_transaction_filters(
         select(Transaction).options(*_load_opts()).where(Transaction.org_id == org_id),
         org_id, **filter_kwargs,

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -33,6 +33,7 @@ from app.schemas.transaction import (
 )
 from app.services.category_rules_service import learn_from_choice
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+from app.services.list_query import resolve_order_by
 from app.services.transaction_filters import (
     effective_period_date_expr,
     is_reportable_transaction,
@@ -1716,27 +1717,25 @@ def _parse_search_amount(raw: str) -> Decimal | None:
         return None
 
 
-async def list_transactions(
-    db: AsyncSession,
+def _apply_transaction_filters(
+    q,
     org_id: int,
-    account_id: int | None = None,
-    category_id: int | None = None,
-    tx_type: str | None = None,
-    status: str | None = None,
-    date_from: datetime.date | None = None,
-    date_to: datetime.date | None = None,
-    search: str | None = None,
-    tags: list[str] | None = None,
-    tags_exclude: list[str] | None = None,
-    tag_match: str = "all",
-    limit: int = 50,
-    offset: int = 0,
-) -> list[Transaction]:
-    q = (
-        select(Transaction)
-        .options(*_load_opts())
-        .where(Transaction.org_id == org_id)
-    )
+    *,
+    account_id: int | None,
+    category_id: int | None,
+    tx_type: str | None,
+    status: str | None,
+    date_from: datetime.date | None,
+    date_to: datetime.date | None,
+    search: str | None,
+    tags: list[str] | None,
+    tags_exclude: list[str] | None,
+    tag_match: str,
+):
+    """Apply all transaction list filters to a query. Used for BOTH the page
+    query and the count query so `total` is computed over the same filtered
+    set (org-scoping contract; see app.services.list_query). The caller must
+    already have scoped `q` to org_id. Returns the filtered query."""
     if account_id is not None:
         q = q.where(Transaction.account_id == account_id)
     if category_id is not None:
@@ -1836,12 +1835,66 @@ async def list_transactions(
                     )
                 )
             )
+    return q
 
-    q = q.order_by(effective_period_date_expr().desc(), Transaction.id.desc())
-    q = q.limit(limit).offset(offset)
 
-    result = await db.execute(q)
-    return list(result.scalars().all())
+async def list_transactions(
+    db: AsyncSession,
+    org_id: int,
+    account_id: int | None = None,
+    category_id: int | None = None,
+    tx_type: str | None = None,
+    status: str | None = None,
+    date_from: datetime.date | None = None,
+    date_to: datetime.date | None = None,
+    search: str | None = None,
+    tags: list[str] | None = None,
+    tags_exclude: list[str] | None = None,
+    tag_match: str = "all",
+    sort_by: str | None = None,
+    sort_dir: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[Transaction], int]:
+    filter_kwargs = dict(
+        account_id=account_id, category_id=category_id, tx_type=tx_type,
+        status=status, date_from=date_from, date_to=date_to, search=search,
+        tags=tags, tags_exclude=tags_exclude, tag_match=tag_match,
+    )
+
+    page_q = _apply_transaction_filters(
+        select(Transaction).options(*_load_opts()).where(Transaction.org_id == org_id),
+        org_id, **filter_kwargs,
+    )
+    count_q = _apply_transaction_filters(
+        select(func.count()).select_from(Transaction).where(Transaction.org_id == org_id),
+        org_id, **filter_kwargs,
+    )
+
+    total = (await db.scalar(count_q)) or 0
+
+    allowed = {
+        "date": effective_period_date_expr(),
+        "amount": Transaction.amount,
+        "description": Transaction.description,
+        "status": Transaction.status,
+        "account_name": Account.name,
+        "category_name": Category.name,
+    }
+    if sort_by == "account_name":
+        page_q = page_q.join(Account, Account.id == Transaction.account_id)
+    elif sort_by == "category_name":
+        page_q = page_q.join(Category, Category.id == Transaction.category_id)
+
+    order_by = resolve_order_by(
+        sort_by, sort_dir, allowed=allowed,
+        default_key="date", default_dir="desc",
+        tiebreaker=Transaction.id.desc(),
+    )
+    page_q = page_q.order_by(*order_by).limit(limit).offset(offset)
+
+    items = list((await db.execute(page_q)).scalars().all())
+    return items, total
 
 
 async def reconcile_account(

--- a/backend/tests/routers/test_transactions_list_route.py
+++ b/backend/tests/routers/test_transactions_list_route.py
@@ -166,3 +166,8 @@ def test_invalid_sort_by_is_400(client):
 def test_invalid_sort_dir_is_400(client):
     res = client.get("/api/v1/transactions?sort_by=amount&sort_dir=up")
     assert res.status_code == 400
+
+
+def test_limit_zero_rejected(client):
+    res = client.get("/api/v1/transactions?limit=0")
+    assert res.status_code == 422

--- a/backend/tests/routers/test_transactions_list_route.py
+++ b/backend/tests/routers/test_transactions_list_route.py
@@ -1,0 +1,168 @@
+"""Router-level test for GET /api/v1/transactions.
+
+Task 2 changed the list endpoint to return a ``ListEnvelope`` (was a bare
+list) and to accept ``sort_by``/``sort_dir`` query params that drive
+server-side ordering. Invalid sort columns/directions must surface as
+HTTP 400 (the service's ``resolve_order_by`` raises ``ValidationError``).
+
+Harness mirrors tests/routers/test_recurring_generate_route.py: an
+in-memory SQLite ``session_factory``, ``make_app`` with get_db /
+get_current_user overrides, and a ``_seed`` helper that builds an org +
+user + account + category + a few transactions of distinct amounts.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Role, User
+from app.routers.transactions import router as transactions_router
+from app.security import hash_password
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    app.include_router(transactions_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    async with factory() as db:
+        org = Organization(name="Test Org", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username="root",
+            email="root@example.com",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_superadmin=True,
+            is_active=True,
+            email_verified=True,
+        )
+        at = AccountType(
+            org_id=org.id, name="Checking", slug="checking", is_system=True
+        )
+        db.add_all([user, at])
+        await db.flush()
+        acct = Account(
+            org_id=org.id, name="Acct A", account_type_id=at.id,
+            balance=Decimal("1000"), currency="EUR",
+        )
+        db.add(acct)
+        await db.flush()
+        cat = Category(
+            org_id=org.id, name="Groceries", slug="groceries",
+            type=CategoryType.EXPENSE, is_system=False,
+        )
+        db.add(cat)
+        await db.flush()
+        # Distinct amounts so the sort assertion is meaningful, inserted
+        # out of order so a default order can't accidentally satisfy it.
+        for i, amt in enumerate(["30.00", "10.00", "20.00"]):
+            db.add(Transaction(
+                org_id=org.id, account_id=acct.id, category_id=cat.id,
+                description=f"tx-{i}", amount=Decimal(amt),
+                type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+                date=date(2026, 1, i + 1),
+                settled_date=date(2026, 1, i + 1),
+            ))
+        await db.commit()
+        return {"org_id": org.id, "acct_id": acct.id, "cat_id": cat.id}
+
+
+@pytest_asyncio.fixture
+async def client(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as c:
+        yield c
+
+
+# ── tests ────────────────────────────────────────────────────────────────
+
+
+def test_list_returns_envelope(client):
+    res = client.get("/api/v1/transactions?limit=2&offset=0")
+    assert res.status_code == 200
+    body = res.json()
+    assert set(body.keys()) == {"items", "total", "limit", "offset"}
+    assert body["limit"] == 2
+    assert body["offset"] == 0
+    assert isinstance(body["items"], list)
+    assert body["total"] >= len(body["items"])
+
+
+def test_list_server_side_sort_amount_asc(client):
+    res = client.get("/api/v1/transactions?sort_by=amount&sort_dir=asc")
+    assert res.status_code == 200
+    amounts = [float(i["amount"]) for i in res.json()["items"]]
+    assert amounts == sorted(amounts)
+
+
+def test_invalid_sort_by_is_400(client):
+    res = client.get("/api/v1/transactions?sort_by=evil")
+    assert res.status_code == 400
+
+
+def test_invalid_sort_dir_is_400(client):
+    res = client.get("/api/v1/transactions?sort_by=amount&sort_dir=up")
+    assert res.status_code == 400

--- a/backend/tests/services/test_transaction_service_category_filter.py
+++ b/backend/tests/services/test_transaction_service_category_filter.py
@@ -120,7 +120,7 @@ async def test_category_filter_returns_only_matching_rows(db_session, world):
     ])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, category_id=world["groceries"].id,
     )
     assert sorted(r.description for r in rows) == ["g1", "g2"]
@@ -134,7 +134,7 @@ async def test_category_filter_none_returns_all(db_session, world):
     ])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id,
     )
     assert sorted(r.description for r in rows) == ["d1", "g1"]
@@ -156,7 +156,7 @@ async def test_master_category_filter_includes_subcategories(db_session, world):
     ])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, category_id=world["groceries"].id,
     )
     assert sorted(r.description for r in rows) == ["g-master", "g-sub"]
@@ -175,7 +175,7 @@ async def test_subcategory_filter_exact_match_only(db_session, world):
     ])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, category_id=world["groceries_sub"].id,
     )
     assert [r.description for r in rows] == ["g-sub"]
@@ -199,7 +199,7 @@ async def test_category_filter_compounds_with_date_range(db_session, world):
     ])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id,
         category_id=world["groceries"].id,
         date_from=date(2026, 5, 1),

--- a/backend/tests/services/test_transaction_service_list_filters.py
+++ b/backend/tests/services/test_transaction_service_list_filters.py
@@ -101,7 +101,7 @@ async def test_settled_in_period_settled_date_inside(db_session, world):
     db_session.add(tx)
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, date_from=MAY_FROM, date_to=MAY_TO,
     )
     assert [r.description for r in rows] == ["settled-in"]
@@ -119,7 +119,7 @@ async def test_settled_in_period_settled_date_outside(db_session, world):
     db_session.add(tx)
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, date_from=MAY_FROM, date_to=MAY_TO,
     )
     assert rows == []
@@ -134,7 +134,7 @@ async def test_pending_settling_in_period(db_session, world):
     db_session.add(tx)
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, date_from=MAY_FROM, date_to=MAY_TO,
     )
     assert [r.description for r in rows] == ["pending-in"]
@@ -152,7 +152,7 @@ async def test_pending_settling_after_period(db_session, world):
     db_session.add(tx)
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, date_from=MAY_FROM, date_to=MAY_TO,
     )
     assert rows == []
@@ -167,7 +167,7 @@ async def test_pending_settling_before_period(db_session, world):
     db_session.add(tx)
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, date_from=MAY_FROM, date_to=MAY_TO,
     )
     assert rows == []
@@ -185,7 +185,7 @@ async def test_pending_no_settled_date_falls_back_to_date(db_session, world):
     db_session.add(tx)
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, date_from=MAY_FROM, date_to=MAY_TO,
     )
     assert [r.description for r in rows] == ["pending-null"]
@@ -223,7 +223,7 @@ async def test_sort_order_uses_effective_date(db_session, world):
     db_session.add_all([tx_a, tx_b, tx_c])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, date_from=MAY_FROM, date_to=MAY_TO,
     )
     # Effective dates: B=05-25, A=05-15, C=05-10  ->  DESC: B, A, C

--- a/backend/tests/services/test_transaction_service_search_filter.py
+++ b/backend/tests/services/test_transaction_service_search_filter.py
@@ -132,7 +132,7 @@ async def test_search_pure_text_matches_description(db_session, world):
     ])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, search="coffee",
     )
     assert [r.description for r in rows] == ["Coffee shop"]
@@ -147,7 +147,7 @@ async def test_search_amount_matches_both_signs(db_session, world):
     ])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, search="42",
     )
     assert sorted(r.description for r in rows) == ["Charge", "Refund"]
@@ -162,7 +162,7 @@ async def test_search_decimal_amount_matches_equivalent_forms(db_session, world)
     ])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, search="42.50",
     )
     assert sorted(r.description for r in rows) == ["A", "B"]
@@ -175,7 +175,7 @@ async def test_search_amount_no_match_returns_empty(db_session, world):
     ])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, search="9999.99",
     )
     assert rows == []
@@ -194,7 +194,7 @@ async def test_search_numeric_string_or_description_and_amount(db_session, world
     ])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, search="1234",
     )
     assert sorted(r.description for r in rows) == [
@@ -213,7 +213,7 @@ async def test_search_combined_with_account_filter_is_and(db_session, world):
     ])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session,
         world["org"].id,
         search="coffee",
@@ -231,7 +231,7 @@ async def test_search_empty_string_skips_filter(db_session, world):
     ])
     await db_session.flush()
 
-    rows = await transaction_service.list_transactions(
+    rows, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, search="   ",
     )
     assert sorted(r.description for r in rows) == ["A", "B"]

--- a/backend/tests/services/test_transaction_service_tag_filters.py
+++ b/backend/tests/services/test_transaction_service_tag_filters.py
@@ -116,7 +116,7 @@ async def test_list_returns_empty_tag_list_for_untagged_transaction(
     db_session.add(tx)
     await db_session.commit()
 
-    txns = await transaction_service.list_transactions(
+    txns, _ = await transaction_service.list_transactions(
         db_session, world["org"].id
     )
     assert len(txns) == 1
@@ -140,7 +140,7 @@ async def test_list_returns_attached_tags(db_session, world):
     )
     await db_session.commit()
 
-    txns = await transaction_service.list_transactions(
+    txns, _ = await transaction_service.list_transactions(
         db_session, world["org"].id
     )
     response = transaction_service.to_response(txns[0])
@@ -166,7 +166,7 @@ async def test_filter_tags_single_returns_only_tagged_rows(db_session, world):
     # tx_c has no tags
     await db_session.commit()
 
-    txns = await transaction_service.list_transactions(
+    txns, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, tags=["insurance"]
     )
     assert [tx.id for tx in txns] == [tx_a.id]
@@ -199,7 +199,7 @@ async def test_filter_tags_default_is_and(db_session, world):
     ])
     await db_session.commit()
 
-    txns = await transaction_service.list_transactions(
+    txns, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, tags=["insurance", "vacation"]
     )
     assert [tx.id for tx in txns] == [tx_both.id]
@@ -220,7 +220,7 @@ async def test_filter_tags_match_any_is_or(db_session, world):
     # tx_c untagged
     await db_session.commit()
 
-    txns = await transaction_service.list_transactions(
+    txns, _ = await transaction_service.list_transactions(
         db_session, world["org"].id,
         tags=["insurance", "vacation"], tag_match="any",
     )
@@ -247,7 +247,7 @@ async def test_filter_tags_exclude(db_session, world):
     await _attach_tags(db_session, tx_b, ["vacation"], world["org"].id)
     await db_session.commit()
 
-    txns = await transaction_service.list_transactions(
+    txns, _ = await transaction_service.list_transactions(
         db_session, world["org"].id, tags_exclude=["insurance"]
     )
     ids = sorted(tx.id for tx in txns)
@@ -285,7 +285,7 @@ async def test_filter_tags_combined_with_exclude(db_session, world):
     ])
     await db_session.commit()
 
-    txns = await transaction_service.list_transactions(
+    txns, _ = await transaction_service.list_transactions(
         db_session, world["org"].id,
         tags=["vacation"], tags_exclude=["insurance"],
     )

--- a/backend/tests/services/test_transactions_list_envelope.py
+++ b/backend/tests/services/test_transactions_list_envelope.py
@@ -165,3 +165,35 @@ async def test_org_scoping(db_session):
     items, total = await transaction_service.list_transactions(db_session, org_a)
     assert total == 1
     assert [t.description for t in items] == ["a"]
+
+
+async def test_sort_category_name(db_session):
+    org_id, at = await _org(db_session, "A")
+    acct = await _acct(db_session, org_id, at, "Main")
+    c1 = await _cat(db_session, org_id, "Zoo", "zoo")
+    c2 = await _cat(db_session, org_id, "Auto", "auto")
+    await _tx(db_session, org_id, acct, c1, desc="z", amount="1.00", when=date.today())
+    await _tx(db_session, org_id, acct, c2, desc="a", amount="1.00", when=date.today())
+    await db_session.commit()
+
+    items, _ = await transaction_service.list_transactions(
+        db_session, org_id, sort_by="category_name", sort_dir="asc"
+    )
+    assert [t.description for t in items] == ["a", "z"]
+
+
+async def test_filter_composes_with_sort(db_session):
+    org_id, at = await _org(db_session, "A")
+    acct = await _acct(db_session, org_id, at, "Main")
+    keep = await _cat(db_session, org_id, "Keep", "keep")
+    drop = await _cat(db_session, org_id, "Drop", "drop")
+    await _tx(db_session, org_id, acct, keep, desc="k-big", amount="50.00", when=date.today())
+    await _tx(db_session, org_id, acct, keep, desc="k-small", amount="5.00", when=date.today())
+    await _tx(db_session, org_id, acct, drop, desc="d", amount="99.00", when=date.today())
+    await db_session.commit()
+
+    items, total = await transaction_service.list_transactions(
+        db_session, org_id, category_id=keep, sort_by="amount", sort_dir="asc"
+    )
+    assert total == 2  # filter applied to count too
+    assert [t.description for t in items] == ["k-small", "k-big"]  # sort within filtered set

--- a/backend/tests/services/test_transactions_list_envelope.py
+++ b/backend/tests/services/test_transactions_list_envelope.py
@@ -1,0 +1,167 @@
+"""list_transactions returns (items, total) with server-side sort.
+
+- total is the full filtered count, independent of limit/offset
+- sort by each whitelisted key (asc + desc), incl. account_name / category_name
+- id-desc tiebreaker keeps pagination stable across equal sort values
+- invalid sort_by / sort_dir raise ValidationError
+- org-scoping: a second org's rows are never counted or returned
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.services import transaction_service
+from app.services.exceptions import ValidationError
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _org(db, name):
+    org = Organization(name=name, billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db.add(at)
+    await db.flush()
+    return org.id, at.id
+
+
+async def _acct(db, org_id, at_id, name):
+    a = Account(org_id=org_id, name=name, account_type_id=at_id,
+                balance=Decimal("0"), currency="EUR")
+    db.add(a)
+    await db.flush()
+    return a.id
+
+
+async def _cat(db, org_id, name, slug):
+    c = Category(org_id=org_id, name=name, slug=slug, type=CategoryType.EXPENSE)
+    db.add(c)
+    await db.flush()
+    return c.id
+
+
+async def _tx(db, org_id, acct_id, cat_id, *, desc, amount, when, status=TransactionStatus.SETTLED):
+    t = Transaction(
+        org_id=org_id, account_id=acct_id, category_id=cat_id, description=desc,
+        amount=Decimal(amount), type=TransactionType.EXPENSE, status=status,
+        date=when, settled_date=when if status == TransactionStatus.SETTLED else None,
+    )
+    db.add(t)
+    await db.flush()
+    return t.id
+
+
+async def test_envelope_total_independent_of_limit(db_session):
+    org_id, at = await _org(db_session, "A")
+    acct = await _acct(db_session, org_id, at, "Main")
+    cat = await _cat(db_session, org_id, "Gym", "gym")
+    for i in range(5):
+        await _tx(db_session, org_id, acct, cat, desc=f"t{i}", amount="10.00",
+                  when=date.today() - timedelta(days=i))
+    await db_session.commit()
+
+    items, total = await transaction_service.list_transactions(db_session, org_id, limit=2, offset=0)
+    assert total == 5
+    assert len(items) == 2
+
+
+async def test_sort_amount_asc_and_desc(db_session):
+    org_id, at = await _org(db_session, "A")
+    acct = await _acct(db_session, org_id, at, "Main")
+    cat = await _cat(db_session, org_id, "Gym", "gym")
+    await _tx(db_session, org_id, acct, cat, desc="cheap", amount="5.00", when=date.today())
+    await _tx(db_session, org_id, acct, cat, desc="pricey", amount="50.00", when=date.today())
+    await db_session.commit()
+
+    asc, _ = await transaction_service.list_transactions(db_session, org_id, sort_by="amount", sort_dir="asc")
+    assert [t.description for t in asc] == ["cheap", "pricey"]
+    desc, _ = await transaction_service.list_transactions(db_session, org_id, sort_by="amount", sort_dir="desc")
+    assert [t.description for t in desc] == ["pricey", "cheap"]
+
+
+async def test_sort_account_name(db_session):
+    org_id, at = await _org(db_session, "A")
+    a1 = await _acct(db_session, org_id, at, "Zebra")
+    a2 = await _acct(db_session, org_id, at, "Alpha")
+    cat = await _cat(db_session, org_id, "Gym", "gym")
+    await _tx(db_session, org_id, a1, cat, desc="z", amount="1.00", when=date.today())
+    await _tx(db_session, org_id, a2, cat, desc="a", amount="1.00", when=date.today())
+    await db_session.commit()
+
+    items, _ = await transaction_service.list_transactions(db_session, org_id, sort_by="account_name", sort_dir="asc")
+    assert [t.description for t in items] == ["a", "z"]
+
+
+async def test_tiebreaker_stable_across_pages(db_session):
+    org_id, at = await _org(db_session, "A")
+    acct = await _acct(db_session, org_id, at, "Main")
+    cat = await _cat(db_session, org_id, "Gym", "gym")
+    same = date.today()
+    ids = [await _tx(db_session, org_id, acct, cat, desc=f"t{i}", amount="10.00", when=same) for i in range(4)]
+    await db_session.commit()
+
+    page1, total = await transaction_service.list_transactions(db_session, org_id, sort_by="date", sort_dir="desc", limit=2, offset=0)
+    page2, _ = await transaction_service.list_transactions(db_session, org_id, sort_by="date", sort_dir="desc", limit=2, offset=2)
+    seen = [t.id for t in page1] + [t.id for t in page2]
+    assert sorted(seen) == sorted(ids)
+    assert len(set(seen)) == 4
+
+
+async def test_invalid_sort_raises(db_session):
+    org_id, _ = await _org(db_session, "A")
+    with pytest.raises(ValidationError):
+        await transaction_service.list_transactions(db_session, org_id, sort_by="evil_column")
+    with pytest.raises(ValidationError):
+        await transaction_service.list_transactions(db_session, org_id, sort_dir="sideways")
+
+
+async def test_org_scoping(db_session):
+    org_a, at_a = await _org(db_session, "A")
+    org_b, at_b = await _org(db_session, "B")
+    aa = await _acct(db_session, org_a, at_a, "MainA")
+    ab = await _acct(db_session, org_b, at_b, "MainB")
+    ca = await _cat(db_session, org_a, "Gym", "gym")
+    cb = await _cat(db_session, org_b, "Gym", "gym")
+    await _tx(db_session, org_a, aa, ca, desc="a", amount="1.00", when=date.today())
+    await _tx(db_session, org_b, ab, cb, desc="b1", amount="1.00", when=date.today())
+    await _tx(db_session, org_b, ab, cb, desc="b2", amount="1.00", when=date.today())
+    await db_session.commit()
+
+    items, total = await transaction_service.list_transactions(db_session, org_a)
+    assert total == 1
+    assert [t.description for t in items] == ["a"]

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -251,15 +251,15 @@ export default function DashboardPage() {
     const forecastUrl = realPeriodStart ? `/api/v1/forecast-plans/current?period_start=${realPeriodStart}` : "/api/v1/forecast-plans/current";
     const dateFilter = `date_from=${monthFrom}${monthTo ? `&date_to=${monthTo}` : ""}`;
     const [pageData, allData, bds, fc] = await Promise.all([
-      apiFetch<Transaction[]>(`/api/v1/transactions?limit=${PAGE_SIZE + 1}&offset=${p * PAGE_SIZE}&${dateFilter}`),
-      p === 0 ? apiFetch<Transaction[]>(`/api/v1/transactions?limit=200&${dateFilter}`) : null,
+      apiFetch<{ items: Transaction[]; total: number }>(`/api/v1/transactions?limit=${PAGE_SIZE + 1}&offset=${p * PAGE_SIZE}&${dateFilter}`),
+      p === 0 ? apiFetch<{ items: Transaction[]; total: number }>(`/api/v1/transactions?limit=200&${dateFilter}`) : null,
       p === 0 ? apiFetch<Budget[]>(budgetUrl) : null,
       p === 0 ? apiFetch<ForecastPlan | null>(forecastUrl) : null,
     ]);
-    const page_txs = pageData ?? [];
+    const page_txs = pageData?.items ?? [];
     setHasMore(page_txs.length > PAGE_SIZE);
     setTransactions(page_txs.slice(0, PAGE_SIZE));
-    if (allData) setAllTransactions(allData);
+    if (allData) setAllTransactions(allData.items);
     if (bds) setBudgets(bds);
     // null is a valid response (no plan yet) — set state so empty-state UI renders.
     if (p === 0) setForecast(fc ?? null);

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -25,14 +25,16 @@ import SuggestCategoryButton from "@/components/transactions/SuggestCategoryButt
 import ResetSortFiltersButton from "@/components/ui/ResetSortFiltersButton";
 import {
   FILTERS_KEY_TRANSACTIONS,
+  PAGE_SIZE_KEY_TRANSACTIONS,
   SORT_KEY_TRANSACTIONS,
 } from "@/lib/hooks/persisted-keys";
 import { usePersistedFilters } from "@/lib/hooks/use-persisted-filters";
 import { usePersistedSort } from "@/lib/hooks/use-persisted-sort";
+import Pagination from "@/components/ui/Pagination";
+import { pageCount } from "@/lib/hooks/use-table-state";
 
 
 
-const PAGE_SIZE = 20;
 const DATE_PARAM_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 // Column-aware sort defaults. When the user clicks a different column, that
@@ -86,7 +88,13 @@ function TransactionsPageContent() {
   const [refreshing, setRefreshing] = useState(false);
   const [fetching, setFetching] = useState(true);
   const [page, setPage] = useState(0);
-  const [hasMore, setHasMore] = useState(false);
+  const [total, setTotal] = useState(0);
+  const [pageSize, setPageSize] = useState<number>(() => {
+    if (typeof window === "undefined") return 25;
+    const raw = window.localStorage.getItem(PAGE_SIZE_KEY_TRANSACTIONS);
+    const n = raw ? Number(raw) : 25;
+    return [10, 25, 50, 100].includes(n) ? n : 25;
+  });
 
   // Edit
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -267,7 +275,8 @@ function TransactionsPageContent() {
   }, []);
 
   const loadTransactions = useCallback(async (p: number) => {
-    let url = `/api/v1/transactions?limit=${PAGE_SIZE + 1}&offset=${p * PAGE_SIZE}`;
+    let url = `/api/v1/transactions?limit=${pageSize}&offset=${p * pageSize}`;
+    url += `&sort_by=${sortField}&sort_dir=${sortDir}`;
     if (filterAccount) url += `&account_id=${filterAccount}`;
     if (filterCategory) url += `&category_id=${filterCategory}`;
     if (filterType) url += `&type=${filterType}`;
@@ -275,7 +284,7 @@ function TransactionsPageContent() {
 
     // Period filter overrides date_from/date_to
     if (filterPeriod) {
-      const per = periods.find((p) => String(p.id) === filterPeriod);
+      const per = periods.find((pp) => String(pp.id) === filterPeriod);
       if (per && per.end_date !== null) {
         url += `&date_from=${per.start_date}`;
         url += `&date_to=${per.end_date}`;
@@ -286,11 +295,11 @@ function TransactionsPageContent() {
     }
 
     if (filterSearch) url += `&search=${encodeURIComponent(filterSearch)}`;
-    const data = (await apiFetch<Transaction[]>(url)) ?? [];
-    setHasMore(data.length > PAGE_SIZE);
-    setTransactions(data.slice(0, PAGE_SIZE));
+    const data = await apiFetch<{ items: Transaction[]; total: number }>(url);
+    setTransactions(data?.items ?? []);
+    setTotal(data?.total ?? 0);
     setFetching(false);
-  }, [filterAccount, filterCategory, filterType, filterStatus, filterDateFrom, filterDateTo, filterSearch, filterPeriod, periods]);
+  }, [filterAccount, filterCategory, filterType, filterStatus, filterDateFrom, filterDateTo, filterSearch, filterPeriod, periods, pageSize, sortField, sortDir]);
 
   useEffect(() => {
     if (!loading && user) loadRefs().catch(() => {});
@@ -360,6 +369,14 @@ function TransactionsPageContent() {
   }, [loading, user, loadTransactions, page]);
 
   useEffect(() => { setPage(0); }, [filterAccount, filterCategory, filterType, filterStatus, filterDateFrom, filterDateTo, filterSearch, filterPeriod]);
+
+  // Clamp the page after a refetch shrinks the result set (e.g. a bulk
+  // delete that empties the last page) so the user is never stranded on a
+  // page beyond the new total.
+  useEffect(() => {
+    const last = pageCount(total, pageSize) - 1;
+    if (page > last) setPage(Math.max(0, last));
+  }, [total, pageSize, page]);
 
   // After a write from the AppShell-level "+ New Transaction" CTA the
   // page must re-pull the visible list (the new row should appear) and
@@ -580,6 +597,13 @@ function TransactionsPageContent() {
 
   function clearSelection() {
     setSelectedIds(new Set());
+  }
+
+  function changePageSize(n: number) {
+    setPageSize(n);
+    setPage(0);
+    clearSelection();
+    if (typeof window !== "undefined") window.localStorage.setItem(PAGE_SIZE_KEY_TRANSACTIONS, String(n));
   }
 
   async function handleDelete(id: number) {
@@ -829,32 +853,17 @@ function TransactionsPageContent() {
     } else {
       persistedSort.setSort(field, SORT_DEFAULTS[field]);
     }
+    setPage(0);
+    clearSelection();
   }
-  // Memoize the sort. On a typed-into-search render, only `filter*` state
-  // changes — the same `transactions` array shouldn't be re-sorted, and the
-  // result shouldn't get a new reference (which would invalidate every
-  // downstream map() identity check).
-  const sortedTransactions = useMemo(() => {
-    const copy = [...transactions];
-    copy.sort((a, b) => {
-      let cmp = 0;
-      if (sortField === "date") cmp = a.date.localeCompare(b.date);
-      else if (sortField === "description") cmp = a.description.localeCompare(b.description);
-      else if (sortField === "account_name") cmp = a.account_name.localeCompare(b.account_name);
-      else if (sortField === "category_name") cmp = a.category_name.localeCompare(b.category_name);
-      else if (sortField === "status") cmp = a.status.localeCompare(b.status);
-      else if (sortField === "amount") cmp = Number(a.amount) - Number(b.amount);
-      return sortDir === "asc" ? cmp : -cmp;
-    });
-    return copy;
-  }, [transactions, sortField, sortDir]);
-
-  // Visible rows are sortedTransactions minus the cascaded "duplicate" half
-  // of any transfer pair. Memoized so the array reference is stable across
+  // Visible rows are the fetched (server-sorted) transactions minus the
+  // cascaded "duplicate" half of any transfer pair. Rows arrive pre-sorted
+  // from the server (sort_by/sort_dir on the list request), so there is no
+  // client-side sort. Memoized so the array reference is stable across
   // unrelated renders (typing in the new-transaction form, hover, etc.).
   const visibleTxs = useMemo(
-    () => sortedTransactions.filter((t) => !selectionHiddenIds.has(t.id)),
-    [sortedTransactions, selectionHiddenIds],
+    () => transactions.filter((t) => !selectionHiddenIds.has(t.id)),
+    [transactions, selectionHiddenIds],
   );
   const targetTransactionId = useMemo(() => {
     const raw = searchParams.get("transaction_id");
@@ -2036,15 +2045,15 @@ function TransactionsPageContent() {
             })()}
           </div>
 
-          {(page > 0 || hasMore) && (
-            <div className="mt-4 flex items-center justify-between">
-              <button onClick={() => setPage(Math.max(0, page - 1))} disabled={page === 0 || bulkDeleting} className="rounded-md border border-border px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-raised disabled:opacity-40">
-                Previous
-              </button>
-              <span className="text-xs text-text-muted">Page {page + 1}</span>
-              <button onClick={() => setPage(page + 1)} disabled={!hasMore || bulkDeleting} className="rounded-md border border-border px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-raised disabled:opacity-40">
-                Next
-              </button>
+          {(total > pageSize || page > 0) && (
+            <div className="mt-4">
+              <Pagination
+                page={page + 1}
+                pageSize={pageSize}
+                total={total}
+                onPageChange={(n) => { setPage(n - 1); clearSelection(); }}
+                onPageSizeChange={changePageSize}
+              />
             </div>
           )}
         </>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -276,7 +276,7 @@ function TransactionsPageContent() {
 
   const loadTransactions = useCallback(async (p: number) => {
     let url = `/api/v1/transactions?limit=${pageSize}&offset=${p * pageSize}`;
-    url += `&sort_by=${sortField}&sort_dir=${sortDir}`;
+    url += `&sort_by=${encodeURIComponent(sortField)}&sort_dir=${encodeURIComponent(sortDir)}`;
     if (filterAccount) url += `&account_id=${filterAccount}`;
     if (filterCategory) url += `&category_id=${filterCategory}`;
     if (filterType) url += `&type=${filterType}`;

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -399,10 +399,12 @@ function TransactionsPageContent() {
     void refreshAfterTransactionAdded();
   });
 
+  // Clear selection whenever the visible row set changes (filters, sort, page,
+  // or page size) so navigation never leaves an invisible selection behind.
   useEffect(() => {
     clearSelection();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterAccount, filterCategory, filterType, filterStatus, filterDateFrom, filterDateTo, filterSearch, filterPeriod, sortField, sortDir, page]);
+  }, [filterAccount, filterCategory, filterType, filterStatus, filterDateFrom, filterDateTo, filterSearch, filterPeriod, sortField, sortDir, page, pageSize]);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -602,7 +604,6 @@ function TransactionsPageContent() {
   function changePageSize(n: number) {
     setPageSize(n);
     setPage(0);
-    clearSelection();
     if (typeof window !== "undefined") window.localStorage.setItem(PAGE_SIZE_KEY_TRANSACTIONS, String(n));
   }
 
@@ -854,7 +855,6 @@ function TransactionsPageContent() {
       persistedSort.setSort(field, SORT_DEFAULTS[field]);
     }
     setPage(0);
-    clearSelection();
   }
   // Visible rows are the fetched (server-sorted) transactions minus the
   // cascaded "duplicate" half of any transfer pair. Rows arrive pre-sorted
@@ -2051,7 +2051,7 @@ function TransactionsPageContent() {
                 page={page + 1}
                 pageSize={pageSize}
                 total={total}
-                onPageChange={(n) => { setPage(n - 1); clearSelection(); }}
+                onPageChange={(n) => setPage(n - 1)}
                 onPageSizeChange={changePageSize}
               />
             </div>

--- a/frontend/lib/hooks/persisted-keys.ts
+++ b/frontend/lib/hooks/persisted-keys.ts
@@ -9,3 +9,5 @@ export const SORT_KEY_DASHBOARD_TRANSACTIONS = "pfv:sort:dashboard-transactions"
 export const SORT_KEY_RECURRING = "pfv:sort:recurring";
 
 export const FILTERS_KEY_TRANSACTIONS = "pfv:filters:transactions";
+
+export const PAGE_SIZE_KEY_TRANSACTIONS = "tbd.tx.pageSize";

--- a/frontend/lib/hooks/persisted-keys.ts
+++ b/frontend/lib/hooks/persisted-keys.ts
@@ -10,4 +10,4 @@ export const SORT_KEY_RECURRING = "pfv:sort:recurring";
 
 export const FILTERS_KEY_TRANSACTIONS = "pfv:filters:transactions";
 
-export const PAGE_SIZE_KEY_TRANSACTIONS = "tbd.tx.pageSize";
+export const PAGE_SIZE_KEY_TRANSACTIONS = "pfv:page-size:transactions";

--- a/frontend/lib/pagination.ts
+++ b/frontend/lib/pagination.ts
@@ -2,9 +2,10 @@ import { apiFetch } from "@/lib/api";
 
 /**
  * Page through a list endpoint that supports `limit` + `offset` query
- * params and returns an array of T. Stops when a response shorter than
- * `pageSize` arrives. For all-time aggregates whose per-page cap (≤200
- * server-side) would otherwise truncate the result.
+ * params and returns the `{ items, total }` list envelope. Reads `.items`
+ * off each response and stops when a page shorter than `pageSize` arrives.
+ * For all-time aggregates whose per-page cap (≤200 server-side) would
+ * otherwise truncate the result. Used for the transactions list endpoint.
  *
  * Caller passes a base URL with any non-pagination query params already
  * attached, e.g. `fetchAll<Transaction>("/api/v1/transactions?status=pending")`.
@@ -23,8 +24,11 @@ export async function fetchAll<T>(baseUrl: string, pageSize = 200): Promise<T[]>
   // beyond any realistic dashboard workload; raise if a real workload
   // ever approaches it.
   for (let page = 0; page < 100; page += 1) {
-    const rows = await apiFetch<T[]>(`${baseUrl}${sep}limit=${pageSize}&offset=${offset}`);
-    if (!Array.isArray(rows) || rows.length === 0) break;
+    const resp = await apiFetch<{ items: T[]; total: number }>(
+      `${baseUrl}${sep}limit=${pageSize}&offset=${offset}`,
+    );
+    const rows = resp?.items ?? [];
+    if (rows.length === 0) break;
     result.push(...rows);
     if (rows.length < pageSize) break;
     offset += pageSize;

--- a/frontend/tests/app/accounts-adjust-balance-button.test.tsx
+++ b/frontend/tests/app/accounts-adjust-balance-button.test.tsx
@@ -71,9 +71,8 @@ function mockApi() {
     if (path === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
     if (path.startsWith("/api/v1/accounts")) return Promise.resolve(ACCOUNTS);
     if (path.startsWith("/api/v1/transactions")) {
-      // fetchAll wraps the response — return a paginated shape compatible
-      // with both array and {items, total} fetchers.
-      return Promise.resolve([]);
+      // fetchAll reads `.items` off the list envelope.
+      return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
     }
     return Promise.resolve([]);
   });

--- a/frontend/tests/app/accounts-edit-type.test.tsx
+++ b/frontend/tests/app/accounts-edit-type.test.tsx
@@ -98,7 +98,7 @@ function mockApi(accounts = [CHECKING_ACCT, CC_ACCT]) {
     if (path.startsWith("/api/v1/accounts/") && path.endsWith("/reconcile")) {
       return Promise.resolve({});
     }
-    if (path.startsWith("/api/v1/transactions")) return Promise.resolve([]);
+    if (path.startsWith("/api/v1/transactions")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
     return Promise.resolve([]);
   });
 }
@@ -275,7 +275,7 @@ describe("Edit Account Type — inline edit row", () => {
     vi.mocked(apiFetch).mockImplementation((path: string, init?: RequestInit) => {
       if (path === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
       if (path === "/api/v1/accounts") return Promise.resolve([CHECKING_ACCT, CC_ACCT]);
-      if (path.startsWith("/api/v1/transactions")) return Promise.resolve([]);
+      if (path.startsWith("/api/v1/transactions")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
       if (init?.method === "PUT") {
         return Promise.reject(new Error("close_day is only allowed on credit_card accounts"));
       }

--- a/frontend/tests/app/accounts-list-headers.test.tsx
+++ b/frontend/tests/app/accounts-list-headers.test.tsx
@@ -89,7 +89,7 @@ function mockApi() {
   vi.mocked(apiFetch).mockImplementation(((url: string) => {
     if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
     if (url === "/api/v1/accounts") return Promise.resolve(ACCOUNTS);
-    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
     return Promise.resolve({});
   }) as never);
 }
@@ -140,7 +140,7 @@ describe("AccountsPage — list header row and fixed action column", () => {
     vi.mocked(apiFetch).mockImplementation(((url: string) => {
       if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
       if (url === "/api/v1/accounts") return Promise.resolve([]);
-      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
       return Promise.resolve({});
     }) as never);
 

--- a/frontend/tests/app/accounts-pending-visibility.test.tsx
+++ b/frontend/tests/app/accounts-pending-visibility.test.tsx
@@ -98,7 +98,7 @@ describe("AccountsPage — pending visibility (L3.4)", () => {
       if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
       if (url === "/api/v1/accounts") return Promise.resolve(ACCOUNTS);
       // fetchAll<T> appends &limit=200&offset=N; match the prefix.
-      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve(pending);
+      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: pending, total: pending.length, limit: 200, offset: 0 });
       return Promise.resolve({});
     }) as never);
   }

--- a/frontend/tests/app/accounts-side-by-side-layout.test.tsx
+++ b/frontend/tests/app/accounts-side-by-side-layout.test.tsx
@@ -73,7 +73,7 @@ function mockApi() {
   vi.mocked(apiFetch).mockImplementation(((url: string) => {
     if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
     if (url === "/api/v1/accounts") return Promise.resolve(ACCOUNTS);
-    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
     return Promise.resolve({});
   }) as never);
 }

--- a/frontend/tests/app/accounts-sort-pagination.test.tsx
+++ b/frontend/tests/app/accounts-sort-pagination.test.tsx
@@ -100,7 +100,7 @@ function mockApi(accounts: unknown[] = ACCOUNTS) {
   vi.mocked(apiFetch).mockImplementation(((url: string) => {
     if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
     if (url === "/api/v1/accounts") return Promise.resolve(accounts);
-    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
     return Promise.resolve({});
   }) as never);
 }
@@ -195,7 +195,7 @@ describe("AccountsPage — page clamping when row count shrinks", () => {
       const method = opts?.method?.toUpperCase() ?? "GET";
       if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
       if (url === "/api/v1/accounts" && method === "GET") return Promise.resolve(initialAccounts);
-      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
       return Promise.resolve({});
     }) as never);
 
@@ -215,7 +215,7 @@ describe("AccountsPage — page clamping when row count shrinks", () => {
       const method = opts?.method?.toUpperCase() ?? "GET";
       if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
       if (url === "/api/v1/accounts" && method === "GET") return Promise.resolve(afterDeleteAccounts);
-      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
       if (url.match(/\/api\/v1\/accounts\/\d+/) && method === "DELETE") return Promise.resolve({});
       return Promise.resolve({});
     }) as never);
@@ -328,7 +328,7 @@ describe("AccountsPage — nulls-last stable sort", () => {
     vi.mocked(apiFetch).mockImplementation(((url: string) => {
       if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
       if (url === "/api/v1/accounts") return Promise.resolve(ACCOUNTS_WITH_EMPTY_TYPE);
-      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
       return Promise.resolve({});
     }) as never);
   });

--- a/frontend/tests/app/dashboard-forecast-by-category-colors.test.tsx
+++ b/frontend/tests/app/dashboard-forecast-by-category-colors.test.tsx
@@ -143,9 +143,9 @@ function setupApiMocks() {
     if (url.startsWith("/api/v1/forecast/account-balances"))
       return Promise.resolve({ accounts: [], period_start: "2026-05-01", period_end: "2026-05-31" });
     if (url.startsWith("/api/v1/transactions?status=pending"))
-      return Promise.resolve([]);
+      return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
     if (url.startsWith("/api/v1/transactions"))
-      return Promise.resolve([]);
+      return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
     return Promise.resolve(null);
   }) as never);
 }

--- a/frontend/tests/app/dashboard-help-anchor.test.tsx
+++ b/frontend/tests/app/dashboard-help-anchor.test.tsx
@@ -58,7 +58,7 @@ function mockEmptyDashboard() {
       return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
     if (url === "/api/v1/settings/billing-periods")
       return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
-    if (url.startsWith("/api/v1/transactions")) return Promise.resolve([]);
+    if (url.startsWith("/api/v1/transactions")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
     if (url.startsWith("/api/v1/forecast-plans/current"))
       return Promise.resolve(null);
     return Promise.resolve({});

--- a/frontend/tests/app/dashboard-on-track-tour-anchor-shape.test.tsx
+++ b/frontend/tests/app/dashboard-on-track-tour-anchor-shape.test.tsx
@@ -82,7 +82,7 @@ function mockEmptyDashboard() {
       return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
     if (url === "/api/v1/settings/billing-periods")
       return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
-    if (url.startsWith("/api/v1/transactions")) return Promise.resolve([]);
+    if (url.startsWith("/api/v1/transactions")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
     if (url.startsWith("/api/v1/forecast-plans/current"))
       return Promise.resolve(null);
     return Promise.resolve({});

--- a/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
+++ b/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
@@ -119,16 +119,18 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
       // these calls and return [] so fetchAll exits on the first page.
       if (url.startsWith("/api/v1/transactions?status=pending")) {
         pendingCalls += 1;
-        return Promise.resolve([]);
+        return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
       }
       // limit=200 is the period-scoped "all" fetch (donut, charts, etc.).
       // limit=11 is the paginated visible-page fetch (PAGE_SIZE+1).
-      if (url.startsWith("/api/v1/transactions?limit=200"))
-        return Promise.resolve([...PAGE_0_ROWS, ...PAGE_1_ROWS]);
+      if (url.startsWith("/api/v1/transactions?limit=200")) {
+        const items = [...PAGE_0_ROWS, ...PAGE_1_ROWS];
+        return Promise.resolve({ items, total: items.length, limit: 200, offset: 0 });
+      }
       if (url.startsWith("/api/v1/transactions?limit=11&offset=0"))
-        return Promise.resolve(PAGE_0_ROWS);
+        return Promise.resolve({ items: PAGE_0_ROWS, total: PAGE_0_ROWS.length, limit: 11, offset: 0 });
       if (url.startsWith("/api/v1/transactions?limit=11&offset=10"))
-        return Promise.resolve(PAGE_1_ROWS);
+        return Promise.resolve({ items: PAGE_1_ROWS, total: PAGE_1_ROWS.length, limit: 11, offset: 10 });
       return Promise.resolve({});
     }) as never);
 
@@ -183,10 +185,10 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
         return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
       if (url.startsWith("/api/v1/forecast-plans/current")) return Promise.resolve(null);
       if (url.startsWith("/api/v1/forecast?period_start=")) return Promise.resolve(null);
-      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
-      if (url.startsWith("/api/v1/transactions?limit=200")) return Promise.resolve([SETTLED_TX]);
+      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
+      if (url.startsWith("/api/v1/transactions?limit=200")) return Promise.resolve({ items: [SETTLED_TX], total: 1, limit: 200, offset: 0 });
       if (url.startsWith("/api/v1/transactions?limit=11&offset=0"))
-        return Promise.resolve([SETTLED_TX]);
+        return Promise.resolve({ items: [SETTLED_TX], total: 1, limit: 11, offset: 0 });
       return Promise.resolve({});
     }) as never);
 
@@ -228,10 +230,10 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
         return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
       if (url.startsWith("/api/v1/forecast-plans/current")) return Promise.resolve(null);
       if (url.startsWith("/api/v1/forecast?period_start=")) return Promise.resolve(null);
-      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
-      if (url.startsWith("/api/v1/transactions?limit=200")) return Promise.resolve([CC_TX]);
+      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
+      if (url.startsWith("/api/v1/transactions?limit=200")) return Promise.resolve({ items: [CC_TX], total: 1, limit: 200, offset: 0 });
       if (url.startsWith("/api/v1/transactions?limit=11&offset=0"))
-        return Promise.resolve([CC_TX]);
+        return Promise.resolve({ items: [CC_TX], total: 1, limit: 11, offset: 0 });
       return Promise.resolve({});
     }) as never);
 

--- a/frontend/tests/app/dashboard-projection-race.test.tsx
+++ b/frontend/tests/app/dashboard-projection-race.test.tsx
@@ -132,7 +132,7 @@ describe("DashboardPage — projection race protection", () => {
       if (url === "/api/v1/settings/billing-cycle") return Promise.resolve({ billing_cycle_day: 1 });
       if (url === "/api/v1/settings/billing-period") return Promise.resolve(periods[0]);
       if (url === "/api/v1/settings/billing-periods") return Promise.resolve(periods);
-      if (url.startsWith("/api/v1/transactions")) return Promise.resolve([]);
+      if (url.startsWith("/api/v1/transactions")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
       if (url.includes("forecast-plans/current"))
         return Promise.resolve({ ...PLAN_1000, period_start: url.includes("2026-04-01") ? "2026-04-01" : "2026-05-01" });
       // The race: May's projection is held; April's resolves immediately.

--- a/frontend/tests/app/dashboard-recent-tx-columns.test.tsx
+++ b/frontend/tests/app/dashboard-recent-tx-columns.test.tsx
@@ -94,8 +94,8 @@ function mockDashboard() {
       return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
     if (url.startsWith("/api/v1/forecast-plans/current")) return Promise.resolve(null);
     if (url.startsWith("/api/v1/forecast?period_start=")) return Promise.resolve(null);
-    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([TXS[1]]);
-    if (url.startsWith("/api/v1/transactions")) return Promise.resolve(TXS);
+    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [TXS[1]], total: 1, limit: 200, offset: 0 });
+    if (url.startsWith("/api/v1/transactions")) return Promise.resolve({ items: TXS, total: TXS.length, limit: 200, offset: 0 });
     return Promise.resolve({});
   }) as never);
 }

--- a/frontend/tests/app/dashboard-refresh-error-banner.test.tsx
+++ b/frontend/tests/app/dashboard-refresh-error-banner.test.tsx
@@ -116,7 +116,7 @@ function makeHandler(opts: { failTxOnSecondCall?: boolean } = {}) {
       if (opts.failTxOnSecondCall && txCalls >= 2) {
         throw new Error("backend hiccup");
       }
-      return [] as never;
+      return { items: [], total: 0, limit: 200, offset: 0 } as never;
     }
     return null as never;
   };
@@ -226,7 +226,7 @@ describe("Dashboard refresh-error banner", () => {
         // (call #2) is the only failure. After Retry the banner
         // clears.
         if (txCalls === 2) throw new Error("transient");
-        return [] as never;
+        return { items: [], total: 0, limit: 200, offset: 0 } as never;
       }
       return null as never;
     });

--- a/frontend/tests/app/dashboard-reset-banner.test.tsx
+++ b/frontend/tests/app/dashboard-reset-banner.test.tsx
@@ -48,7 +48,7 @@ function mockEmptyDashboard() {
     if (url === "/api/v1/settings/billing-cycle") return Promise.resolve({ billing_cycle_day: 1 });
     if (url === "/api/v1/settings/billing-period") return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
     if (url === "/api/v1/settings/billing-periods") return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
-    if (url.startsWith("/api/v1/transactions")) return Promise.resolve([]);
+    if (url.startsWith("/api/v1/transactions")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
     if (url.startsWith("/api/v1/forecast-plans/current")) return Promise.resolve(null);
     return Promise.resolve({});
   }) as never);

--- a/frontend/tests/app/dashboard-sort-header-touch-targets.test.tsx
+++ b/frontend/tests/app/dashboard-sort-header-touch-targets.test.tsx
@@ -50,9 +50,10 @@ function mockDashboardWithOneTx() {
       return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
     if (url.startsWith("/api/v1/forecast-plans/current")) return Promise.resolve(null);
     if (url.startsWith("/api/v1/forecast?period_start=")) return Promise.resolve(null);
-    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+    if (url.startsWith("/api/v1/transactions?status=pending"))
+      return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
     if (url.startsWith("/api/v1/transactions")) {
-      return Promise.resolve([
+      const items = [
         {
           id: 1,
           account_id: 10,
@@ -69,7 +70,8 @@ function mockDashboardWithOneTx() {
           is_imported: false,
           settled_date: "2026-05-01",
         },
-      ]);
+      ];
+      return Promise.resolve({ items, total: items.length, limit: 200, offset: 0 });
     }
     return Promise.resolve({});
   }) as never);

--- a/frontend/tests/app/dashboard-spending-sort-persistence.test.tsx
+++ b/frontend/tests/app/dashboard-spending-sort-persistence.test.tsx
@@ -106,11 +106,12 @@ function setupApiFetch() {
     if (url.startsWith("/api/v1/budgets")) return [] as never;
     if (url.startsWith("/api/v1/forecast")) return null as never;
     if (url.startsWith("/api/v1/transactions")) {
-      return [
+      const items = [
         tx({ id: 1, amount: "100.00", category_id: 11, category_name: "Groceries", date: "2026-05-02" }),
         tx({ id: 2, amount: "500.00", category_id: 12, category_name: "Rent", date: "2026-05-03" }),
         tx({ id: 3, amount: "50.00", category_id: 11, category_name: "Groceries", date: "2026-05-04" }),
-      ] as never;
+      ];
+      return { items, total: items.length, limit: 200, offset: 0 } as never;
     }
     return null as never;
   });

--- a/frontend/tests/app/transactions-deep-links.test.tsx
+++ b/frontend/tests/app/transactions-deep-links.test.tsx
@@ -97,7 +97,8 @@ function setupApiFetch(txs: ReturnType<typeof makeTx>[]) {
     if (url.startsWith("/api/v1/settings/billing-periods")) {
       return [{ id: 9, start_date: "2026-05-01", end_date: null }] as never;
     }
-    if (url.startsWith("/api/v1/transactions")) return txs as never;
+    if (url.startsWith("/api/v1/transactions"))
+      return { items: txs, total: txs.length, limit: 25, offset: 0 } as never;
     return null as never;
   });
   return apiFetchMock;

--- a/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
+++ b/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
@@ -94,7 +94,8 @@ function setupApiFetch(txs: Tx[]) {
     if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
     if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
     if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
-    if (url.startsWith("/api/v1/transactions") && method === "GET") return txs as never;
+    if (url.startsWith("/api/v1/transactions") && method === "GET")
+      return { items: txs, total: txs.length, limit: 25, offset: 0 } as never;
     if (url === "/api/v1/transactions" && method === "POST") {
       return { ...makeTx(), id: 999 } as never;
     }

--- a/frontend/tests/app/transactions-page.test.tsx
+++ b/frontend/tests/app/transactions-page.test.tsx
@@ -99,7 +99,8 @@ function setupApiFetch(txs: ReturnType<typeof makeTx>[]) {
     if (url.startsWith("/api/v1/accounts")) return [ACCT_A, ACCT_B] as never;
     if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
     if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
-    if (url.startsWith("/api/v1/transactions")) return txs as never;
+    if (url.startsWith("/api/v1/transactions"))
+      return { items: txs, total: txs.length, limit: 25, offset: 0 } as never;
     return null as never;
   });
 }
@@ -337,7 +338,8 @@ describe("TransactionsPage — transfer wiring (Task D7)", () => {
         if (url === "/api/v1/transactions/99/tags") {
           throw new Error("tag attach failed");
         }
-        if (url.startsWith("/api/v1/transactions")) return [] as never;
+        if (url.startsWith("/api/v1/transactions"))
+          return { items: [], total: 0, limit: 25, offset: 0 } as never;
         return null as never;
       },
     );

--- a/frontend/tests/app/transactions-pending-pill-opacity.test.tsx
+++ b/frontend/tests/app/transactions-pending-pill-opacity.test.tsx
@@ -87,7 +87,8 @@ function setupApiFetch(txs: ReturnType<typeof makePendingTx>[]) {
     if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
     if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
     if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
-    if (url.startsWith("/api/v1/transactions")) return txs as never;
+    if (url.startsWith("/api/v1/transactions"))
+      return { items: txs, total: txs.length, limit: 25, offset: 0 } as never;
     return null as never;
   });
 }

--- a/frontend/tests/app/transactions-promote-recurring.test.tsx
+++ b/frontend/tests/app/transactions-promote-recurring.test.tsx
@@ -97,7 +97,8 @@ function setupApiFetch(txs: Tx[], extras: Record<string, unknown> = {}) {
     if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
     if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
     if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
-    if (url.startsWith("/api/v1/transactions") && method === "GET") return txs as never;
+    if (url.startsWith("/api/v1/transactions") && method === "GET")
+      return { items: txs, total: txs.length, limit: 25, offset: 0 } as never;
     return null as never;
   });
 }
@@ -215,7 +216,8 @@ describe("TransactionsPage — promote to recurring (L3.12)", () => {
       if (url === "/api/v1/transactions/75/promote-to-recurring" && method === "POST") {
         throw new Error("recurring quota exceeded");
       }
-      if (url.startsWith("/api/v1/transactions") && method === "GET") return [tx] as never;
+      if (url.startsWith("/api/v1/transactions") && method === "GET")
+        return { items: [tx], total: 1, limit: 25, offset: 0 } as never;
       return null as never;
     });
 
@@ -317,7 +319,8 @@ describe("TransactionsPage — promote to recurring (L3.12)", () => {
           recurring_id: 9001,
         }) as never;
       }
-      if (url.startsWith("/api/v1/transactions") && method === "GET") return [] as never;
+      if (url.startsWith("/api/v1/transactions") && method === "GET")
+        return { items: [], total: 0, limit: 25, offset: 0 } as never;
       return null as never;
     });
 
@@ -396,7 +399,8 @@ describe("TransactionsPage — promote to recurring (L3.12)", () => {
           recurring_id: 9002,
         }) as never;
       }
-      if (url.startsWith("/api/v1/transactions") && method === "GET") return [] as never;
+      if (url.startsWith("/api/v1/transactions") && method === "GET")
+        return { items: [], total: 0, limit: 25, offset: 0 } as never;
       return null as never;
     });
 

--- a/frontend/tests/app/transactions-quick-filters-and-sort.test.tsx
+++ b/frontend/tests/app/transactions-quick-filters-and-sort.test.tsx
@@ -71,7 +71,8 @@ function setupApiFetch(periods: Period[] = []) {
     if (url.startsWith("/api/v1/accounts")) return [ACCT] as never;
     if (url.startsWith("/api/v1/categories")) return [CATEGORY] as never;
     if (url.startsWith("/api/v1/settings/billing-periods")) return periods as never;
-    if (url.startsWith("/api/v1/transactions")) return [] as never;
+    if (url.startsWith("/api/v1/transactions"))
+      return { items: [], total: 0, limit: 25, offset: 0 } as never;
     return null as never;
   });
   return apiFetchMock;

--- a/frontend/tests/app/transactions-server-pagination.test.tsx
+++ b/frontend/tests/app/transactions-server-pagination.test.tsx
@@ -244,6 +244,42 @@ describe("TransactionsPage — server-side pagination/sort/selection (Task 4)", 
     });
   });
 
+  it("per-page size persists across remount", async () => {
+    const { unmount } = render(<TransactionsPage />);
+    await waitForStableTxList();
+
+    // Change the page size; this writes to localStorage.
+    fireEvent.change(screen.getByLabelText(/per page/i), {
+      target: { value: "50" },
+    });
+    await waitFor(() => {
+      expect(
+        listUrls().some((u) => u.includes("limit=50")),
+      ).toBe(true);
+    });
+
+    // Unmount, then drop the recorded URLs so the next assertion only
+    // sees the fresh mount's fetches. localStorage is intentionally NOT
+    // cleared (beforeEach clears once; the two renders share it).
+    unmount();
+    urls = [];
+
+    // Fresh mount rehydrates the persisted page size. We can't reuse
+    // waitForStableTxList here: with pageSize=50 and 30 total rows the
+    // page renders a single page, and the page only mounts <Pagination>
+    // (which owns the "Per page" control) when `total > pageSize ||
+    // page > 0`. So settle on a visible row instead, then assert the
+    // rehydrated fetch carried the persisted limit.
+    render(<TransactionsPage />);
+    await screen.findAllByText("Row 1", undefined, { timeout: 4000 });
+
+    await waitFor(() => {
+      expect(
+        listUrls().some((u) => u.includes("limit=50")),
+      ).toBe(true);
+    });
+  });
+
   it("selection clears on navigation", async () => {
     render(<TransactionsPage />);
     await waitForStableTxList();

--- a/frontend/tests/app/transactions-server-pagination.test.tsx
+++ b/frontend/tests/app/transactions-server-pagination.test.tsx
@@ -1,0 +1,271 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import TransactionsPage from "@/app/transactions/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/transactions",
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const USER = {
+  id: 1, username: "user", email: "user@example.com",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner" as const, org_id: 1, org_name: "Org",
+  billing_cycle_day: 1, is_superadmin: false, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const ACCT_A = {
+  id: 100, name: "Checking A", account_type_id: 1,
+  account_type_name: "Checking", account_type_slug: "checking",
+  balance: 0, currency: "EUR", is_active: true,
+  close_day: null, is_default: true,
+};
+
+const ACCT_B = {
+  id: 200, name: "Checking B", account_type_id: 1,
+  account_type_name: "Checking", account_type_slug: "checking",
+  balance: 0, currency: "EUR", is_active: true,
+  close_day: null, is_default: false,
+};
+
+const CATEGORY_GROCERIES = {
+  id: 11, name: "Groceries", type: "expense" as const,
+  parent_id: null, parent_name: null, description: null,
+  slug: "groceries", is_system: false, transaction_count: 0,
+};
+
+function makeTx(over: Partial<{
+  id: number;
+  account_id: number;
+  account_name: string;
+  category_id: number;
+  category_name: string;
+  description: string;
+  amount: number;
+  type: "income" | "expense";
+  status: "settled" | "pending";
+  linked_transaction_id: number | null;
+  recurring_id: number | null;
+  date: string;
+  settled_date: string | null;
+  is_imported: boolean;
+}> = {}) {
+  return {
+    id: 1,
+    account_id: ACCT_A.id,
+    account_name: ACCT_A.name,
+    category_id: CATEGORY_GROCERIES.id,
+    category_name: CATEGORY_GROCERIES.name,
+    description: "Tx",
+    amount: 100,
+    type: "expense" as const,
+    status: "settled" as const,
+    linked_transaction_id: null,
+    recurring_id: null,
+    date: "2026-05-01",
+    settled_date: null,
+    is_imported: false,
+    ...over,
+  };
+}
+
+// total of 30 rows on the server (> default page size 25 => Pagination renders).
+const SERVER_TOTAL = 30;
+
+// Module-level record of every LIST URL the page requested.
+let urls: string[] = [];
+
+// Only the top-level list endpoint, excluding sub-paths like
+// /transactions/30, /transactions/30/tags, /transactions/bulk-delete.
+function listUrls(): string[] {
+  return urls.filter((u) => /^\/api\/v1\/transactions\?/.test(u));
+}
+
+function paramOf(url: string, key: string): string | null {
+  const q = url.split("?")[1] ?? "";
+  return new URLSearchParams(q).get(key);
+}
+
+function setupApiFetch() {
+  urls = [];
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith("/api/v1/accounts")) return [ACCT_A, ACCT_B] as never;
+    if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
+    if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
+
+    // List endpoint (has a query string). Record it and return a page-sized
+    // slice driven by the requested limit/offset.
+    if (/^\/api\/v1\/transactions\?/.test(url)) {
+      urls.push(url);
+      const limit = Number(paramOf(url, "limit") ?? 25);
+      const offset = Number(paramOf(url, "offset") ?? 0);
+      const items = [];
+      for (let i = 0; i < limit && offset + i < SERVER_TOTAL; i++) {
+        const id = offset + i + 1;
+        items.push(
+          makeTx({
+            id,
+            description: `Row ${id}`,
+            amount: 10 + id,
+          }),
+        );
+      }
+      return { items, total: SERVER_TOTAL, limit, offset } as never;
+    }
+    return null as never;
+  });
+}
+
+async function waitForStableTxList() {
+  // Page kicks off loadRefs() + loadTransactions(0); the list effect re-fires
+  // (setFetching(true) -> Spinner) once `periods` settles, then resolves to
+  // the table. findAllByText drives the act() flush through the full
+  // spinner -> table settle (this is the same settle pattern the sibling
+  // transactions-page test relies on). Once a row is visible the page is in
+  // its non-fetching branch, so the shared Pagination has mounted too.
+  await screen.findAllByText("Row 1", undefined, { timeout: 4000 });
+  await waitFor(
+    () => {
+      expect(screen.getByLabelText(/per page/i)).toBeInTheDocument();
+    },
+    { timeout: 4000 },
+  );
+}
+
+describe("TransactionsPage — server-side pagination/sort/selection (Task 4)", () => {
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    useAuthMock.mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+    setupApiFetch();
+  });
+
+  it("renders shared Pagination with real total", async () => {
+    render(<TransactionsPage />);
+    await waitForStableTxList();
+
+    // Per-page selector present.
+    expect(screen.getByLabelText(/per page/i)).toBeInTheDocument();
+
+    // Status line: 30 total / 25 per page => 2 pages.
+    await waitFor(() => {
+      expect(screen.getByText(/Page 1 of 2/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/30 total/)).toBeInTheDocument();
+  });
+
+  it("Next page fetches offset=25 (limit=25)", async () => {
+    render(<TransactionsPage />);
+    await waitForStableTxList();
+
+    fireEvent.click(screen.getByLabelText("Next page"));
+
+    await waitFor(() => {
+      expect(
+        listUrls().some(
+          (u) => u.includes("offset=25") && u.includes("limit=25"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("sort header resets to offset=0 and sends sort params", async () => {
+    render(<TransactionsPage />);
+    await waitForStableTxList();
+
+    // First move off page 0 so a later offset=0 fetch is unambiguously the
+    // sort's doing, not the initial load.
+    fireEvent.click(screen.getByLabelText("Next page"));
+    await waitFor(() => {
+      expect(listUrls().some((u) => u.includes("offset=25"))).toBe(true);
+    });
+
+    // Click the "Description" column header (toggleSort("description")).
+    fireEvent.click(screen.getByRole("button", { name: /^Description/ }));
+
+    await waitFor(() => {
+      expect(
+        listUrls().some(
+          (u) =>
+            u.includes("sort_by=description") &&
+            u.includes("sort_dir=") &&
+            u.includes("offset=0"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("per-page selector changes limit and resets offset", async () => {
+    render(<TransactionsPage />);
+    await waitForStableTxList();
+
+    fireEvent.change(screen.getByLabelText(/per page/i), {
+      target: { value: "50" },
+    });
+
+    await waitFor(() => {
+      expect(
+        listUrls().some(
+          (u) => u.includes("limit=50") && u.includes("offset=0"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("selection clears on navigation", async () => {
+    render(<TransactionsPage />);
+    await waitForStableTxList();
+
+    // Wait for the per-row checkbox to render, then select row 1.
+    await waitFor(() => {
+      expect(
+        screen.queryAllByLabelText("Select transaction 1").length,
+      ).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByLabelText("Select transaction 1")[0]);
+
+    // Bulk bar appears with the "N selected" count text.
+    await waitFor(() => {
+      expect(screen.getAllByText(/^\d+ selected$/).length).toBeGreaterThan(0);
+    });
+
+    // Navigate to the next page; selection must clear (count text gone).
+    fireEvent.click(screen.getByLabelText("Next page"));
+
+    await waitFor(() => {
+      expect(screen.queryAllByText(/^\d+ selected$/).length).toBe(0);
+    });
+  });
+});

--- a/frontend/tests/app/transactions-sort-filter-persistence.test.tsx
+++ b/frontend/tests/app/transactions-sort-filter-persistence.test.tsx
@@ -63,7 +63,8 @@ function setupApiFetch() {
     if (url.startsWith("/api/v1/accounts")) return [ACCT] as never;
     if (url.startsWith("/api/v1/categories")) return [CATEGORY] as never;
     if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
-    if (url.startsWith("/api/v1/transactions")) return [] as never;
+    if (url.startsWith("/api/v1/transactions"))
+      return { items: [], total: 0, limit: 25, offset: 0 } as never;
     return null as never;
   });
   return apiFetchMock;

--- a/specs/transactions-server-side-list.md
+++ b/specs/transactions-server-side-list.md
@@ -1,0 +1,183 @@
+# Transactions server-side list contract + shared pagination/sort
+
+**Date:** 2026-06-03
+**Status:** Spec — ready for implementation plan
+**Branch target:** `feat/transactions-server-side-list` (off `main`)
+
+## Problem
+
+The transactions page is the last table in the standardization fan-out still on
+its own bespoke pagination. The list endpoint
+(`GET /api/v1/transactions`, `routers/transactions.py:65`) returns a **bare
+list with no total count and no sort params**. The frontend
+(`frontend/app/transactions/page.tsx`) fetches `limit=PAGE_SIZE+1&offset=...`
+and derives `hasMore` from the +1 probe, rendering a bespoke
+`Previous / Page N / Next` control (no per-page selector, no page count). Sorting
+is done **client-side over only the current page** (`useMemo` on the visible
+rows) — a latent bug that becomes obvious with real pagination ("sort by amount"
+would reorder just one page of rows).
+
+The other tables (Recurring, Accounts client-side; Admin Users server-side) use
+the shared `Pagination` / `SortableHeader` / `useTableState` primitives shipped
+in #388/#389. The shared `Pagination` component **requires a real `total`**
+(it renders "Page X of Y · N total"), so adopting it forces a backend change.
+Fetching all rows to slice client-side (the Recurring/Accounts pattern) is not
+viable for a large, server-paginated dataset.
+
+## Goal
+
+Migrate transactions to the **#389 server-side `ListEnvelope` contract** (Admin
+Users is the canonical reference): the endpoint returns `{items, total}` and
+supports server-side sort via `resolve_order_by`; the page uses the shared
+`Pagination` (numbered pages + per-page selector) and server-side
+`SortableHeader`. Fix the page-local sort bug. Keep the page's existing
+**localStorage** persistence model (`usePersistedSort` / `usePersistedFilters`),
+not Admin Users' URL-state model. Preserve all existing behavior: filters, bulk
+select/delete, inline edit, recurring-promote, transfer pairing.
+
+## Decisions (locked 2026-06-03)
+
+- **Full server-side** sort + pagination (not a total-count-only reskin).
+- **Sort whitelist (all 6 current columns):** `date`, `amount`, `description`,
+  `status`, `account_name`, `category_name`. `account_name`/`category_name`
+  require inner joins to `Account`/`Category` in the page query.
+- **`date` sorts by `effective_period_date_expr()`** (consistent with the
+  existing date filter + period bucketing), not raw `Transaction.date`.
+- **Stable ordering:** `tiebreaker=Transaction.id.desc()` always appended.
+- **Default page size 25** (up from 20, a valid `PAGE_SIZE_OPTIONS` value),
+  persisted in localStorage; **page number is ephemeral** (reset to 1 on
+  filter/sort change; not persisted).
+- **Selection clears on page navigation and on sort change** (filter change
+  already resets the page). With server-side paging the client only holds the
+  current page's rows, so cross-page selection would show an invisible
+  "N selected".
+- **Persistence stays localStorage** (`usePersistedSort`/`usePersistedFilters`),
+  matching the transactions page today; URL params remain inbound-deep-link only.
+- **No change** to single/bulk delete semantics, transfer pairing, inline edit,
+  or recurring-promote.
+
+## Current behavior (baseline)
+
+- **Endpoint** `routers/transactions.py:65` — `response_model=list[TransactionResponse]`,
+  params: `account_id, category_id, type, status, date_from, date_to, search,
+  tags, tags_exclude, tag_match, limit (le=200, default 50), offset (ge=0)`. No
+  sort params. Calls `svc.list_transactions(...)` and returns
+  `[svc.to_response(tx) for tx in txns]`.
+- **Service** `transaction_service.list_transactions` (`:1787`) — builds
+  `q = select(Transaction).options(*_load_opts()).where(org_id==...)` then chains
+  `.where(...)` per filter (incl. category master-includes-subs, `search`
+  description+amount, tag subqueries, `effective_period_date_expr()` for dates),
+  ends with order/limit/offset. `_load_opts()` uses `selectinload` for
+  account/category/tags. Returns `list[Transaction]`. No count.
+- **Frontend** `transactions/page.tsx` — `PAGE_SIZE = 20` (`:35`); `page`
+  useState (`:88`); fetch builds `limit=${PAGE_SIZE+1}&offset=${p*PAGE_SIZE}`
+  (`:270`), `hasMore = data.length > PAGE_SIZE`; bespoke controls (`:2039-2046`).
+  `usePersistedFilters`/`usePersistedSort` (localStorage) at `:141`/`:172`;
+  `SortField` = date|description|account_name|category_name|status|amount with
+  per-column `SORT_DEFAULTS` (`:42-57`). Client-side sort `useMemo` (~`:837`).
+  `setPage(0)` on filter change (`:362`). Selection: `selectedIds: Set<number>`
+  (`:222`), `allPageSelected`/`togglePage` per visible page (`:555-579`),
+  `clearSelection` (`:581`); bulk delete reloads `loadTransactions(page)`.
+- **Reference (server-side):** Admin Users (`frontend/app/admin/users/page.tsx`)
+  + `admin_users_search_service.list_users` + `resolve_order_by` +
+  `UsersListResponse {items,total,limit,offset}`.
+- **Shared primitives:** `Pagination` props `{page, pageSize, total, onPageChange,
+  onPageSizeChange, pageSizeOptions?}` (1-based, requires `total`);
+  `pageCount(total, pageSize)`, `PAGE_SIZE_OPTIONS=[10,25,50,100]` in
+  `lib/hooks/use-table-state.ts`.
+
+## Proposed behavior
+
+### 1. Backend
+
+**`transaction_service.list_transactions`** — refactor to:
+- Build the list of WHERE clauses once into a local list (extracting the current
+  inline `.where(...)` chain), so both queries share identical filters.
+- Page query: `select(Transaction).options(*_load_opts())` + the where clauses
+  + (when sorting by `account_name`/`category_name`) `.join(Account)` /
+  `.join(Category)` + `.order_by(*resolve_order_by(...))` + `.limit/.offset`.
+- Count query: `select(func.count()).select_from(Transaction)` + the **same**
+  where clauses (no joins needed unless a filter requires them; the existing tag
+  filters use `Transaction.id.in_(subquery)` so no join is needed for count).
+- New signature params: `sort_by: str | None = None, sort_dir: str | None = None`.
+- `resolve_order_by(sort_by, sort_dir, allowed=ALLOWED_TX_SORT,
+  default_key="date", default_dir="desc", tiebreaker=Transaction.id.desc())`
+  where `ALLOWED_TX_SORT = {"date": effective_period_date_expr(), "amount":
+  Transaction.amount, "description": Transaction.description, "status":
+  Transaction.status, "account_name": Account.name, "category_name":
+  Category.name}`.
+- Return `tuple[list[Transaction], int]` (items, total).
+
+**`routers/transactions.py`** — `list_transactions`:
+- `response_model=ListEnvelope[TransactionResponse]` — reuse the generic
+  `ListEnvelope[T]` shared contract from `schemas/common.py` (that is the point
+  of #389; verify its field names — expected `items: list[T]; total: int;
+  limit: int; offset: int` — and match the frontend to them). If the admin
+  reference turned out to use a concrete `UsersListResponse` instead of the
+  generic, prefer the generic here unless it does not serialize cleanly as a
+  FastAPI `response_model`, in which case mirror the concrete admin shape. The
+  plan must confirm which during implementation by reading `schemas/common.py`
+  and the admin router.
+- Add `sort_by: str | None = Query(default=None)`, `sort_dir: Literal["asc",
+  "desc"] | None = Query(default=None)`.
+- Wrap the service call so a `ValidationError` (invalid_sort_by/dir) maps to
+  HTTP 400, mirroring `admin_users`.
+- Return `TransactionListResponse(items=[to_response(tx) for tx in items],
+  total=total, limit=limit, offset=offset)`.
+
+### 2. Frontend (`transactions/page.tsx`)
+
+- Fetch parses `{items, total}`; store `total` in state; drop the `+1` probe and
+  `hasMore`.
+- Send `sort_by=sortField&sort_dir=sortDir` on every fetch; add them to the
+  fetch effect deps. **Remove the client-side sort `useMemo`** (rows render in
+  server order).
+- `page` is 1-based component state; the fetch offset is `(page-1)*pageSize`.
+  Reset `page` to 1 on filter change (existing effect) and on sort change.
+- Add `pageSize` state (default 25) persisted in localStorage (small dedicated
+  key alongside the existing persisted-keys); `onPageSizeChange` sets size +
+  resets page to 1.
+- Replace `:2039-2046` bespoke controls with
+  `<Pagination page={page} pageSize={pageSize} total={total}
+  onPageChange={setPage} onPageSizeChange={...} />`, rendered when
+  `total > pageSize || page > 1`.
+- After every refetch (incl. post-mutation), clamp:
+  `if (page > pageCount(total, pageSize)) setPage(pageCount(total, pageSize))`.
+- `clearSelection()` on page change and on sort change.
+- `SortableHeader` usage stays; `handleSort` updates `usePersistedSort` and
+  resets page to 1.
+
+### 3. Preserved (must not regress)
+Filters (all current params + tag filters + period), bulk select/delete (+
+empty-page snap-back), inline edit, recurring-promote, transfer
+link/mark/unpair modals, refetch-on-mutation. These keep working off the new
+`{items}`.
+
+## Out of scope
+- URL-as-state (transactions stays localStorage-persisted).
+- New filter controls (separate paused reports-filters thread).
+- Changing delete/transfer/recurring semantics.
+- Cross-page "select all matching" (selection stays per-page).
+
+## Testing
+
+**Backend (`backend/tests/...`, in-memory SQLite)**
+- Envelope shape: `{items, total, limit, offset}`; `total` is the full filtered
+  count, independent of `limit`.
+- `total` mirrors filters: applying account/category/type/status/date/search/tag
+  filters changes `total` consistently with `items`.
+- Server-side sort per whitelisted key (asc + desc), including
+  `account_name`/`category_name` ordering via joins.
+- Tiebreaker: rows with equal sort values come back in stable `id desc` order;
+  pagination across pages has no gaps/dupes.
+- `sort_by`/`sort_dir` invalid → 400.
+- Org-scoping: a second org's rows never counted in `total` or returned.
+
+**Frontend (`frontend/tests/app/...`, Vitest/RTL)**
+- Renders shared `Pagination` showing real total / page count.
+- Page navigation refetches with the correct `offset`.
+- Sort header click sends `sort_by`/`sort_dir`, resets to page 1, and clears
+  selection.
+- Per-page selector changes size, resets to page 1, persists across remount.
+- Selection clears on page navigation.
+- Deleting the last row on the final page snaps back to the new last page.


### PR DESCRIPTION
Migrates the transactions list to the #389 server-side `ListEnvelope` contract and the shared `Pagination` component (per-page selector + real page counts), replacing the bespoke Previous/Next control. Fixes the prior client-side sort that only reordered the current page.

- **Backend:** `GET /api/v1/transactions` now returns `ListEnvelope[TransactionResponse]` (`{items, total, limit, offset}`) and accepts `sort_by`/`sort_dir`. `list_transactions` returns `(items, total)`; its filter chain was extracted verbatim into a helper applied to both the page query and a count query (so `total` stays org-scoped). Server-side sort via the `resolve_order_by` whitelist (date, amount, description, status, account_name, category_name; `date` orders by the effective period date; `id desc` tiebreaker). Invalid sort returns 400.
- **Frontend (transactions):** reads the envelope, sends server-side sort, renders the shared `Pagination` (default page size 25, persisted), clears selection on navigation, and clamps the page after refetch. localStorage persistence kept.
- **Cross-page consumers:** the endpoint is global, so the dashboard and accounts pages (which also read it) were migrated to the envelope; `fetchAll` now unwraps `{items}`.

Last table in the standardization fan-out. Persistence, delete/transfer/recurring semantics unchanged.