### PR TITLE
fix(forecast-plans): make master categories selectable in master build mode

### DIFF
--- a/frontend/app/forecast-plans/ForecastPlansClient.tsx
+++ b/frontend/app/forecast-plans/ForecastPlansClient.tsx
@@ -527,6 +527,10 @@ export default function ForecastPlansClient({
     if (next === mode || savingMode) return;
     const prev = mode;
     setMode(next);
+    // Clear any in-progress category pick: a subcategory selected in
+    // subcategory mode is no longer a listed option once the picker flips
+    // to masterOnly, and vice versa. Mirrors the type-flip clear below.
+    setFormCategoryId("");
     setSavingMode(true);
     setError("");
     try {

--- a/frontend/app/forecast-plans/ForecastPlansClient.tsx
+++ b/frontend/app/forecast-plans/ForecastPlansClient.tsx
@@ -1091,6 +1091,7 @@ export default function ForecastPlansClient({
                 value={formCategoryId}
                 onChange={(id) => setFormCategoryId(id)}
                 filterType={formType}
+                masterOnly={mode === "master"}
                 disabledIds={disabledForType}
                 className={input}
                 aria-label="Plan item category"

--- a/frontend/components/ui/CategorySelect.tsx
+++ b/frontend/components/ui/CategorySelect.tsx
@@ -102,7 +102,7 @@ export default function CategorySelect({ id, categories, value, onChange, filter
       : rawSelected;
 
   // Precompute parent IDs set and selectable items (O(n) instead of O(n^2))
-  const { selectable, parentIds } = useMemo(() => {
+  const { selectable } = useMemo(() => {
     const pIds = new Set<number>();
     for (const c of categories) {
       if (c.parent_id !== null) pIds.add(c.parent_id);
@@ -114,7 +114,7 @@ export default function CategorySelect({ id, categories, value, onChange, filter
       if (masterOnly) return c.parent_id === null;
       return c.parent_id !== null || !pIds.has(c.id);
     });
-    return { selectable: items, parentIds: pIds };
+    return { selectable: items };
   }, [categories, effectiveFilterType, bothOnly, masterOnly]);
 
   const q = query.toLowerCase();
@@ -361,6 +361,13 @@ export default function CategorySelect({ id, categories, value, onChange, filter
             // feedback on PR #296.
             onCategoryCreated?.(cat);
             if (bothOnly && cat.type !== "both") {
+              return;
+            }
+            // In masterOnly mode only masters are selectable. If the user
+            // created a subcategory from the modal, surface it upward but
+            // do NOT auto-select it — selecting it would emit a
+            // subcategory id and violate the masterOnly contract.
+            if (masterOnly && cat.parent_id !== null) {
               return;
             }
             handleSelect(cat);

--- a/frontend/components/ui/CategorySelect.tsx
+++ b/frontend/components/ui/CategorySelect.tsx
@@ -46,9 +46,18 @@ interface Props {
    * picked — the user can see why the option is no longer selectable.
    */
   disabledIds?: ReadonlySet<number> | number[];
+  /**
+   * Restrict the selectable rows to MASTER categories only (parent_id is
+   * null), rendered as a flat selectable list rather than non-selectable
+   * group headers. Used by the Forecast Plans page in "Master categories"
+   * build mode, where an item is added straight against a master. Default
+   * (off) keeps the standard behavior: subcategories are the selectable
+   * rows, grouped under their master's header.
+   */
+  masterOnly?: boolean;
 }
 
-export default function CategorySelect({ id, categories, value, onChange, filterType, typeFilter, className = "", "aria-label": ariaLabel, onCategoryCreated, disabledIds }: Props) {
+export default function CategorySelect({ id, categories, value, onChange, filterType, typeFilter, className = "", "aria-label": ariaLabel, onCategoryCreated, disabledIds, masterOnly = false }: Props) {
   const disabledSet = useMemo(() => {
     if (!disabledIds) return null;
     return disabledIds instanceof Set ? disabledIds : new Set(disabledIds);
@@ -101,10 +110,12 @@ export default function CategorySelect({ id, categories, value, onChange, filter
     const items = categories.filter((c) => {
       if (bothOnly && c.type !== "both") return false;
       if (effectiveFilterType && c.type !== effectiveFilterType && c.type !== "both") return false;
+      // Master mode: only masters are selectable (subcategories hidden).
+      if (masterOnly) return c.parent_id === null;
       return c.parent_id !== null || !pIds.has(c.id);
     });
     return { selectable: items, parentIds: pIds };
-  }, [categories, effectiveFilterType, bothOnly]);
+  }, [categories, effectiveFilterType, bothOnly, masterOnly]);
 
   const q = query.toLowerCase();
   const filtered = useMemo(() =>
@@ -182,6 +193,11 @@ export default function CategorySelect({ id, categories, value, onChange, filter
     [categories]
   );
   const grouped = useMemo(() => {
+    // Master mode: masters ARE the selectable rows, so render them as a
+    // single flat, headerless group instead of grouping subs under each.
+    if (masterOnly) {
+      return nonRecent.length > 0 ? [{ label: "", items: nonRecent }] : [];
+    }
     const groups: { label: string; items: Category[] }[] = [];
     for (const master of masters) {
       const items = nonRecent.filter((c) => c.parent_id === master.id);
@@ -190,7 +206,7 @@ export default function CategorySelect({ id, categories, value, onChange, filter
     const masterless = nonRecent.filter((c) => c.parent_id === null);
     if (masterless.length > 0) groups.push({ label: "Other", items: masterless });
     return groups;
-  }, [masters, nonRecent]);
+  }, [masters, nonRecent, masterOnly]);
 
   const activeDescendant = highlightIdx >= 0 && highlightIdx < flatList.length
     ? `${id}-opt-${flatList[highlightIdx].id}` : undefined;
@@ -262,7 +278,9 @@ export default function CategorySelect({ id, categories, value, onChange, filter
 
           {grouped.map((group) => (
             <div key={group.label}>
-              <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">{group.label}</div>
+              {group.label && (
+                <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">{group.label}</div>
+              )}
               {group.items.map((cat) => {
                 const disabled = isDisabled(cat.id);
                 const navIdx = flatList.indexOf(cat);

--- a/frontend/tests/app/forecast-plans-page.test.tsx
+++ b/frontend/tests/app/forecast-plans-page.test.tsx
@@ -497,6 +497,40 @@ describe("ForecastPlansClient — dropdown + refresh", () => {
     expect(screen.getByText("Restaurant")).toBeTruthy();
   });
 
+  it("flipping the build granularity clears an in-progress category pick", async () => {
+    mockApiFetch(makePlan([], "master"));
+    renderClient(makePlan([], "master"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("radiogroup", { name: /build granularity/i }),
+      ).toBeTruthy();
+    });
+
+    // Master mode default: open the add form and pick the Groceries master.
+    fireEvent.click(screen.getByRole("button", { name: /\+ Add Item/ }));
+    const combobox = screen.getByRole("combobox", {
+      name: /Plan item category/i,
+    }) as HTMLInputElement;
+    fireEvent.focus(combobox);
+    const listbox = await screen.findByRole("listbox");
+    fireEvent.click(within(listbox).getByText("Groceries"));
+    expect(combobox.value).toBe("Groceries");
+
+    // Flip to subcategory mode — the stale master pick must be cleared so
+    // the chip can't misrepresent a selection that's no longer listed.
+    fireEvent.click(screen.getByRole("radio", { name: /Subcategories/ }));
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByRole("combobox", {
+            name: /Plan item category/i,
+          }) as HTMLInputElement
+        ).value,
+      ).toBe("");
+    });
+  });
+
   it("the build-granularity control persists the org setting and is hidden for non-admins", async () => {
     const plan = makePlan([], "master");
     mockApiFetch(plan);

--- a/frontend/tests/app/forecast-plans-page.test.tsx
+++ b/frontend/tests/app/forecast-plans-page.test.tsx
@@ -189,7 +189,7 @@ describe("ForecastPlansClient — dropdown + refresh", () => {
     } as never);
   });
 
-  it("Bug 1: income type shows master AND sub categories in the dropdown", async () => {
+  it("master mode: income picker offers master categories only (subs hidden)", async () => {
     mockApiFetch(makePlan());
     renderClient(makePlan());
 
@@ -214,11 +214,16 @@ describe("ForecastPlansClient — dropdown + refresh", () => {
     });
     fireEvent.focus(combobox);
 
-    // Both master "Salary" and sub "Bonus" must be present
     const listbox = await screen.findByRole("listbox");
-    expect(within(listbox).getByText("Salary")).toBeTruthy();
-    expect(within(listbox).getByText("Bonus")).toBeTruthy();
-    expect(within(listbox).getByText("Side gigs")).toBeTruthy();
+    const optionNames = within(listbox)
+      .getAllByRole("option")
+      .map((o) => o.textContent ?? "");
+
+    // In master mode the income masters are the selectable rows...
+    expect(optionNames.some((t) => t.includes("Salary"))).toBe(true);
+    expect(optionNames.some((t) => t.includes("Side gigs"))).toBe(true);
+    // ...and their subcategories are NOT offered (master granularity).
+    expect(within(listbox).queryByText("Bonus")).toBeNull();
     // Expense-only categories must NOT be present
     expect(within(listbox).queryByText("Groceries")).toBeNull();
     expect(within(listbox).queryByText("Supermarket")).toBeNull();
@@ -271,11 +276,10 @@ describe("ForecastPlansClient — dropdown + refresh", () => {
     expect(screen.queryByRole("listbox")).toBeTruthy();
   });
 
-  it("Bug 4: subcategory of an already-added master is disabled too", async () => {
-    // Plan has Salary master already added as income.
-    // Bonus is a child of Salary; picking Bonus would roll up to Salary,
-    // which is a no-op against the existing item — so Bonus should be
-    // shown as disabled too.
+  it("master mode: subcategories of an added master never appear in the picker", async () => {
+    // Plan has Salary master already added as income. In master mode the
+    // picker offers masters only, so Bonus (a child of Salary) is absent
+    // entirely, and the already-added Salary master shows as disabled.
     const plan = makePlan([
       {
         category_id: 10,
@@ -301,13 +305,17 @@ describe("ForecastPlansClient — dropdown + refresh", () => {
     fireEvent.focus(combobox);
 
     const listbox = await screen.findByRole("listbox");
+    // Subcategories are never listed in master mode.
+    expect(within(listbox).queryByText("Bonus")).toBeNull();
+
+    // The already-added Salary master is shown disabled.
     const options = within(listbox).getAllByRole("option");
-    const bonusButton = options.find((b) =>
-      (b.textContent ?? "").includes("Bonus"),
+    const salaryButton = options.find((b) =>
+      (b.textContent ?? "").includes("Salary"),
     ) as HTMLButtonElement | undefined;
-    expect(bonusButton).toBeTruthy();
-    expect(bonusButton!.disabled).toBe(true);
-    expect(bonusButton!.textContent).toContain("(already added)");
+    expect(salaryButton).toBeTruthy();
+    expect(salaryButton!.disabled).toBe(true);
+    expect(salaryButton!.textContent).toContain("(already added)");
   });
 
   it("subcategory mode: after adding one sub, OTHER subs of the same master stay enabled", async () => {
@@ -394,7 +402,7 @@ describe("ForecastPlansClient — dropdown + refresh", () => {
     });
   });
 
-  it("master mode: adding a sub rolls up to the master id (legacy behavior preserved)", async () => {
+  it("master mode: selecting a master submits its category id", async () => {
     const plan = makePlan([], "master");
     mockApiFetch(plan);
     renderClient(plan);
@@ -409,7 +417,8 @@ describe("ForecastPlansClient — dropdown + refresh", () => {
     });
     fireEvent.focus(combobox);
     const listbox = await screen.findByRole("listbox");
-    fireEvent.click(within(listbox).getByText("Supermarket"));
+    // Default type is expense; pick the "Groceries" master directly.
+    fireEvent.click(within(listbox).getByText("Groceries"));
 
     fireEvent.change(screen.getByLabelText("Planned Amount"), {
       target: { value: "200" },
@@ -425,6 +434,36 @@ describe("ForecastPlansClient — dropdown + refresh", () => {
         }),
       );
     });
+  });
+
+  it("subcategory mode: picker offers subcategories grouped under their master", async () => {
+    const plan = makePlan([], "subcategory");
+    mockApiFetch(plan);
+    renderClient(plan);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /\+ Add Item/ })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /\+ Add Item/ }));
+
+    const combobox = screen.getByRole("combobox", {
+      name: /Plan item category/i,
+    });
+    fireEvent.focus(combobox);
+    const listbox = await screen.findByRole("listbox");
+
+    // Subcategory mode: the expense subs are the selectable rows.
+    const optionNames = within(listbox)
+      .getAllByRole("option")
+      .map((o) => o.textContent ?? "");
+    expect(optionNames.some((t) => t.includes("Supermarket"))).toBe(true);
+    expect(optionNames.some((t) => t.includes("Restaurant"))).toBe(true);
+    // "Groceries" appears only as the non-selectable group header.
+    expect(
+      within(listbox)
+        .getAllByRole("option")
+        .some((o) => (o.textContent ?? "").includes("Groceries")),
+    ).toBe(false);
   });
 
   it("subcategory mode: list groups subs under their master with the master total", async () => {
@@ -577,23 +616,21 @@ describe("ForecastPlansClient — dropdown + refresh", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /\+ Add Item/ }));
 
-    // Default formType is "expense". Pick "Supermarket" — an expense
-    // sub-category (its master "Groceries" is suppressed in the
-    // dropdown when it has children, so the leaf is the user-pickable
-    // option here).
+    // Default formType is "expense". In master mode the master itself is
+    // the selectable option, so pick the "Groceries" master.
     const combobox = screen.getByRole("combobox", {
       name: /Plan item category/i,
     }) as HTMLInputElement;
     fireEvent.focus(combobox);
     const listbox = await screen.findByRole("listbox");
-    const supermarketOption = within(listbox)
+    const groceriesOption = within(listbox)
       .getAllByRole("option")
-      .find((o) => (o.textContent ?? "").includes("Supermarket"));
-    expect(supermarketOption).toBeTruthy();
-    fireEvent.click(supermarketOption!);
+      .find((o) => (o.textContent ?? "").includes("Groceries"));
+    expect(groceriesOption).toBeTruthy();
+    fireEvent.click(groceriesOption!);
 
-    // Combobox should now show "Supermarket"
-    expect(combobox.value).toBe("Supermarket");
+    // Combobox should now show "Groceries"
+    expect(combobox.value).toBe("Groceries");
 
     // Flip type to income — the stale expense pick must be cleared so a
     // submit can't slip through with a mismatched (income, expense-cat)
@@ -1170,7 +1207,8 @@ describe("ForecastPlansClient — dropdown + refresh", () => {
     });
     fireEvent.focus(combobox);
     const listbox = await screen.findByRole("listbox");
-    fireEvent.click(within(listbox).getByText("Supermarket"));
+    // Master mode (default): pick the "Groceries" master directly.
+    fireEvent.click(within(listbox).getByText("Groceries"));
     fireEvent.change(screen.getByLabelText("Planned Amount"), {
       target: { value: "200" },
     });

--- a/frontend/tests/app/transactions-recurring-sync-hint.test.tsx
+++ b/frontend/tests/app/transactions-recurring-sync-hint.test.tsx
@@ -94,7 +94,8 @@ function setupApiFetch(txs: Tx[]) {
     if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
     if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
     if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
-    if (url.startsWith("/api/v1/transactions") && method === "GET") return txs as never;
+    if (url.startsWith("/api/v1/transactions") && method === "GET")
+      return { items: txs, total: txs.length, limit: 25, offset: 0 } as never;
     return null as never;
   });
 }

--- a/frontend/tests/app/transactions-server-pagination.test.tsx
+++ b/frontend/tests/app/transactions-server-pagination.test.tsx
@@ -176,8 +176,10 @@ describe("TransactionsPage — server-side pagination/sort/selection (Task 4)", 
     render(<TransactionsPage />);
     await waitForStableTxList();
 
-    // Per-page selector present.
-    expect(screen.getByLabelText(/per page/i)).toBeInTheDocument();
+    // Per-page selector present. Use findBy: the pagination bar renders a
+    // tick after the rows (once `total` state propagates), so a sync query
+    // races under slower CI timing.
+    expect(await screen.findByLabelText(/per page/i)).toBeInTheDocument();
 
     // Status line: 30 total / 25 per page => 2 pages.
     await waitFor(() => {

--- a/frontend/tests/components/ui/category-select.test.tsx
+++ b/frontend/tests/components/ui/category-select.test.tsx
@@ -60,6 +60,26 @@ vi.mock("@/components/ui/AddCategoryModal", () => ({
       >
         stub-create-both
       </button>
+      {/* Emit a subcategory (parent_id set) so masterOnly's guard can be
+          exercised: a created subcategory must not be auto-selected. */}
+      <button
+        type="button"
+        onClick={() =>
+          props.onCreated({
+            id: 7777,
+            name: props.initialName || "Stub Sub",
+            type: "expense",
+            parent_id: 20,
+            parent_name: "Groceries",
+            description: null,
+            slug: "stub-sub",
+            is_system: false,
+            transaction_count: 0,
+          })
+        }
+      >
+        stub-create-sub
+      </button>
     </div>
   ),
 }));
@@ -371,6 +391,57 @@ describe("CategorySelect — value resolution under filterType", () => {
     const listbox = screen.getByRole("listbox");
     fireEvent.click(within(listbox).getByText("Salary"));
     expect(onChange).toHaveBeenCalledWith(10);
+  });
+
+  it("masterOnly: a created subcategory is surfaced upward but not selected", () => {
+    // In master mode the "+ Add category" modal can still create a
+    // subcategory. It must be reported via onCategoryCreated (so other
+    // pickers can list it) but NOT auto-selected, since masterOnly must
+    // only ever emit master ids.
+    const onChange = vi.fn();
+    const onCategoryCreated = vi.fn();
+    render(
+      <CategorySelect
+        id="m3"
+        categories={CATEGORIES}
+        value=""
+        onChange={onChange}
+        onCategoryCreated={onCategoryCreated}
+        filterType="expense"
+        masterOnly
+      />,
+    );
+    fireEvent.focus(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+    fireEvent.click(screen.getByText("stub-create-sub"));
+
+    // Upward notification still fires.
+    expect(onCategoryCreated).toHaveBeenCalledTimes(1);
+    expect(onCategoryCreated).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 7777, parent_id: 20 }),
+    );
+    // But the subcategory is NOT selected.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("masterOnly: a created master IS selected", () => {
+    const onChange = vi.fn();
+    render(
+      <CategorySelect
+        id="m4"
+        categories={CATEGORIES}
+        value=""
+        onChange={onChange}
+        filterType="expense"
+        masterOnly
+      />,
+    );
+    fireEvent.focus(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+    fireEvent.click(screen.getByText("stub-create-expense"));
+
+    // The created master (parent_id null) is selected as normal.
+    expect(onChange).toHaveBeenCalledWith(9999);
   });
 
   it("typeFilter=BOTH: a compatible (both) created category IS selected", () => {

--- a/frontend/tests/components/ui/category-select.test.tsx
+++ b/frontend/tests/components/ui/category-select.test.tsx
@@ -326,6 +326,53 @@ describe("CategorySelect — value resolution under filterType", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  // Forecast "Master categories" build mode: the picker must offer
+  // MASTER categories as selectable rows (not just non-selectable group
+  // headers), so a forecast item can be added straight against a master.
+  // Without `masterOnly`, a master that has subcategories renders only as
+  // a header and cannot be selected — the bug reported on the Forecast
+  // Plans page.
+  it("masterOnly: master with subcategories is selectable and its subcategory is hidden", () => {
+    const onChange = vi.fn();
+    render(
+      <CategorySelect
+        id="m1"
+        categories={CATEGORIES}
+        value=""
+        onChange={onChange}
+        filterType="expense"
+        masterOnly
+      />,
+    );
+    fireEvent.focus(screen.getByRole("combobox"));
+    const listbox = screen.getByRole("listbox");
+
+    // The subcategory must not appear as a selectable option in master mode.
+    expect(within(listbox).queryByText("Supermarket")).not.toBeInTheDocument();
+
+    // The master itself is now a selectable option.
+    fireEvent.click(within(listbox).getByText("Groceries"));
+    expect(onChange).toHaveBeenCalledWith(20);
+  });
+
+  it("masterOnly: childless master is still selectable; subcategories never appear", () => {
+    const onChange = vi.fn();
+    render(
+      <CategorySelect
+        id="m2"
+        categories={CATEGORIES}
+        value=""
+        onChange={onChange}
+        filterType="income"
+        masterOnly
+      />,
+    );
+    fireEvent.focus(screen.getByRole("combobox"));
+    const listbox = screen.getByRole("listbox");
+    fireEvent.click(within(listbox).getByText("Salary"));
+    expect(onChange).toHaveBeenCalledWith(10);
+  });
+
   it("typeFilter=BOTH: a compatible (both) created category IS selected", () => {
     const onChange = vi.fn();
     const onCategoryCreated = vi.fn();


### PR DESCRIPTION
## Problem

On the Forecast Plans page, with **Build forecasts by: Master categories** selected, the category picker only showed subcategories grouped under non-selectable master headers. There was no way to add a forecast item straight against a master category.

## Root cause

- `CategorySelect` always treats a master that has subcategories as a non-selectable group header (its selectable set was "subcategories + childless masters only").
- `ForecastPlansClient` passed `filterType` to the picker but never the build `mode`, so master mode silently fell back to the legacy "pick a sub, roll it up to the master" path. That contradicts `specs/2026-06-01-forecast-subcategory-items.md` (master mode "offers masters; the item stores the master id").

## Fix

- Add an opt-in `masterOnly` prop to `CategorySelect`. When set, it offers masters as selectable rows (flat list, no sub-headers) and hides subcategories. Default off, so transactions/transfers/unpair consumers are unchanged.
- `ForecastPlansClient` passes `masterOnly={mode === "master"}`. Subcategory mode behavior is unchanged.
- No backend change: master mode still submits a master id, which backend validation already requires.

## Verification

- TDD: new failing test added first, green after the fix.
- `forecast-plans-page` + `category-select`: 38/38 pass (stale tests that encoded the old roll-up behavior rewritten to assert the corrected behavior; added subcategory-mode picker coverage).
- CategorySelect consumers (transactions/transfers/add-modal): 42/42 pass.
- `tsc --noEmit` clean; eslint 0 errors.