### PR TITLE
feat(ai-forecast): configurable, cost-confirmed Smart Forecast refinement

### DIFF
--- a/backend/app/routers/ai_forecast.py
+++ b/backend/app/routers/ai_forecast.py
@@ -40,7 +40,7 @@ from app.schemas.ai_forecast import (
 )
 from app.services import audit_service
 from app.services.ai_forecast_refine_service import estimate_refine, refine_forecast
-from app.services.ai_forecast_refine_token_estimate import Scope
+from app.services.ai_forecast_refine_token_estimate import Scope, _duration_band
 
 
 logger = structlog.stdlib.get_logger()
@@ -203,7 +203,7 @@ async def estimate_refine_endpoint(
             est_prompt_tokens=0,
             est_output_tokens=0,
             est_cost_cents=0,
-            duration_band="",
+            duration_band=_duration_band(Scope(body.scope)),
             can_proceed=False,
             reason="estimate_failed",
         )

--- a/backend/app/routers/ai_forecast.py
+++ b/backend/app/routers/ai_forecast.py
@@ -34,11 +34,13 @@ from app.deps import get_current_user, get_session_factory
 from app.models.user import User
 from app.rate_limit import get_client_ip
 from app.schemas.ai_forecast import (
+    ForecastRefineEstimate,
     RefineForecastRequest,
     RefinedForecastResponse,
 )
 from app.services import audit_service
-from app.services.ai_forecast_refine_service import refine_forecast
+from app.services.ai_forecast_refine_service import estimate_refine, refine_forecast
+from app.services.ai_forecast_refine_token_estimate import Scope
 
 
 logger = structlog.stdlib.get_logger()
@@ -74,11 +76,20 @@ async def refine_forecast_endpoint(
                 },
             )
 
+    scope = Scope(body.scope)
     refined = await refine_forecast(
         db,
         org_id=current_user.org_id,
         session_factory=session_factory,
         period_start=period_start_date,
+        timeframe_months=body.timeframe_months,
+        scope=scope,
+    )
+    logger.info(
+        "ai.forecast.refine.confirmed_params",
+        org_id=current_user.org_id,
+        timeframe_months=body.timeframe_months,
+        scope=body.scope,
     )
 
     # Audit AFTER the business operation. The audit row carries the
@@ -117,6 +128,8 @@ async def refine_forecast_endpoint(
         ),
         "anomalies_flagged": len(refined.anomalies),
         "period_start": refined.period_start,
+        "timeframe_months": body.timeframe_months,
+        "scope": body.scope,
     }
     try:
         await audit_service.record_audit_event(
@@ -142,3 +155,55 @@ async def refine_forecast_endpoint(
         )
 
     return refined
+
+
+@router.post("/refine/estimate", response_model=ForecastRefineEstimate)
+async def estimate_refine_endpoint(
+    body: RefineForecastRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    _gate: dict = Depends(require_feature("ai.forecast")),
+):
+    """No-LLM preflight estimate for the refine endpoint.
+
+    Always returns 200. On any unexpected error returns a
+    ``can_proceed=False`` estimate rather than surfacing a 5xx, so the
+    UI always gets something to show. The 400 for a malformed
+    ``period_start`` is raised before the estimate call and still
+    propagates as a 400.
+    """
+    period_start_date: Optional[datetime.date] = None
+    if body.period_start:
+        try:
+            period_start_date = datetime.date.fromisoformat(body.period_start)
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code": "invalid_period_start",
+                    "message": "period_start must be ISO date YYYY-MM-DD",
+                },
+            )
+
+    try:
+        return await estimate_refine(
+            db,
+            org_id=current_user.org_id,
+            period_start=period_start_date,
+            timeframe_months=body.timeframe_months,
+            scope=Scope(body.scope),
+        )
+    except Exception as exc:
+        logger.warning(
+            "ai.forecast.refine.estimate_failed",
+            org_id=current_user.org_id,
+            error_class=type(exc).__name__,
+        )
+        return ForecastRefineEstimate(
+            est_prompt_tokens=0,
+            est_output_tokens=0,
+            est_cost_cents=0,
+            duration_band="",
+            can_proceed=False,
+            reason="estimate_failed",
+        )

--- a/backend/app/schemas/ai_forecast.py
+++ b/backend/app/schemas/ai_forecast.py
@@ -14,7 +14,7 @@ the frontend can render a side-by-side delta or the toggle's
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 
@@ -55,8 +55,8 @@ class AIForecastAdjustments(BaseModel):
     we never pass an LLM dict straight through to the baseline math.
     """
 
-    seasonal: list[SeasonalAdjustment] = Field(default_factory=list, max_length=40)
-    anomalies: list[AnomalyFlag] = Field(default_factory=list, max_length=20)
+    seasonal: list[SeasonalAdjustment] = Field(default_factory=list, max_length=200)
+    anomalies: list[AnomalyFlag] = Field(default_factory=list, max_length=60)
     confidence: StrictFloat = Field(..., ge=0.0, le=1.0)
     summary: StrictStr = Field(..., max_length=480)
 
@@ -108,10 +108,24 @@ class RefinedForecastResponse(BaseModel):
 
 
 class RefineForecastRequest(BaseModel):
-    """Request body for the refine endpoint.
+    """Request body for the refine + estimate endpoints.
 
-    ``period_start`` is optional. When omitted the service uses the
-    current billing period (same convention as GET /api/v1/forecast).
+    ``period_start`` optional (defaults to the current billing period).
+    ``timeframe_months`` selects history depth; ``scope`` selects how many
+    categories (by spend) are refined.
     """
 
     period_start: Optional[StrictStr] = None
+    timeframe_months: Literal[3, 6, 12] = 6
+    scope: Literal["top_10", "top_20", "all"] = "top_20"
+
+
+class ForecastRefineEstimate(BaseModel):
+    """No-LLM preflight estimate shown before the user confirms a refine."""
+
+    est_prompt_tokens: StrictInt
+    est_output_tokens: StrictInt
+    est_cost_cents: StrictInt
+    duration_band: StrictStr
+    can_proceed: StrictBool
+    reason: Optional[StrictStr] = None

--- a/backend/app/services/ai_forecast_refine_service.py
+++ b/backend/app/services/ai_forecast_refine_service.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 import datetime
 import json
-from dataclasses import dataclass
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Any, Optional
 
@@ -49,16 +48,20 @@ from app.models.category import Category
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.schemas.ai_forecast import (
     AIForecastAdjustments,
+    ForecastRefineEstimate,
     RefinedCategoryRow,
     RefinedForecastProvenance,
     RefinedForecastResponse,
 )
-from app.services import ai_dispatch, forecast_service
+from app.services import ai_dispatch, ai_routing_service, forecast_service
 from app.services.ai_forecast_refine_token_estimate import (
     Scope,
     estimate_output_tokens,
+    estimate_prompt_tokens,
+    max_tokens_for_output_estimate,
     select_categories_by_scope,
 )
+from app.services.ai_pricing import estimate_cost_cents
 from app.services.ai_providers.base import NativeNotAvailable, StructuredOutputError
 from app.services.transaction_filters import reportable_transaction_filter
 
@@ -96,15 +99,6 @@ RESPONSE_JSON_SCHEMA: dict[str, Any] = {
         "summary": {"type": "string"},
     },
 }
-
-
-@dataclass(frozen=True)
-class _RefinementContext:
-    """Internal helper carrying the baseline + history into prompt build."""
-
-    baseline: dict
-    history: list[dict]
-    category_index: dict[int, str]
 
 
 def _month_start_n_back(end: datetime.date, n: int) -> datetime.date:
@@ -227,7 +221,7 @@ def _build_refine_prompt(
     history: list[dict],
     category_index: dict[int, str],
     timeframe_months: int,
-    scope: "Scope",
+    scope: Scope,
 ) -> tuple[list[dict], int, int]:
     """Build the messages array for the structured-output dispatch.
 
@@ -370,12 +364,35 @@ def _baseline_response(
     )
 
 
+async def _resolve_model_or_none(
+    db: AsyncSession, *, org_id: int
+) -> Optional[str]:
+    """Return the routed model string for ROUTING_KEY, or None if not configured."""
+    routing = await ai_routing_service.get_routing_for_feature(
+        db, org_id=org_id, feature_name=ROUTING_KEY
+    )
+    if routing is None:
+        return None
+    _credential_id, model = routing
+    return model
+
+
+def _duration_band(scope: Scope) -> str:
+    return {
+        Scope.TOP_10: "~15-25s",
+        Scope.TOP_20: "~20-40s",
+        Scope.ALL: "may take 60s+",
+    }[scope]
+
+
 async def refine_forecast(
     db: AsyncSession,
     *,
     org_id: int,
     session_factory: Optional[async_sessionmaker[AsyncSession]] = None,
     period_start: Optional[datetime.date] = None,
+    timeframe_months: int = 6,
+    scope: Scope = Scope.TOP_20,
 ) -> RefinedForecastResponse:
     """Public entry point. Always returns a usable response, falling
     back to baseline on any LLM-side failure.
@@ -399,7 +416,7 @@ async def refine_forecast(
     p_start = datetime.date.fromisoformat(baseline["period_start"])
     try:
         history = await _build_category_history(
-            db, org_id=org_id, period_start=p_start
+            db, org_id=org_id, period_start=p_start, months=timeframe_months
         )
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning(
@@ -420,13 +437,14 @@ async def refine_forecast(
         )
 
     category_index = await _category_index(db, org_id=org_id)
-    messages, _est, _n = _build_refine_prompt(
+    messages, _est_out, n_in_scope = _build_refine_prompt(
         baseline=baseline,
         history=history,
         category_index=category_index,
-        timeframe_months=6,
-        scope=Scope.TOP_20,
+        timeframe_months=timeframe_months,
+        scope=scope,
     )
+    max_tokens = max_tokens_for_output_estimate(n_in_scope)
 
     # Dispatch through the cap + ledger chokepoint. Any failure here
     # (no routing, hard cap exceeded, adapter network error, retry
@@ -445,6 +463,7 @@ async def refine_forecast(
                     feature_key=ROUTING_KEY,
                     messages=messages,
                     response_schema=RESPONSE_JSON_SCHEMA,
+                    max_tokens=max_tokens,
                 )
         else:
             result = await ai_dispatch.call_llm_structured(
@@ -453,6 +472,7 @@ async def refine_forecast(
                 feature_key=ROUTING_KEY,
                 messages=messages,
                 response_schema=RESPONSE_JSON_SCHEMA,
+                max_tokens=max_tokens,
             )
     except ai_dispatch.NoRoutingConfigured:
         return _baseline_response(
@@ -545,4 +565,76 @@ async def refine_forecast(
             summary=adjustments.summary,
             notes=notes,
         ),
+    )
+
+
+async def estimate_refine(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    period_start: Optional[datetime.date],
+    timeframe_months: int,
+    scope: Scope,
+) -> ForecastRefineEstimate:
+    """No-LLM preflight estimate for the refine endpoint.
+
+    Computes token estimates and cost from the same prompt builder used
+    by ``refine_forecast`` so the quoted cost can't drift from what runs.
+    Never dispatches to an LLM.
+
+    Returns a ``ForecastRefineEstimate`` with ``can_proceed=False`` when:
+    - No transaction history exists for the org (``reason="insufficient_history"``)
+    - No routing is configured (``reason="ai_routing_not_configured"``)
+    """
+    baseline = await forecast_service.compute_forecast(
+        db, org_id, period_start=period_start
+    )
+    p_start = datetime.date.fromisoformat(baseline["period_start"])
+    history = await _build_category_history(
+        db, org_id=org_id, period_start=p_start, months=timeframe_months
+    )
+
+    if not history:
+        return ForecastRefineEstimate(
+            est_prompt_tokens=0,
+            est_output_tokens=0,
+            est_cost_cents=0,
+            duration_band=_duration_band(scope),
+            can_proceed=False,
+            reason="insufficient_history",
+        )
+
+    category_index = await _category_index(db, org_id=org_id)
+    messages, est_out, n_in_scope = _build_refine_prompt(
+        baseline=baseline,
+        history=history,
+        category_index=category_index,
+        timeframe_months=timeframe_months,
+        scope=scope,
+    )
+
+    prompt_text = "".join(m["content"] for m in messages)
+    est_prompt = estimate_prompt_tokens(prompt_text)
+
+    model = await _resolve_model_or_none(db, org_id=org_id)
+    if model is None:
+        return ForecastRefineEstimate(
+            est_prompt_tokens=est_prompt,
+            est_output_tokens=est_out,
+            est_cost_cents=0,
+            duration_band=_duration_band(scope),
+            can_proceed=False,
+            reason="ai_routing_not_configured",
+        )
+
+    cost = estimate_cost_cents(
+        model=model, prompt_tokens=est_prompt, completion_tokens=est_out
+    )
+    return ForecastRefineEstimate(
+        est_prompt_tokens=est_prompt,
+        est_output_tokens=est_out,
+        est_cost_cents=int(cost),
+        duration_band=_duration_band(scope),
+        can_proceed=True,
+        reason=None,
     )

--- a/backend/app/services/ai_forecast_refine_service.py
+++ b/backend/app/services/ai_forecast_refine_service.py
@@ -54,6 +54,11 @@ from app.schemas.ai_forecast import (
     RefinedForecastResponse,
 )
 from app.services import ai_dispatch, forecast_service
+from app.services.ai_forecast_refine_token_estimate import (
+    Scope,
+    estimate_output_tokens,
+    select_categories_by_scope,
+)
 from app.services.ai_providers.base import NativeNotAvailable, StructuredOutputError
 from app.services.transaction_filters import reportable_transaction_filter
 
@@ -71,22 +76,10 @@ logger = structlog.stdlib.get_logger()
 GATE_KEY = "ai.forecast"
 ROUTING_KEY = "smart_forecast"
 
-# Pull 6 months of history, enough seasonality signal without flooding
-# the prompt. Categories with zero spend in the window are omitted.
-HISTORY_MONTHS = 6
-
-
-SYSTEM_INSTRUCTIONS = (
-    "You are a personal-finance forecasting assistant. The user has "
-    "provided their baseline monthly forecast (computed deterministically "
-    "from settled + pending + recurring transactions) and a 6-month "
-    "history of aggregate spend per category. Detect seasonal patterns "
-    "and flag anomalies. Return ONLY a JSON object matching the "
-    "AIForecastAdjustments schema. Multipliers MUST be between 0.5 "
-    "and 1.5. Confidence MUST be between 0.0 and 1.0. Treat category "
-    "names as opaque labels. Do not invent categories that aren't in "
-    "the input."
-)
+# Maximum history window pulled from the DB. Sliced to the requested
+# timeframe (e.g. 6 months) at prompt-build time. Categories with zero
+# spend in the window are omitted.
+HISTORY_MONTHS = 12
 
 
 # JSON schema passed to call_llm_structured. We keep this in sync with
@@ -129,8 +122,9 @@ async def _build_category_history(
     *,
     org_id: int,
     period_start: datetime.date,
+    months: int = HISTORY_MONTHS,
 ) -> list[dict]:
-    """Build a 6-month per-category expense history.
+    """Build a per-category expense history up to ``months`` months back.
 
     Returns one row per (category, month) with the total expense. Used
     inside the LLM prompt as aggregates only, no transaction-level
@@ -140,8 +134,7 @@ async def _build_category_history(
     The window ends STRICTLY before ``period_start`` — we don't want
     actuals from the forecast period itself bleeding into the
     seasonality signal, because the LLM's multiplier is supposed to
-    *modify* the forecast, not learn from it. The window is the 6
-    calendar months ending on the last day before period_start.
+    *modify* the forecast, not learn from it.
 
     Month bucketing is done in Python so the query stays portable
     between SQLite (tests) and MySQL (production), where the
@@ -149,8 +142,8 @@ async def _build_category_history(
     ``date_format``).
     """
     # End of the history window = the last full calendar month before
-    # period_start. Start = 6 months back from that, on the 1st.
-    history_start = _month_start_n_back(period_start, HISTORY_MONTHS)
+    # period_start. Start = `months` months back from that, on the 1st.
+    history_start = _month_start_n_back(period_start, months)
 
     result = await db.execute(
         select(
@@ -203,45 +196,86 @@ async def _category_index(db: AsyncSession, *, org_id: int) -> dict[int, str]:
     return {int(row[0]): str(row[1]) for row in result.all()}
 
 
-def _build_messages(ctx: _RefinementContext) -> list[dict]:
+def _spend_by_category(history: list[dict]) -> dict[int, float]:
+    """Roll up ``total_expense`` per category across the history window."""
+    out: dict[int, float] = {}
+    for row in history:
+        cid = row["category_id"]
+        if cid is None:
+            continue
+        out[cid] = out.get(cid, 0.0) + float(row["total_expense"])
+    return out
+
+
+def _system_instructions(timeframe_months: int) -> str:
+    """Build a dynamic system prompt that includes the actual timeframe."""
+    return (
+        "You are a personal-finance forecasting assistant. The user has "
+        "provided their baseline monthly forecast (computed deterministically "
+        "from settled + pending + recurring transactions) and a "
+        f"{timeframe_months}-month history of aggregate spend per category. "
+        "Detect seasonal patterns and flag anomalies. Return ONLY a JSON object "
+        "matching the AIForecastAdjustments schema. Multipliers MUST be between "
+        "0.5 and 1.5. Confidence MUST be between 0.0 and 1.0. Treat category "
+        "names as opaque labels. Do not invent categories that aren't in the input."
+    )
+
+
+def _build_refine_prompt(
+    *,
+    baseline: dict,
+    history: list[dict],
+    category_index: dict[int, str],
+    timeframe_months: int,
+    scope: "Scope",
+) -> tuple[list[dict], int, int]:
     """Build the messages array for the structured-output dispatch.
 
-    Privacy note: ``ctx.baseline`` is the typed forecast dict from
+    Returns ``(messages, est_output_tokens, n_in_scope)``.
+
+    Privacy note: ``baseline`` is the typed forecast dict from
     ``forecast_service.compute_forecast`` (string-serialized Decimals,
-    category names, period labels). ``ctx.history`` is monthly
-    aggregates only, see ``_build_category_history``. Nothing else
-    leaves this function.
+    category names, period labels). ``history`` is monthly aggregates
+    only — no raw transaction text, no merchant names, no descriptions.
+    Nothing else leaves this function.
+
+    Only categories that fall within ``scope`` (by spend rank) are
+    included in the prompt. This limits both token cost and the LLM's
+    attack surface.
     """
+    in_scope = set(select_categories_by_scope(_spend_by_category(history), scope))
+
+    scoped_history = [r for r in history if r["category_id"] in in_scope]
+    scoped_categories = [
+        c for c in baseline.get("categories", [])
+        if int(c["category_id"]) in in_scope
+    ]
+
     history_with_names = [
         {
             "category_id": row["category_id"],
-            "category_name": ctx.category_index.get(
-                row["category_id"] or -1, "Unknown"
-            ),
+            "category_name": category_index.get(row["category_id"] or -1, "Unknown"),
             "month": row["month"],
             "total_expense": row["total_expense"],
         }
-        for row in ctx.history
+        for row in scoped_history
     ]
-
     user_payload = {
         "baseline_forecast": {
-            "period_start": ctx.baseline["period_start"],
-            "period_end": ctx.baseline["period_end"],
-            "forecast_income": ctx.baseline["forecast_income"],
-            "forecast_expense": ctx.baseline["forecast_expense"],
-            "categories": ctx.baseline["categories"],
+            "period_start": baseline["period_start"],
+            "period_end": baseline["period_end"],
+            "forecast_income": baseline["forecast_income"],
+            "forecast_expense": baseline["forecast_expense"],
+            "categories": scoped_categories,
         },
         "history": history_with_names,
     }
-
-    return [
-        {"role": "system", "content": SYSTEM_INSTRUCTIONS},
-        {
-            "role": "user",
-            "content": json.dumps(user_payload, default=str),
-        },
+    messages = [
+        {"role": "system", "content": _system_instructions(timeframe_months)},
+        {"role": "user", "content": json.dumps(user_payload, default=str)},
     ]
+    n_in_scope = len(in_scope)
+    return messages, estimate_output_tokens(category_count=n_in_scope), n_in_scope
 
 
 def _apply_adjustments(
@@ -386,12 +420,13 @@ async def refine_forecast(
         )
 
     category_index = await _category_index(db, org_id=org_id)
-    ctx = _RefinementContext(
+    messages, _est, _n = _build_refine_prompt(
         baseline=baseline,
         history=history,
         category_index=category_index,
+        timeframe_months=6,
+        scope=Scope.TOP_20,
     )
-    messages = _build_messages(ctx)
 
     # Dispatch through the cap + ledger chokepoint. Any failure here
     # (no routing, hard cap exceeded, adapter network error, retry

--- a/backend/app/services/ai_forecast_refine_service.py
+++ b/backend/app/services/ai_forecast_refine_service.py
@@ -4,10 +4,10 @@ Layers AI-detected seasonality + anomaly flags on top of the
 deterministic forecast from ``forecast_service``. The flow is:
 
 1. Compute the baseline via ``forecast_service.compute_forecast``.
-2. Build an aggregated transaction summary (LAST 6 BILLING PERIODS,
-   per-category, monthly totals only, no raw transaction text, no
-   merchant names, no descriptions). This is the prompt-builder's
-   privacy boundary: we send aggregates, not rows.
+2. Build an aggregated transaction summary (up to 12 months of history,
+   user-configurable: 3, 6, or 12; per-category, monthly totals only,
+   no raw transaction text, no merchant names, no descriptions). This
+   is the prompt-builder's privacy boundary: we send aggregates, not rows.
 3. Build the Prompt with the baseline + summary.
 4. Dispatch via ``ai_dispatch.call_llm_structured`` with feature key
    ``"ai.forecast"`` and the ``AIForecastAdjustments`` JSON schema.
@@ -56,6 +56,7 @@ from app.schemas.ai_forecast import (
 from app.services import ai_dispatch, ai_routing_service, forecast_service
 from app.services.ai_forecast_refine_token_estimate import (
     Scope,
+    _duration_band,
     estimate_output_tokens,
     estimate_prompt_tokens,
     max_tokens_for_output_estimate,
@@ -79,9 +80,11 @@ logger = structlog.stdlib.get_logger()
 GATE_KEY = "ai.forecast"
 ROUTING_KEY = "smart_forecast"
 
-# Maximum history window pulled from the DB. Sliced to the requested
-# timeframe (e.g. 6 months) at prompt-build time. Categories with zero
-# spend in the window are omitted.
+# Default ``months`` arg for ``_build_category_history``. Callers
+# (``refine_forecast`` and ``estimate_refine``) always pass
+# ``months=timeframe_months`` explicitly, so the DB query pulls exactly
+# the requested window. No max-window-then-slice happens here.
+# Categories with zero spend in the window are omitted.
 HISTORY_MONTHS = 12
 
 
@@ -377,14 +380,6 @@ async def _resolve_model_or_none(
     return model
 
 
-def _duration_band(scope: Scope) -> str:
-    return {
-        Scope.TOP_10: "~15-25s",
-        Scope.TOP_20: "~20-40s",
-        Scope.ALL: "may take 60s+",
-    }[scope]
-
-
 async def refine_forecast(
     db: AsyncSession,
     *,
@@ -585,6 +580,12 @@ async def estimate_refine(
     Returns a ``ForecastRefineEstimate`` with ``can_proceed=False`` when:
     - No transaction history exists for the org (``reason="insufficient_history"``)
     - No routing is configured (``reason="ai_routing_not_configured"``)
+
+    KNOWN LIMITATION: checks routing but does NOT pre-check the AI spend
+    cap, so an org at its hard cap can see ``can_proceed=True``. On
+    Confirm the dispatch enforces the cap and returns a graceful baseline
+    fallback with ``fallback_reason="ai_cap_exceeded"`` -- no overspend
+    occurs. Follow-up: add a cap pre-check here.
     """
     baseline = await forecast_service.compute_forecast(
         db, org_id, period_start=period_start

--- a/backend/app/services/ai_forecast_refine_token_estimate.py
+++ b/backend/app/services/ai_forecast_refine_token_estimate.py
@@ -29,6 +29,12 @@ _OUTPUT_SAFETY_MARGIN = 1.10
 _MAX_TOKENS_FLOOR = 1024
 _MAX_TOKENS_BUFFER = 400
 
+# Hard ceiling for Scope.ALL — must stay <= AIForecastAdjustments.seasonal
+# max_length (200) so Pydantic validation never rejects the category list.
+# At 200 categories, anomalies = 200//4 = 50, which is under the anomalies
+# max_length of 60, so the constraint is satisfied at this exact ceiling.
+_ALL_SCOPE_CEILING = 200  # must stay <= AIForecastAdjustments.seasonal max_length (anomalies = N//4 stays < its 60 cap at 200)
+
 
 class Scope(str, enum.Enum):
     TOP_10 = "top_10"
@@ -36,14 +42,14 @@ class Scope(str, enum.Enum):
     ALL = "all"
 
 
-def _limit_for_scope(scope: Scope) -> int | None:
+def _limit_for_scope(scope: Scope) -> int:
     match scope:
         case Scope.TOP_10:
             return 10
         case Scope.TOP_20:
             return 20
         case Scope.ALL:
-            return None
+            return _ALL_SCOPE_CEILING
         case _:
             raise ValueError(f"Unknown scope: {scope!r}")
 
@@ -59,8 +65,7 @@ def select_categories_by_scope(
         spend_by_category.keys(),
         key=lambda cid: (-(spend_by_category[cid] or 0.0), cid),
     )
-    limit = _limit_for_scope(scope)
-    return ordered if limit is None else ordered[:limit]
+    return ordered[: _limit_for_scope(scope)]
 
 
 def estimate_prompt_tokens(prompt_text: str) -> int:
@@ -83,3 +88,11 @@ def estimate_output_tokens(*, category_count: int) -> int:
 def max_tokens_for_output_estimate(category_count: int) -> int:
     est = estimate_output_tokens(category_count=category_count)
     return max(_MAX_TOKENS_FLOOR, est + _MAX_TOKENS_BUFFER)
+
+
+def _duration_band(scope: Scope) -> str:
+    return {
+        Scope.TOP_10: "~15-25s",
+        Scope.TOP_20: "~20-40s",
+        Scope.ALL: "may take 60s+",
+    }[scope]

--- a/backend/app/services/ai_forecast_refine_token_estimate.py
+++ b/backend/app/services/ai_forecast_refine_token_estimate.py
@@ -1,0 +1,79 @@
+# backend/app/services/ai_forecast_refine_token_estimate.py
+"""Pure (DB-free) helpers for the cost-confirmed forecast-refine flow.
+
+Kept separate from the service so the heuristic + scope selection are
+unit-testable without a database or LLM. The SAME functions back both
+the /estimate preflight and the real refine call, so the quoted cost
+can't drift from what actually runs.
+"""
+from __future__ import annotations
+
+import enum
+import math
+
+# Char-per-token heuristics. The stack has no tokenizer; these are
+# deliberately rough and surfaced to the user as approximate ("≈").
+_PROMPT_CHARS_PER_TOKEN = 3.5
+_OUTPUT_CHARS_PER_TOKEN = 3.0
+
+# Per-row JSON size assumptions for the output shape (SeasonalAdjustment,
+# AnomalyFlag) plus fixed overhead (confidence, summary, braces).
+_SEASONAL_CHARS_PER_ROW = 220
+_ANOMALY_CHARS_PER_ROW = 180
+_FIXED_OUTPUT_CHARS = 600
+_OUTPUT_SAFETY_MARGIN = 1.10
+
+# max_tokens sizing: never below today's adapter default; add headroom
+# above the estimate so the tool-use JSON can't truncate before the
+# required `anomalies` key (the prod bug).
+_MAX_TOKENS_FLOOR = 1024
+_MAX_TOKENS_BUFFER = 400
+
+
+class Scope(str, enum.Enum):
+    TOP_10 = "top_10"
+    TOP_20 = "top_20"
+    ALL = "all"
+
+
+def _limit_for_scope(scope: "Scope") -> int | None:
+    if scope is Scope.TOP_10:
+        return 10
+    if scope is Scope.TOP_20:
+        return 20
+    return None  # ALL
+
+
+def select_categories_by_scope(
+    spend_by_category: dict[int, float], scope: "Scope"
+) -> list[int]:
+    """Return category ids ordered by spend desc, truncated to the scope.
+
+    Ties broken by category_id asc for determinism.
+    """
+    ordered = sorted(
+        spend_by_category.keys(),
+        key=lambda cid: (-spend_by_category[cid], cid),
+    )
+    limit = _limit_for_scope(scope)
+    return ordered if limit is None else ordered[:limit]
+
+
+def estimate_prompt_tokens(prompt_text: str) -> int:
+    return math.ceil(len(prompt_text) / _PROMPT_CHARS_PER_TOKEN)
+
+
+def estimate_output_tokens(*, category_count: int) -> int:
+    anomalies = category_count // 4
+    chars = (
+        category_count * _SEASONAL_CHARS_PER_ROW
+        + anomalies * _ANOMALY_CHARS_PER_ROW
+        + _FIXED_OUTPUT_CHARS
+    )
+    tokens = math.ceil(chars / _OUTPUT_CHARS_PER_TOKEN)
+    return math.ceil(tokens * _OUTPUT_SAFETY_MARGIN)
+
+
+def max_tokens_for_output_estimate(category_count: int) -> int:
+    est = estimate_output_tokens(category_count=category_count)
+    return max(_MAX_TOKENS_FLOOR, est + _MAX_TOKENS_BUFFER)

--- a/backend/app/services/ai_forecast_refine_token_estimate.py
+++ b/backend/app/services/ai_forecast_refine_token_estimate.py
@@ -36,16 +36,20 @@ class Scope(str, enum.Enum):
     ALL = "all"
 
 
-def _limit_for_scope(scope: "Scope") -> int | None:
-    if scope is Scope.TOP_10:
-        return 10
-    if scope is Scope.TOP_20:
-        return 20
-    return None  # ALL
+def _limit_for_scope(scope: Scope) -> int | None:
+    match scope:
+        case Scope.TOP_10:
+            return 10
+        case Scope.TOP_20:
+            return 20
+        case Scope.ALL:
+            return None
+        case _:
+            raise ValueError(f"Unknown scope: {scope!r}")
 
 
 def select_categories_by_scope(
-    spend_by_category: dict[int, float], scope: "Scope"
+    spend_by_category: dict[int, float], scope: Scope
 ) -> list[int]:
     """Return category ids ordered by spend desc, truncated to the scope.
 
@@ -53,7 +57,7 @@ def select_categories_by_scope(
     """
     ordered = sorted(
         spend_by_category.keys(),
-        key=lambda cid: (-spend_by_category[cid], cid),
+        key=lambda cid: (-(spend_by_category[cid] or 0.0), cid),
     )
     limit = _limit_for_scope(scope)
     return ordered if limit is None else ordered[:limit]
@@ -64,6 +68,8 @@ def estimate_prompt_tokens(prompt_text: str) -> int:
 
 
 def estimate_output_tokens(*, category_count: int) -> int:
+    if category_count < 0:
+        raise ValueError(f"category_count must be >= 0, got {category_count}")
     anomalies = category_count // 4
     chars = (
         category_count * _SEASONAL_CHARS_PER_ROW

--- a/backend/app/services/ai_providers/anthropic.py
+++ b/backend/app/services/ai_providers/anthropic.py
@@ -32,7 +32,7 @@ from app.services.ai_providers.base import (
 
 
 VALIDATE_TIMEOUT_S = 10.0
-CHAT_TIMEOUT_S = 30.0
+CHAT_TIMEOUT_S = 60.0
 STREAM_TIMEOUT_S = 60.0
 # Anthropic advertises chat + tool use + structured output + streaming.
 # ``embed`` is intentionally absent — Anthropic has no embeddings API.

--- a/backend/tests/routers/test_ai_forecast_refine.py
+++ b/backend/tests/routers/test_ai_forecast_refine.py
@@ -773,6 +773,7 @@ async def test_estimate_endpoint_returns_200_on_unexpected_error(session_factory
     body = resp.json()
     assert body["can_proceed"] is False
     assert body["reason"] == "estimate_failed"
+    assert body["duration_band"] != ""
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_ai_forecast_refine.py
+++ b/backend/tests/routers/test_ai_forecast_refine.py
@@ -722,6 +722,87 @@ async def test_capability_not_supported_falls_back(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_estimate_endpoint_returns_200_with_estimate(session_factory):
+    """POST /refine/estimate returns 200 with a ForecastRefineEstimate body.
+
+    No LLM dispatch happens — the endpoint only computes token heuristics.
+    With no routing configured the body comes back with can_proceed=False and
+    the expected estimate keys present.
+    """
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/ai/forecast/refine/estimate",
+        json={"timeframe_months": 6, "scope": "top_20"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "est_cost_cents" in body
+    assert "can_proceed" in body
+    # No routing configured → can_proceed=False with reason
+    assert body["can_proceed"] is False
+    assert body["reason"] == "ai_routing_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_estimate_endpoint_returns_200_on_unexpected_error(session_factory):
+    """Defensive guard: if estimate_refine raises unexpectedly the endpoint
+    must still return 200 with can_proceed=False and reason='estimate_failed'.
+    """
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    with patch(
+        "app.routers.ai_forecast.estimate_refine",
+        side_effect=RuntimeError("boom"),
+    ):
+        resp = client.post(
+            "/api/v1/ai/forecast/refine/estimate",
+            json={"timeframe_months": 6, "scope": "top_20"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["can_proceed"] is False
+    assert body["reason"] == "estimate_failed"
+
+
+@pytest.mark.asyncio
+async def test_refine_accepts_timeframe_scope_and_audits_them(session_factory):
+    """POST /refine with timeframe_months=12 and scope='top_10' must pass those
+    params into the service and write them into the audit detail row.
+    """
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    # No routing configured → baseline fallback, but the params are still
+    # threaded through and the audit row is still written.
+    resp = client.post(
+        "/api/v1/ai/forecast/refine",
+        json={"timeframe_months": 12, "scope": "top_10"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    rows = await _audit_rows(session_factory)
+    assert len(rows) == 1
+    detail = rows[0].detail or {}
+    assert detail["timeframe_months"] == 12
+    assert detail["scope"] == "top_10"
+
+
+@pytest.mark.asyncio
 async def test_endpoint_never_mutates_user_data_tables(session_factory):
     """The /refine endpoint must NEVER write to Transaction, Category,
     or Budget. Pinning the suggestion-only invariant at the router

--- a/backend/tests/schemas/test_ai_forecast_schema.py
+++ b/backend/tests/schemas/test_ai_forecast_schema.py
@@ -1,0 +1,28 @@
+import pytest
+from pydantic import ValidationError
+from app.schemas.ai_forecast import RefineForecastRequest, ForecastRefineEstimate
+
+
+def test_request_defaults_are_6_months_top_20():
+    req = RefineForecastRequest()
+    assert req.timeframe_months == 6
+    assert req.scope == "top_20"
+
+
+def test_request_rejects_bad_timeframe_and_scope():
+    with pytest.raises(ValidationError):
+        RefineForecastRequest(timeframe_months=7)
+    with pytest.raises(ValidationError):
+        RefineForecastRequest(scope="everything")
+
+
+def test_estimate_response_shape():
+    est = ForecastRefineEstimate(
+        est_prompt_tokens=11000,
+        est_output_tokens=2000,
+        est_cost_cents=15,
+        duration_band="~20-40s",
+        can_proceed=True,
+        reason=None,
+    )
+    assert est.can_proceed is True

--- a/backend/tests/services/test_ai_forecast_prompt_builder.py
+++ b/backend/tests/services/test_ai_forecast_prompt_builder.py
@@ -1,0 +1,69 @@
+# backend/tests/services/test_ai_forecast_prompt_builder.py
+import json
+from app.services.ai_forecast_refine_service import _build_refine_prompt
+from app.services.ai_forecast_refine_token_estimate import Scope
+
+
+def _ctx():
+    baseline = {
+        "period_start": "2026-06-01", "period_end": "2026-06-30",
+        "forecast_income": "5000", "forecast_expense": "3000",
+        "categories": [
+            {"category_id": 1, "category_name": "Rent", "forecast": "1500"},
+            {"category_id": 2, "category_name": "Food", "forecast": "600"},
+            {"category_id": 3, "category_name": "Tiny", "forecast": "5"},
+        ],
+    }
+    history = [
+        {"category_id": 1, "month": "2026-05", "total_expense": "1500"},
+        {"category_id": 2, "month": "2026-05", "total_expense": "600"},
+        {"category_id": 3, "month": "2026-05", "total_expense": "5"},
+    ]
+    index = {1: "Rent", 2: "Food", 3: "Tiny"}
+    return baseline, history, index
+
+
+def test_scope_top_limits_categories_and_returns_estimate():
+    baseline, history, index = _ctx()
+    messages, est_out, n_in_scope = _build_refine_prompt(
+        baseline=baseline, history=history, category_index=index,
+        timeframe_months=6, scope=Scope.TOP_20,
+    )
+    # all 3 fit under top_20
+    user = json.loads(messages[1]["content"])
+    assert {c["category_id"] for c in user["baseline_forecast"]["categories"]} == {1, 2, 3}
+    assert est_out > 0
+    assert n_in_scope == 3
+
+
+def test_system_prompt_reflects_timeframe():
+    baseline, history, index = _ctx()
+    messages, _, n_in_scope = _build_refine_prompt(
+        baseline=baseline, history=history, category_index=index,
+        timeframe_months=12, scope=Scope.ALL,
+    )
+    assert "12-month" in messages[0]["content"]
+    assert n_in_scope == 3
+
+
+def test_top_10_drops_lowest_spend_category():
+    baseline, history, index = _ctx()
+    # force a tiny scope by monkeypatching is overkill; use a 11-category set:
+    baseline["categories"] = [
+        {"category_id": i, "category_name": f"C{i}", "forecast": str(100 - i)}
+        for i in range(1, 12)
+    ]
+    history = [
+        {"category_id": i, "month": "2026-05", "total_expense": str(100 - i)}
+        for i in range(1, 12)
+    ]
+    index = {i: f"C{i}" for i in range(1, 12)}
+    messages, _, n_in_scope = _build_refine_prompt(
+        baseline=baseline, history=history, category_index=index,
+        timeframe_months=6, scope=Scope.TOP_10,
+    )
+    user = json.loads(messages[1]["content"])
+    ids = {c["category_id"] for c in user["baseline_forecast"]["categories"]}
+    assert len(ids) == 10
+    assert 11 not in ids  # lowest spend dropped
+    assert n_in_scope == 10

--- a/backend/tests/services/test_ai_forecast_refine_service.py
+++ b/backend/tests/services/test_ai_forecast_refine_service.py
@@ -1,0 +1,252 @@
+"""Tests for Task 4 of ai-forecast-refine-cost-confirmed:
+- refine_forecast passes a sized max_tokens to call_llm_structured
+- estimate_refine returns token estimates without dispatching to the LLM
+"""
+from __future__ import annotations
+
+import base64
+import os
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings as app_settings
+from app.models import Base
+from app.models.org_ai_credential import AiProvider, OrgAICredential
+from app.models.org_ai_routing import OrgAIDefaultRouting
+from app.models.user import Organization, Role, User
+from app.security import hash_password
+from app.services import ai_dispatch, ai_forecast_refine_service as svc
+from app.services.ai_credential_crypto import encrypt
+from app.services.ai_forecast_refine_token_estimate import Scope
+
+
+# ---------- fixtures --------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db_session(session_factory) -> AsyncIterator[AsyncSession]:
+    async with session_factory() as session:
+        yield session
+
+
+@pytest.fixture(autouse=True)
+def _set_ai_key(monkeypatch):
+    monkeypatch.setattr(
+        app_settings,
+        "ai_credential_encryption_key",
+        base64.urlsafe_b64encode(os.urandom(32)).decode("ascii"),
+    )
+    monkeypatch.setattr(
+        app_settings, "ai_credential_encryption_key_prev", ""
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_redis(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.redis_client.get_client",
+        lambda: None,
+    )
+
+
+@pytest_asyncio.fixture
+async def seeded_org(db_session: AsyncSession) -> Organization:
+    """Minimal org with a user + routing so the service can resolve a model."""
+    org = Organization(name="TestOrg", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.commit()
+
+    user = User(
+        org_id=org.id,
+        username="owner",
+        email="owner@example.com",
+        password_hash=hash_password("pw-testtest"),
+        role=Role.OWNER,
+        is_superadmin=False,
+        is_active=True,
+        email_verified=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    cred = OrgAICredential(
+        org_id=org.id,
+        provider=AiProvider.OPENAI,
+        encrypted_api_key=encrypt("sk-test-12345"),
+        encrypted_bearer_token=None,
+        base_url=None,
+        key_fingerprint="0123456789abcdef",
+        last_four="2345",
+        label="primary",
+        discovered_capabilities=["chat", "structured_output"],
+    )
+    db_session.add(cred)
+    await db_session.commit()
+
+    routing = OrgAIDefaultRouting(
+        org_id=org.id, credential_id=cred.id, model="gpt-4o-mini"
+    )
+    db_session.add(routing)
+    await db_session.commit()
+
+    return org
+
+
+# ---------- tests ------------------------------------------------------
+
+
+_FAKE_BASELINE = {
+    "period_start": "2026-06-01",
+    "period_end": "2026-06-30",
+    "forecast_income": "5000",
+    "forecast_expense": "3000",
+    "categories": [
+        {"category_id": 1, "category_name": "Rent", "forecast": "1500"},
+        {"category_id": 2, "category_name": "Food", "forecast": "600"},
+    ],
+}
+
+_FAKE_HISTORY = [
+    {"category_id": 1, "month": "2026-05", "total_expense": "1500"},
+    {"category_id": 2, "month": "2026-05", "total_expense": "600"},
+]
+
+
+@pytest.mark.asyncio
+async def test_refine_passes_sized_max_tokens(
+    monkeypatch, db_session: AsyncSession, seeded_org: Organization
+):
+    """refine_forecast must pass a sized max_tokens (>= 1024) to
+    call_llm_structured even when NoRoutingConfigured is raised (the
+    fallback path). Verifies that max_tokens is computed and threaded
+    through before the dispatch attempt.
+    """
+    captured: dict = {}
+
+    # Patch internals so we can reach the dispatch call even in an empty DB
+    async def fake_compute_forecast(db, org_id, period_start=None):
+        return _FAKE_BASELINE
+
+    async def fake_build_history(db, *, org_id, period_start, months=12):
+        return _FAKE_HISTORY
+
+    async def fake_category_index(db, *, org_id):
+        return {1: "Rent", 2: "Food"}
+
+    async def fake_structured(
+        db, *, org_id, feature_key, messages, response_schema, max_tokens=None
+    ):
+        captured["max_tokens"] = max_tokens
+        raise ai_dispatch.NoRoutingConfigured()  # force clean fallback
+
+    monkeypatch.setattr(svc.forecast_service, "compute_forecast", fake_compute_forecast)
+    monkeypatch.setattr(svc, "_build_category_history", fake_build_history)
+    monkeypatch.setattr(svc, "_category_index", fake_category_index)
+    monkeypatch.setattr(ai_dispatch, "call_llm_structured", fake_structured)
+
+    resp = await svc.refine_forecast(
+        db_session,
+        org_id=seeded_org.id,
+        scope=Scope.TOP_20,
+        timeframe_months=6,
+    )
+    assert resp.provenance.ai_applied is False
+    assert captured.get("max_tokens") is not None
+    assert captured["max_tokens"] >= 1024
+
+
+@pytest.mark.asyncio
+async def test_estimate_refine_returns_tokens_without_dispatch(
+    monkeypatch, db_session: AsyncSession, seeded_org: Organization
+):
+    """estimate_refine must compute positive token estimates and return them
+    without ever calling call_llm_structured (even with routing + history).
+    """
+    called: dict = {"dispatch": False}
+
+    async def fake_compute_forecast(db, org_id, period_start=None):
+        return _FAKE_BASELINE
+
+    async def fake_build_history(db, *, org_id, period_start, months=12):
+        return _FAKE_HISTORY
+
+    async def fake_category_index(db, *, org_id):
+        return {1: "Rent", 2: "Food"}
+
+    async def fake_structured(*a, **k):
+        called["dispatch"] = True
+
+    monkeypatch.setattr(svc.forecast_service, "compute_forecast", fake_compute_forecast)
+    monkeypatch.setattr(svc, "_build_category_history", fake_build_history)
+    monkeypatch.setattr(svc, "_category_index", fake_category_index)
+    monkeypatch.setattr(ai_dispatch, "call_llm_structured", fake_structured)
+
+    est = await svc.estimate_refine(
+        db_session,
+        org_id=seeded_org.id,
+        period_start=None,
+        timeframe_months=6,
+        scope=Scope.TOP_20,
+    )
+    assert called["dispatch"] is False
+    assert est.est_prompt_tokens > 0
+    assert est.est_output_tokens > 0
+
+
+@pytest.mark.asyncio
+async def test_estimate_refine_no_history_returns_insufficient_history(
+    monkeypatch, db_session: AsyncSession, seeded_org: Organization
+):
+    """When the org has no history at all, estimate_refine returns
+    can_proceed=False with reason='insufficient_history'.
+    """
+    called: dict = {"dispatch": False}
+
+    async def fake_structured(*a, **k):
+        called["dispatch"] = True
+
+    monkeypatch.setattr(ai_dispatch, "call_llm_structured", fake_structured)
+
+    est = await svc.estimate_refine(
+        db_session,
+        org_id=seeded_org.id,
+        period_start=None,
+        timeframe_months=6,
+        scope=Scope.TOP_20,
+    )
+    assert called["dispatch"] is False
+    assert est.can_proceed is False
+    assert est.reason == "insufficient_history"

--- a/backend/tests/services/test_ai_forecast_refine_token_estimate.py
+++ b/backend/tests/services/test_ai_forecast_refine_token_estimate.py
@@ -1,5 +1,4 @@
 # backend/tests/services/test_ai_forecast_refine_token_estimate.py
-import pytest
 from app.services.ai_forecast_refine_token_estimate import (
     Scope,
     select_categories_by_scope,
@@ -34,5 +33,13 @@ def test_max_tokens_never_below_floor_and_covers_estimate():
 
 
 def test_estimate_prompt_tokens_is_char_based():
-    short = estimate_prompt_tokens("x" * 350)
-    assert short == pytest.approx(100, abs=5)  # ~1 token / 3.5 chars
+    assert estimate_prompt_tokens("x" * 350) == 100
+    assert estimate_prompt_tokens("x" * 351) == 101
+    assert estimate_prompt_tokens("") == 0
+
+
+def test_scope_truncation_lengths():
+    spend = {i: float(i) for i in range(1, 25)}  # 24 categories
+    assert len(select_categories_by_scope(spend, Scope.TOP_10)) == 10
+    assert len(select_categories_by_scope(spend, Scope.TOP_20)) == 20
+    assert len(select_categories_by_scope(spend, Scope.ALL)) == 24

--- a/backend/tests/services/test_ai_forecast_refine_token_estimate.py
+++ b/backend/tests/services/test_ai_forecast_refine_token_estimate.py
@@ -43,3 +43,8 @@ def test_scope_truncation_lengths():
     assert len(select_categories_by_scope(spend, Scope.TOP_10)) == 10
     assert len(select_categories_by_scope(spend, Scope.TOP_20)) == 20
     assert len(select_categories_by_scope(spend, Scope.ALL)) == 24
+
+
+def test_all_scope_is_capped_at_schema_ceiling():
+    spend = {i: float(i) for i in range(1, 301)}  # 300 categories
+    assert len(select_categories_by_scope(spend, Scope.ALL)) == 200

--- a/backend/tests/services/test_ai_forecast_refine_token_estimate.py
+++ b/backend/tests/services/test_ai_forecast_refine_token_estimate.py
@@ -1,0 +1,38 @@
+# backend/tests/services/test_ai_forecast_refine_token_estimate.py
+import pytest
+from app.services.ai_forecast_refine_token_estimate import (
+    Scope,
+    select_categories_by_scope,
+    estimate_prompt_tokens,
+    estimate_output_tokens,
+    max_tokens_for_output_estimate,
+)
+
+
+def test_select_top_n_by_spend_keeps_highest_only():
+    # spend_by_cat: {category_id: total_spend}
+    spend = {1: 100.0, 2: 5000.0, 3: 50.0, 4: 900.0}
+    assert select_categories_by_scope(spend, Scope.TOP_10) == [2, 4, 1, 3]
+    assert select_categories_by_scope(spend, Scope.ALL) == [2, 4, 1, 3]
+    # top_n truncates; with a tiny n via TOP_10 on 4 items we keep all 4
+    top2 = select_categories_by_scope({1: 10.0, 2: 20.0, 3: 30.0}, Scope.TOP_10)
+    assert top2 == [3, 2, 1]
+
+
+def test_estimate_output_tokens_grows_with_category_count():
+    few = estimate_output_tokens(category_count=5)
+    many = estimate_output_tokens(category_count=40)
+    assert many > few
+    assert few > 0
+
+
+def test_max_tokens_never_below_floor_and_covers_estimate():
+    # floor is 1024 (today's default); sizing adds headroom above the estimate
+    assert max_tokens_for_output_estimate(10) >= 1024
+    big = estimate_output_tokens(category_count=40)
+    assert max_tokens_for_output_estimate(40) > big
+
+
+def test_estimate_prompt_tokens_is_char_based():
+    short = estimate_prompt_tokens("x" * 350)
+    assert short == pytest.approx(100, abs=5)  # ~1 token / 3.5 chars

--- a/backend/tests/services/test_ai_providers_anthropic.py
+++ b/backend/tests/services/test_ai_providers_anthropic.py
@@ -1,0 +1,5 @@
+from app.services.ai_providers import anthropic as a
+
+
+def test_chat_timeout_allows_slow_structured_calls():
+    assert a.CHAT_TIMEOUT_S >= 60.0

--- a/frontend/components/dashboard/AIForecastRefinePanel.tsx
+++ b/frontend/components/dashboard/AIForecastRefinePanel.tsx
@@ -18,6 +18,7 @@ const REASON_COPY: Record<string, string> = {
   ai_routing_not_configured:
     "Configure an AI provider in Settings to use this feature.",
   insufficient_history: "Not enough transaction history yet to analyze.",
+  estimate_failed: "Something went wrong estimating the cost. Try again.",
 };
 
 export interface AIForecastRefinePanelProps {
@@ -173,7 +174,7 @@ export function AIForecastRefinePanel({
               <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
               Estimating cost…
             </span>
-          ) : estimate ? (
+          ) : estimate && canProceed ? (
             <span>
               {"≈"} {dollars} {"·"} {estimate.est_output_tokens} tokens{" "}
               {"·"} {estimate.duration_band}

--- a/frontend/components/dashboard/AIForecastRefinePanel.tsx
+++ b/frontend/components/dashboard/AIForecastRefinePanel.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { apiFetch, ApiResponseError } from "@/lib/api";
+import { card } from "@/lib/styles";
+import type { ForecastRefineEstimate } from "@/lib/types";
+import type { RefinedForecastResponse } from "@/components/dashboard/AIForecastRefineToggle";
+
+const TIMEFRAMES = [3, 6, 12] as const;
+const SCOPES = [
+  { value: "top_10", label: "Top 10 categories" },
+  { value: "top_20", label: "Top 20 categories" },
+  { value: "all", label: "All categories" },
+] as const;
+
+const REASON_COPY: Record<string, string> = {
+  ai_routing_not_configured:
+    "Configure an AI provider in Settings to use this feature.",
+  insufficient_history: "Not enough transaction history yet to analyze.",
+};
+
+export interface AIForecastRefinePanelProps {
+  periodStart?: string | null;
+  onApplied: (result: RefinedForecastResponse) => void;
+  onCancel?: () => void;
+  /** Called with the error when a 403 is received (feature gate closed). */
+  onGateBlock?: (err: unknown) => void;
+}
+
+/**
+ * Configure, estimate, and confirm panel for AI forecast refinement.
+ *
+ * On mount (and on any select change), posts to /estimate to show the
+ * user an approximate cost and duration before spending any tokens.
+ * The Confirm button is disabled while estimating, while the refine
+ * call is in flight, or when can_proceed is false (e.g. no AI provider
+ * configured). When confirmed, calls onApplied with the refined result
+ * so the parent toggle can render the result using its existing path.
+ */
+export function AIForecastRefinePanel({
+  periodStart,
+  onApplied,
+  onCancel,
+  onGateBlock,
+}: AIForecastRefinePanelProps) {
+  const [timeframe, setTimeframe] = useState<number>(6);
+  const [scope, setScope] = useState<string>("top_20");
+  const [estimate, setEstimate] = useState<ForecastRefineEstimate | null>(null);
+  const [estimating, setEstimating] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+
+  const refreshEstimate = useCallback(async () => {
+    setEstimating(true);
+    setEstimate(null);
+    try {
+      const est = await apiFetch<ForecastRefineEstimate>(
+        "/api/v1/ai/forecast/refine/estimate",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            period_start: periodStart ?? null,
+            timeframe_months: timeframe,
+            scope,
+          }),
+        },
+      );
+      setEstimate(est);
+    } catch (err) {
+      // 403 = feature gate closed; propagate to parent for hide logic.
+      if (err instanceof ApiResponseError && err.status === 403) {
+        onGateBlock?.(err);
+        return;
+      }
+      // Other estimation errors are non-fatal; the Confirm button stays disabled.
+      setEstimate(null);
+    } finally {
+      setEstimating(false);
+    }
+  }, [timeframe, scope, periodStart]);
+
+  useEffect(() => {
+    void refreshEstimate();
+  }, [refreshEstimate]);
+
+  const handleConfirm = async () => {
+    setRunning(true);
+    setRunError(null);
+    try {
+      const refined = await apiFetch<RefinedForecastResponse>(
+        "/api/v1/ai/forecast/refine",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            period_start: periodStart ?? null,
+            timeframe_months: timeframe,
+            scope,
+          }),
+        },
+      );
+      onApplied(refined);
+    } catch (err) {
+      if (err instanceof ApiResponseError && err.status === 403) {
+        onGateBlock?.(err);
+        return;
+      }
+      setRunError(err instanceof Error ? err.message : "Failed to refine forecast");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const canProceed = !!estimate?.can_proceed;
+  const dollars = estimate
+    ? `$${(estimate.est_cost_cents / 100).toFixed(2)}`
+    : null;
+
+  return (
+    <div className={`${card} mt-3 p-3 md:p-4`} data-testid="ai-forecast-refine-panel">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="ai-refine-timeframe"
+              className="text-xs font-medium text-text-muted"
+            >
+              Timeframe
+            </label>
+            <select
+              id="ai-refine-timeframe"
+              value={timeframe}
+              onChange={(e) => setTimeframe(Number(e.target.value))}
+              className="rounded border border-border bg-bg-secondary px-2 py-1 text-xs text-text-primary focus:border-accent focus:outline-none"
+            >
+              {TIMEFRAMES.map((m) => (
+                <option key={m} value={m}>
+                  {m} months
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="ai-refine-scope"
+              className="text-xs font-medium text-text-muted"
+            >
+              Scope
+            </label>
+            <select
+              id="ai-refine-scope"
+              value={scope}
+              onChange={(e) => setScope(e.target.value)}
+              className="rounded border border-border bg-bg-secondary px-2 py-1 text-xs text-text-primary focus:border-accent focus:outline-none"
+            >
+              {SCOPES.map((s) => (
+                <option key={s.value} value={s.value}>
+                  {s.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="text-xs text-text-secondary" aria-live="polite">
+          {estimating ? (
+            <span className="inline-flex items-center gap-1">
+              <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+              Estimating cost…
+            </span>
+          ) : estimate ? (
+            <span>
+              {"≈"} {dollars} {"·"} {estimate.est_output_tokens} tokens{" "}
+              {"·"} {estimate.duration_band}
+            </span>
+          ) : null}
+        </div>
+
+        {estimate && !canProceed && estimate.reason && (
+          <p className="text-xs text-text-muted" role="status">
+            {REASON_COPY[estimate.reason] ?? "This feature is currently unavailable."}
+          </p>
+        )}
+
+        {runError && (
+          <p className="text-xs text-danger" role="status">
+            {runError}
+          </p>
+        )}
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!canProceed || estimating || running}
+            className="rounded border border-border bg-bg-secondary px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-bg-tertiary disabled:opacity-50"
+          >
+            {running ? (
+              <span className="inline-flex items-center gap-1">
+                <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+                Refining…
+              </span>
+            ) : (
+              "Confirm"
+            )}
+          </button>
+          {onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="text-xs text-text-secondary underline underline-offset-2 hover:text-text-primary"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/AIForecastRefinePanel.tsx
+++ b/frontend/components/dashboard/AIForecastRefinePanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { apiFetch, ApiResponseError } from "@/lib/api";
 import { card } from "@/lib/styles";
@@ -50,8 +50,10 @@ export function AIForecastRefinePanel({
   const [estimating, setEstimating] = useState(false);
   const [running, setRunning] = useState(false);
   const [runError, setRunError] = useState<string | null>(null);
+  const seq = useRef(0);
 
   const refreshEstimate = useCallback(async () => {
+    const mine = ++seq.current;
     setEstimating(true);
     setEstimate(null);
     try {
@@ -67,19 +69,20 @@ export function AIForecastRefinePanel({
           }),
         },
       );
-      setEstimate(est);
+      if (seq.current === mine) setEstimate(est);
     } catch (err) {
       // 403 = feature gate closed; propagate to parent for hide logic.
+      // Gate status is not racy — always forward regardless of sequence.
       if (err instanceof ApiResponseError && err.status === 403) {
         onGateBlock?.(err);
         return;
       }
       // Other estimation errors are non-fatal; the Confirm button stays disabled.
-      setEstimate(null);
+      if (seq.current === mine) setEstimate(null);
     } finally {
-      setEstimating(false);
+      if (seq.current === mine) setEstimating(false);
     }
-  }, [timeframe, scope, periodStart]);
+  }, [timeframe, scope, periodStart, onGateBlock]);
 
   useEffect(() => {
     void refreshEstimate();

--- a/frontend/components/dashboard/AIForecastRefineToggle.tsx
+++ b/frontend/components/dashboard/AIForecastRefineToggle.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { Sparkles, AlertTriangle, Loader2 } from "lucide-react";
-import { apiFetch, ApiResponseError } from "@/lib/api";
+import { Sparkles, AlertTriangle } from "lucide-react";
+import { ApiResponseError } from "@/lib/api";
 import { card } from "@/lib/styles";
+import { AIForecastRefinePanel } from "@/components/dashboard/AIForecastRefinePanel";
 
 // Mirrors backend/app/schemas/ai_forecast.RefinedForecastResponse.
 export interface RefinedCategoryRow {
@@ -68,42 +69,39 @@ export default function AIForecastRefineToggle({
   visible = true,
 }: AIForecastRefineToggleProps) {
   const [refined, setRefined] = useState<RefinedForecastResponse | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [panelOpen, setPanelOpen] = useState(false);
   const [gateBlocked, setGateBlocked] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [tooltipOpen, setTooltipOpen] = useState(false);
 
   if (!visible || gateBlocked) return null;
 
-  const handleClick = async () => {
-    setLoading(true);
-    setErrorMessage(null);
-    try {
-      const body = await apiFetch<RefinedForecastResponse>(
-        "/api/v1/ai/forecast/refine",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ period_start: periodStart ?? null }),
-        },
-      );
-      setRefined(body);
-    } catch (err) {
-      if (err instanceof ApiResponseError && err.status === 403) {
-        // Feature gate closed. Hide the toggle entirely.
-        setGateBlocked(true);
-        return;
-      }
-      setErrorMessage(
-        err instanceof Error ? err.message : "Failed to refine forecast",
-      );
-    } finally {
-      setLoading(false);
+  // When the panel calls onApplied (after a successful Confirm), store the
+  // result and close the panel so the refined-result view renders below.
+  const handleApplied = (result: RefinedForecastResponse) => {
+    setRefined(result);
+    setPanelOpen(false);
+  };
+
+  // The panel's estimate call may 403 (feature gate closed) — propagate that
+  // up to hide the toggle exactly as the old direct-call path did.
+  const handleGateBlock = (err: unknown) => {
+    if (err instanceof ApiResponseError && err.status === 403) {
+      setGateBlocked(true);
     }
   };
 
-  // Idle state — invite the user to opt in.
+  // Idle state — invite the user to configure and confirm.
   if (refined === null) {
+    if (panelOpen) {
+      return (
+        <AIForecastRefinePanel
+          periodStart={periodStart}
+          onApplied={handleApplied}
+          onCancel={() => setPanelOpen(false)}
+          onGateBlock={handleGateBlock}
+        />
+      );
+    }
     return (
       <div className={`${card} mt-3 flex items-center gap-3 p-3 md:p-4`}>
         <Sparkles className="h-4 w-4 text-text-secondary" aria-hidden="true" />
@@ -112,25 +110,12 @@ export default function AIForecastRefineToggle({
         </div>
         <button
           type="button"
-          onClick={handleClick}
-          disabled={loading}
+          onClick={() => setPanelOpen(true)}
           data-testid="ai-forecast-refine-toggle"
           className="rounded border border-border bg-bg-secondary px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-bg-tertiary disabled:opacity-50"
         >
-          {loading ? (
-            <span className="inline-flex items-center gap-1">
-              <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
-              Refining…
-            </span>
-          ) : (
-            "Apply AI refinement"
-          )}
+          Apply AI refinement
         </button>
-        {errorMessage && (
-          <span className="text-xs text-danger" role="status">
-            {errorMessage}
-          </span>
-        )}
       </div>
     );
   }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -17,6 +17,9 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 // requests were never replayed visibly to the user. 45s gives the
 // observed tail enough headroom that a single attempt succeeds.
 const RECOVERY_TIMEOUT_MS = 45_000;
+// AI dispatch endpoints (/ai/*) can take 20-40s for structured LLM calls.
+// Give them a 90s budget to avoid false-positive timeouts on slow models.
+const AI_TIMEOUT_MS = 90_000;
 // Back-compat alias retained for the rest of the module; existing callers
 // reference API_FETCH_TIMEOUT_MS in inline comments.
 const API_FETCH_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
@@ -45,8 +48,14 @@ function isRecoveryPath(path: string): boolean {
   );
 }
 
-function timeoutForPath(path: string): number {
-  return isRecoveryPath(path) ? RECOVERY_TIMEOUT_MS : DEFAULT_TIMEOUT_MS;
+function isAIPath(path: string): boolean {
+  return path.includes("/api/v1/ai/") || path.startsWith("/ai/");
+}
+
+export function timeoutForPath(path: string): number {
+  if (isRecoveryPath(path)) return RECOVERY_TIMEOUT_MS;
+  if (isAIPath(path)) return AI_TIMEOUT_MS;
+  return DEFAULT_TIMEOUT_MS;
 }
 
 let accessToken: string | null = null;

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -766,6 +766,17 @@ export interface NotificationUnseenCountResponse {
 }
 
 // L4.10 — rate-limit overrides admin shape.
+// AI Forecast Refine — cost-confirmed estimate preflight (Task 8).
+// Mirrors backend/app/schemas/ai_forecast.ForecastRefineEstimate.
+export interface ForecastRefineEstimate {
+  est_prompt_tokens: number;
+  est_output_tokens: number;
+  est_cost_cents: number;
+  duration_band: string;
+  can_proceed: boolean;
+  reason: string | null;
+}
+
 export interface RateLimitOverride {
   id: number;
   org_id: number | null;

--- a/frontend/tests/components/AIForecastRefinePanel.test.tsx
+++ b/frontend/tests/components/AIForecastRefinePanel.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+import { apiFetch } from "@/lib/api";
+import { AIForecastRefinePanel } from "@/components/dashboard/AIForecastRefinePanel";
+
+const mockedFetch = apiFetch as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockedFetch.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("AIForecastRefinePanel", () => {
+  it("shows the estimated cost and enables Confirm when can_proceed", async () => {
+    mockedFetch.mockResolvedValue({
+      est_prompt_tokens: 11000,
+      est_output_tokens: 2000,
+      est_cost_cents: 15,
+      duration_band: "~20-40s",
+      can_proceed: true,
+      reason: null,
+    });
+
+    render(<AIForecastRefinePanel onApplied={() => {}} />);
+
+    await waitFor(() => expect(screen.getByText(/\$0\.15/)).toBeInTheDocument());
+    expect(screen.getByText(/~20-40s/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirm/i })).toBeEnabled();
+  });
+
+  it("disables Confirm and shows the reason when can_proceed is false", async () => {
+    mockedFetch.mockResolvedValue({
+      est_prompt_tokens: 0,
+      est_output_tokens: 0,
+      est_cost_cents: 0,
+      duration_band: "~20-40s",
+      can_proceed: false,
+      reason: "ai_routing_not_configured",
+    });
+
+    render(<AIForecastRefinePanel onApplied={() => {}} />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /confirm/i })).toBeDisabled(),
+    );
+    // friendly reason copy mentions "provider"
+    expect(screen.getByText(/provider/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/AIForecastRefinePanel.test.tsx
+++ b/frontend/tests/components/AIForecastRefinePanel.test.tsx
@@ -51,5 +51,27 @@ describe("AIForecastRefinePanel", () => {
     );
     // friendly reason copy mentions "provider"
     expect(screen.getByText(/provider/i)).toBeInTheDocument();
+    // cost/token line must NOT be shown when can_proceed is false
+    expect(screen.queryByText(/tokens/)).toBeNull();
+  });
+
+  it("shows estimate_failed reason copy when can_proceed is false with estimate_failed", async () => {
+    mockedFetch.mockResolvedValue({
+      est_prompt_tokens: 0,
+      est_output_tokens: 0,
+      est_cost_cents: 0,
+      duration_band: "~20-40s",
+      can_proceed: false,
+      reason: "estimate_failed",
+    });
+
+    render(<AIForecastRefinePanel onApplied={() => {}} />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /confirm/i })).toBeDisabled(),
+    );
+    expect(screen.getByText(/something went wrong estimating/i)).toBeInTheDocument();
+    // cost/token line must NOT be shown
+    expect(screen.queryByText(/tokens/)).toBeNull();
   });
 });

--- a/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
+++ b/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
@@ -53,6 +53,17 @@ function refinedFixture(
   };
 }
 
+function estimateFixture(can_proceed = true) {
+  return {
+    est_prompt_tokens: 11000,
+    est_output_tokens: 2000,
+    est_cost_cents: 15,
+    duration_band: "~20-40s",
+    can_proceed,
+    reason: can_proceed ? null : "ai_routing_not_configured",
+  };
+}
+
 beforeEach(() => {
   mockedFetch.mockReset();
 });
@@ -62,8 +73,9 @@ afterEach(() => {
 });
 
 describe("AIForecastRefineToggle - idle and apply flow", () => {
-  it("renders the apply CTA when idle and triggers POST on click", async () => {
-    mockedFetch.mockResolvedValueOnce(refinedFixture());
+  it("renders the apply CTA when idle; clicking opens the configure panel", async () => {
+    // First call is the estimate (on panel mount).
+    mockedFetch.mockResolvedValue(estimateFixture());
 
     render(<AIForecastRefineToggle periodStart="2026-05-01" />);
     const button = screen.getByTestId("ai-forecast-refine-toggle");
@@ -72,28 +84,34 @@ describe("AIForecastRefineToggle - idle and apply flow", () => {
 
     fireEvent.click(button);
 
-    await waitFor(() => {
-      expect(screen.getByTestId("ai-forecast-refined-panel")).toBeInTheDocument();
-    });
-    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    // Panel opens; estimate call fires; Confirm button appears.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /confirm/i })).toBeInTheDocument(),
+    );
+    // Direct refine NOT called yet — only the estimate call.
     expect(mockedFetch).toHaveBeenCalledWith(
-      "/api/v1/ai/forecast/refine",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({ period_start: "2026-05-01" }),
-      }),
+      "/api/v1/ai/forecast/refine/estimate",
+      expect.objectContaining({ method: "POST" }),
     );
   });
 
-  it("shows the AI-refined badge when the backend applies adjustments", async () => {
-    mockedFetch.mockResolvedValueOnce(refinedFixture());
-    render(<AIForecastRefineToggle periodStart="2026-05-01" />);
+  it("shows the AI-refined badge after Confirm completes", async () => {
+    // First call: estimate. Second call: refine.
+    mockedFetch
+      .mockResolvedValueOnce(estimateFixture())
+      .mockResolvedValueOnce(refinedFixture());
 
+    render(<AIForecastRefineToggle periodStart="2026-05-01" />);
     fireEvent.click(screen.getByTestId("ai-forecast-refine-toggle"));
 
-    await waitFor(() => {
-      expect(screen.getByTestId("ai-refined-badge")).toBeInTheDocument();
-    });
+    // Wait for Confirm to be enabled.
+    const confirmBtn = await screen.findByRole("button", { name: /confirm/i });
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("ai-forecast-refined-panel")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("ai-refined-badge")).toBeInTheDocument();
     expect(screen.queryByTestId("ai-fallback-badge")).toBeNull();
     // Delta vs. baseline surfaced.
     expect(screen.getByText(/\+20\.00 vs\. baseline/)).toBeInTheDocument();
@@ -103,10 +121,16 @@ describe("AIForecastRefineToggle - idle and apply flow", () => {
 
 describe("AIForecastRefineToggle - tooltip details", () => {
   it("toggles the detail panel and lists adjustments + anomalies", async () => {
-    mockedFetch.mockResolvedValueOnce(refinedFixture());
-    render(<AIForecastRefineToggle periodStart="2026-05-01" />);
+    mockedFetch
+      .mockResolvedValueOnce(estimateFixture())
+      .mockResolvedValueOnce(refinedFixture());
 
+    render(<AIForecastRefineToggle periodStart="2026-05-01" />);
     fireEvent.click(screen.getByTestId("ai-forecast-refine-toggle"));
+
+    const confirmBtn = await screen.findByRole("button", { name: /confirm/i });
+    fireEvent.click(confirmBtn);
+
     await waitFor(() =>
       expect(screen.getByTestId("ai-forecast-refined-panel")).toBeInTheDocument(),
     );
@@ -135,32 +159,37 @@ describe("AIForecastRefineToggle - tooltip details", () => {
 
 describe("AIForecastRefineToggle - fallback handling", () => {
   it("shows fallback badge + reason when backend returns ai_applied=false", async () => {
-    mockedFetch.mockResolvedValueOnce(
-      refinedFixture({
-        refined_forecast_expense: "100.00",
-        provenance: {
-          ai_applied: false,
-          fallback_reason: "ai_routing_not_configured",
-          model: null,
-          confidence: null,
-          summary: null,
-          notes: [],
-        },
-        categories: [
-          {
-            category_id: 1,
-            category_name: "Groceries",
-            baseline_forecast: "100.00",
-            multiplier: 1.0,
-            refined_forecast: "100.00",
+    mockedFetch
+      .mockResolvedValueOnce(estimateFixture())
+      .mockResolvedValueOnce(
+        refinedFixture({
+          refined_forecast_expense: "100.00",
+          provenance: {
+            ai_applied: false,
+            fallback_reason: "ai_routing_not_configured",
+            model: null,
+            confidence: null,
+            summary: null,
+            notes: [],
           },
-        ],
-        anomalies: [],
-      }),
-    );
+          categories: [
+            {
+              category_id: 1,
+              category_name: "Groceries",
+              baseline_forecast: "100.00",
+              multiplier: 1.0,
+              refined_forecast: "100.00",
+            },
+          ],
+          anomalies: [],
+        }),
+      );
 
     render(<AIForecastRefineToggle periodStart="2026-05-01" />);
     fireEvent.click(screen.getByTestId("ai-forecast-refine-toggle"));
+
+    const confirmBtn = await screen.findByRole("button", { name: /confirm/i });
+    fireEvent.click(confirmBtn);
 
     await waitFor(() =>
       expect(screen.getByTestId("ai-fallback-badge")).toBeInTheDocument(),
@@ -171,8 +200,8 @@ describe("AIForecastRefineToggle - fallback handling", () => {
     );
   });
 
-  it("hides itself entirely on a 403 (feature gate closed)", async () => {
-    mockedFetch.mockRejectedValueOnce(
+  it("hides itself entirely when the estimate call returns a 403 (feature gate closed)", async () => {
+    mockedFetch.mockRejectedValue(
       new ApiResponseError(403, "feature_not_enabled", "feature_not_enabled"),
     );
 

--- a/frontend/tests/lib/api-timeout.test.ts
+++ b/frontend/tests/lib/api-timeout.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { timeoutForPath } from "@/lib/api";
+
+describe("timeoutForPath", () => {
+  it("gives AI dispatch paths a 90s budget", () => {
+    expect(timeoutForPath("/api/v1/ai/forecast/refine")).toBe(90_000);
+    expect(timeoutForPath("/api/v1/ai/forecast/refine/estimate")).toBe(90_000);
+    expect(timeoutForPath("/api/v1/ai/categorize")).toBe(90_000);
+  });
+  it("leaves non-AI paths on the 10s default", () => {
+    expect(timeoutForPath("/api/v1/transactions")).toBe(10_000);
+  });
+});

--- a/specs/ai-assistant-mcp-chat-backlog.md
+++ b/specs/ai-assistant-mcp-chat-backlog.md
@@ -1,0 +1,47 @@
+# AI assistant: natural-language chat over an internal MCP tool layer (backlog)
+
+- Status: Backlog — its own project, needs a dedicated brainstorm → spec → plan
+  cycle when prioritized. NOT part of the 2026-06-04 "make AI real" wave.
+- Filed: 2026-06-04 (operator idea during the forecast-refine fix)
+
+## Idea
+
+Make the app dramatically easier to use by letting users drive it with natural
+language. The operator's framing: build an **internal MCP** exposing tools for
+"anything we can do manually in the system", and an AI chat that translates a
+user's prompt into those tool calls. **Every real change must be confirmed by
+the user before it is applied** (no silent mutations).
+
+Examples of intent: "create a recurring rent payment of 1200 on the 1st",
+"move my groceries budget up 50 this month", "categorize last week's
+transactions", "what did I spend on dining in Q1?".
+
+## Why this is its own project (not a wave item)
+
+- It is an agentic architecture, not a feature: a tool registry, a chat loop /
+  planner, a confirmation-gating layer for mutations, per-tool permission +
+  org-scope enforcement, and audit of every executed action.
+- It must reuse the same authz/org-scoping every existing endpoint enforces, so
+  the tools should wrap the service layer, not bypass it.
+- Read vs write tools need different trust treatment (reads can auto-run; writes
+  require an explicit, previewed confirmation showing exactly what will change).
+- Cost/latency: this rides the same per-org AI dispatch/cap/ledger chokepoint as
+  the other AI features; the `chat` routing key is already reserved in the
+  feature catalog.
+
+## Rough shape to explore later
+
+- An internal tool registry whose tools map 1:1 onto existing service-layer
+  operations (transactions, recurring, budgets, categories, reports queries).
+- A planner that proposes a sequence of tool calls; writes are batched into a
+  preview the user confirms before execution.
+- Mutations route through the existing audit trail; reads are rate-limited and
+  capped like other AI features.
+- Gated behind the same provider-configured requirement as the rest of AI
+  (see the AI-readiness gating spec).
+
+## Dependencies / sequencing
+
+- Sits on top of the AI dispatch chokepoint and the AI-readiness gating work.
+- Should follow the operator's standard flow: dev+architect brainstorm → spec →
+  subagent-driven implementation, when picked up.

--- a/specs/ai-forecast-refine-cost-confirmed-plan.md
+++ b/specs/ai-forecast-refine-cost-confirmed-plan.md
@@ -1,0 +1,1059 @@
+# Smart Forecast Refinement: Cost-Confirmed Flow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the two prod bugs in "Apply AI refinement" (10s client abort, 1024-token truncation) and turn it into a configurable, cost-confirmed flow (timeframe + category-scope knobs, a no-LLM cost estimate the user confirms before any tokens are spent).
+
+**Architecture:** A single shared prompt builder feeds both a new no-LLM `/estimate` preflight and the real refine call, so the quoted cost can't drift from what runs. `max_tokens` is sized from the same estimate, eliminating truncation. Frontend gives `/ai/*` a 90s budget; backend per-call httpx timeout rises to 60s. Synchronous; async execution is backlogged.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 async + Pydantic v2 (backend), Next.js 15 + React 19 + TypeScript + SWR (frontend). Tests: pytest (backend), vitest/RTL (frontend).
+
+**Spec:** `specs/ai-forecast-refine-cost-confirmed.md`
+
+**Branch:** create `fix/ai-forecast-refine-cost-confirmed` off `main` before Task 1.
+
+**Test command reminder:** backend tests run in the container —
+`docker compose exec backend pytest <path> -v`. If dispatched as a parallel
+agent, use an isolated project: `docker compose -p team-<name> exec backend pytest …`
+(never the default project). Frontend: `docker compose exec frontend npm test -- <path>`.
+
+---
+
+## File structure
+
+Backend:
+- `backend/app/services/ai_forecast_refine_token_estimate.py` — **new**, pure helpers: token heuristic + scope selection + max_tokens sizing. Isolated so it's unit-testable without a DB.
+- `backend/app/schemas/ai_forecast.py` — add `timeframe_months`/`scope` to the request; add `ForecastRefineEstimate` response; raise `seasonal`/`anomalies` caps.
+- `backend/app/services/ai_forecast_refine_service.py` — shared `_build_refine_prompt`, scope filtering, timeframe slicing, dynamic system prompt, `HISTORY_MONTHS`→12, new `estimate_refine()` entry point, thread params + `max_tokens` into `refine_forecast()`.
+- `backend/app/routers/ai_forecast.py` — thread params into `/refine`; add `/estimate`; audit detail + structlog.
+- `backend/app/services/ai_providers/anthropic.py` — `CHAT_TIMEOUT_S` 30 → 60.
+
+Frontend:
+- `frontend/lib/api.ts` — `/api/v1/ai/*` 90s timeout matcher.
+- `frontend/lib/types.ts` — `ForecastRefineEstimate`, request param types.
+- `frontend/components/dashboard/AIForecastRefinePanel.tsx` — **new**, the configure→estimate→confirm panel.
+- `frontend/components/dashboard/AIForecastRefineToggle.tsx` — open the panel; pass confirmed params to the refine call.
+
+---
+
+## Task 1: Token-estimation + scope helpers (pure functions)
+
+**Files:**
+- Create: `backend/app/services/ai_forecast_refine_token_estimate.py`
+- Test: `backend/tests/services/test_ai_forecast_refine_token_estimate.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/services/test_ai_forecast_refine_token_estimate.py
+import pytest
+from app.services.ai_forecast_refine_token_estimate import (
+    Scope,
+    select_categories_by_scope,
+    estimate_prompt_tokens,
+    estimate_output_tokens,
+    max_tokens_for_output_estimate,
+)
+
+
+def test_select_top_n_by_spend_keeps_highest_only():
+    # spend_by_cat: {category_id: total_spend}
+    spend = {1: 100.0, 2: 5000.0, 3: 50.0, 4: 900.0}
+    assert select_categories_by_scope(spend, Scope.TOP_10) == [2, 4, 1, 3]
+    assert select_categories_by_scope(spend, Scope.ALL) == [2, 4, 1, 3]
+    # top_n truncates; with a tiny n via TOP_10 on 4 items we keep all 4
+    top2 = select_categories_by_scope({1: 10.0, 2: 20.0, 3: 30.0}, Scope.TOP_10)
+    assert top2 == [3, 2, 1]
+
+
+def test_estimate_output_tokens_grows_with_category_count():
+    few = estimate_output_tokens(category_count=5)
+    many = estimate_output_tokens(category_count=40)
+    assert many > few
+    assert few > 0
+
+
+def test_max_tokens_never_below_floor_and_covers_estimate():
+    # floor is 1024 (today's default); sizing adds headroom above the estimate
+    assert max_tokens_for_output_estimate(10) >= 1024
+    big = estimate_output_tokens(category_count=40)
+    assert max_tokens_for_output_estimate(40) > big
+
+
+def test_estimate_prompt_tokens_is_char_based():
+    short = estimate_prompt_tokens("x" * 350)
+    assert short == pytest.approx(100, abs=5)  # ~1 token / 3.5 chars
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose exec backend pytest tests/services/test_ai_forecast_refine_token_estimate.py -v`
+Expected: FAIL — `ModuleNotFoundError: ai_forecast_refine_token_estimate`.
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# backend/app/services/ai_forecast_refine_token_estimate.py
+"""Pure (DB-free) helpers for the cost-confirmed forecast-refine flow.
+
+Kept separate from the service so the heuristic + scope selection are
+unit-testable without a database or LLM. The SAME functions back both
+the /estimate preflight and the real refine call, so the quoted cost
+can't drift from what actually runs.
+"""
+from __future__ import annotations
+
+import enum
+import math
+
+# Char-per-token heuristics. The stack has no tokenizer; these are
+# deliberately rough and surfaced to the user as approximate ("≈").
+_PROMPT_CHARS_PER_TOKEN = 3.5
+_OUTPUT_CHARS_PER_TOKEN = 3.0
+
+# Per-row JSON size assumptions for the output shape (SeasonalAdjustment,
+# AnomalyFlag) plus fixed overhead (confidence, summary, braces).
+_SEASONAL_CHARS_PER_ROW = 220
+_ANOMALY_CHARS_PER_ROW = 180
+_FIXED_OUTPUT_CHARS = 600
+_OUTPUT_SAFETY_MARGIN = 1.10
+
+# max_tokens sizing: never below today's adapter default; add headroom
+# above the estimate so the tool-use JSON can't truncate before the
+# required `anomalies` key (the prod bug).
+_MAX_TOKENS_FLOOR = 1024
+_MAX_TOKENS_BUFFER = 400
+
+
+class Scope(str, enum.Enum):
+    TOP_10 = "top_10"
+    TOP_20 = "top_20"
+    ALL = "all"
+
+
+def _limit_for_scope(scope: "Scope") -> int | None:
+    if scope is Scope.TOP_10:
+        return 10
+    if scope is Scope.TOP_20:
+        return 20
+    return None  # ALL
+
+
+def select_categories_by_scope(
+    spend_by_category: dict[int, float], scope: "Scope"
+) -> list[int]:
+    """Return category ids ordered by spend desc, truncated to the scope.
+
+    Ties broken by category_id asc for determinism.
+    """
+    ordered = sorted(
+        spend_by_category.keys(),
+        key=lambda cid: (-spend_by_category[cid], cid),
+    )
+    limit = _limit_for_scope(scope)
+    return ordered if limit is None else ordered[:limit]
+
+
+def estimate_prompt_tokens(prompt_text: str) -> int:
+    return math.ceil(len(prompt_text) / _PROMPT_CHARS_PER_TOKEN)
+
+
+def estimate_output_tokens(*, category_count: int) -> int:
+    anomalies = category_count // 4
+    chars = (
+        category_count * _SEASONAL_CHARS_PER_ROW
+        + anomalies * _ANOMALY_CHARS_PER_ROW
+        + _FIXED_OUTPUT_CHARS
+    )
+    tokens = math.ceil(chars / _OUTPUT_CHARS_PER_TOKEN)
+    return math.ceil(tokens * _OUTPUT_SAFETY_MARGIN)
+
+
+def max_tokens_for_output_estimate(category_count: int) -> int:
+    est = estimate_output_tokens(category_count=category_count)
+    return max(_MAX_TOKENS_FLOOR, est + _MAX_TOKENS_BUFFER)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker compose exec backend pytest tests/services/test_ai_forecast_refine_token_estimate.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/ai_forecast_refine_token_estimate.py backend/tests/services/test_ai_forecast_refine_token_estimate.py
+git commit -m "feat(ai-forecast): add token-estimate + scope-selection helpers"
+```
+
+---
+
+## Task 2: Schema — request params + estimate response + raised caps
+
+**Files:**
+- Modify: `backend/app/schemas/ai_forecast.py`
+- Test: `backend/tests/schemas/test_ai_forecast_schema.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/schemas/test_ai_forecast_schema.py
+import pytest
+from pydantic import ValidationError
+from app.schemas.ai_forecast import RefineForecastRequest, ForecastRefineEstimate
+
+
+def test_request_defaults_are_6_months_top_20():
+    req = RefineForecastRequest()
+    assert req.timeframe_months == 6
+    assert req.scope == "top_20"
+
+
+def test_request_rejects_bad_timeframe_and_scope():
+    with pytest.raises(ValidationError):
+        RefineForecastRequest(timeframe_months=7)
+    with pytest.raises(ValidationError):
+        RefineForecastRequest(scope="everything")
+
+
+def test_estimate_response_shape():
+    est = ForecastRefineEstimate(
+        est_prompt_tokens=11000,
+        est_output_tokens=2000,
+        est_cost_cents=15,
+        duration_band="~20-40s",
+        can_proceed=True,
+        reason=None,
+    )
+    assert est.can_proceed is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose exec backend pytest tests/schemas/test_ai_forecast_schema.py -v`
+Expected: FAIL — `ImportError: ForecastRefineEstimate` / unexpected default.
+
+- [ ] **Step 3: Implement schema changes**
+
+In `backend/app/schemas/ai_forecast.py`:
+
+Raise the model caps (so `scope="all"` on a large org isn't rejected at validate time):
+
+```python
+class AIForecastAdjustments(BaseModel):
+    seasonal: list[SeasonalAdjustment] = Field(default_factory=list, max_length=200)
+    anomalies: list[AnomalyFlag] = Field(default_factory=list, max_length=60)
+    confidence: StrictFloat = Field(..., ge=0.0, le=1.0)
+    summary: StrictStr = Field(..., max_length=480)
+```
+
+Replace `RefineForecastRequest` and add the estimate response:
+
+```python
+from typing import Literal
+
+class RefineForecastRequest(BaseModel):
+    """Request body for the refine + estimate endpoints.
+
+    ``period_start`` optional (defaults to the current billing period).
+    ``timeframe_months`` selects history depth; ``scope`` selects how many
+    categories (by spend) are refined.
+    """
+
+    period_start: Optional[StrictStr] = None
+    timeframe_months: Literal[3, 6, 12] = 6
+    scope: Literal["top_10", "top_20", "all"] = "top_20"
+
+
+class ForecastRefineEstimate(BaseModel):
+    """No-LLM preflight estimate shown before the user confirms a refine."""
+
+    est_prompt_tokens: StrictInt
+    est_output_tokens: StrictInt
+    est_cost_cents: StrictInt
+    duration_band: StrictStr
+    can_proceed: StrictBool
+    reason: Optional[StrictStr] = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker compose exec backend pytest tests/schemas/test_ai_forecast_schema.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/schemas/ai_forecast.py backend/tests/schemas/test_ai_forecast_schema.py
+git commit -m "feat(ai-forecast): add timeframe/scope request params + estimate schema"
+```
+
+---
+
+## Task 3: Shared prompt builder — timeframe slicing, scope filtering, dynamic prompt
+
+**Files:**
+- Modify: `backend/app/services/ai_forecast_refine_service.py`
+- Test: `backend/tests/services/test_ai_forecast_prompt_builder.py`
+
+Notes on the change:
+- Bump `HISTORY_MONTHS = 12` (max window pulled); slice to the requested timeframe.
+- `_build_category_history` gains a `months: int` param (defaults 12) and uses it for the window start.
+- Add `_spend_by_category(history) -> dict[int, float]` summing `total_expense` per category over the window.
+- Replace `_build_messages(ctx)` with `_build_refine_prompt(*, baseline, history, category_index, timeframe_months, scope) -> tuple[list[dict], int]`:
+  - filter history + baseline categories to `select_categories_by_scope(...)`,
+  - build the system prompt dynamically with the actual `timeframe_months`,
+  - return `(messages, estimate_output_tokens(category_count=len(in_scope)))`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/services/test_ai_forecast_prompt_builder.py
+import json
+from app.services.ai_forecast_refine_service import _build_refine_prompt
+from app.services.ai_forecast_refine_token_estimate import Scope
+
+
+def _ctx():
+    baseline = {
+        "period_start": "2026-06-01", "period_end": "2026-06-30",
+        "forecast_income": "5000", "forecast_expense": "3000",
+        "categories": [
+            {"category_id": 1, "category_name": "Rent", "forecast": "1500"},
+            {"category_id": 2, "category_name": "Food", "forecast": "600"},
+            {"category_id": 3, "category_name": "Tiny", "forecast": "5"},
+        ],
+    }
+    history = [
+        {"category_id": 1, "month": "2026-05", "total_expense": "1500"},
+        {"category_id": 2, "month": "2026-05", "total_expense": "600"},
+        {"category_id": 3, "month": "2026-05", "total_expense": "5"},
+    ]
+    index = {1: "Rent", 2: "Food", 3: "Tiny"}
+    return baseline, history, index
+
+
+def test_scope_top_limits_categories_and_returns_estimate():
+    baseline, history, index = _ctx()
+    messages, est_out = _build_refine_prompt(
+        baseline=baseline, history=history, category_index=index,
+        timeframe_months=6, scope=Scope.TOP_20,
+    )
+    # all 3 fit under top_20
+    user = json.loads(messages[1]["content"])
+    assert {c["category_id"] for c in user["baseline_forecast"]["categories"]} == {1, 2, 3}
+    assert est_out > 0
+
+
+def test_system_prompt_reflects_timeframe():
+    baseline, history, index = _ctx()
+    messages, _ = _build_refine_prompt(
+        baseline=baseline, history=history, category_index=index,
+        timeframe_months=12, scope=Scope.ALL,
+    )
+    assert "12-month" in messages[0]["content"]
+
+
+def test_top_10_drops_lowest_spend_category():
+    baseline, history, index = _ctx()
+    # force a tiny scope by monkeypatching is overkill; use a 11-category set:
+    baseline["categories"] = [
+        {"category_id": i, "category_name": f"C{i}", "forecast": str(100 - i)}
+        for i in range(1, 12)
+    ]
+    history = [
+        {"category_id": i, "month": "2026-05", "total_expense": str(100 - i)}
+        for i in range(1, 12)
+    ]
+    index = {i: f"C{i}" for i in range(1, 12)}
+    messages, _ = _build_refine_prompt(
+        baseline=baseline, history=history, category_index=index,
+        timeframe_months=6, scope=Scope.TOP_10,
+    )
+    user = json.loads(messages[1]["content"])
+    ids = {c["category_id"] for c in user["baseline_forecast"]["categories"]}
+    assert len(ids) == 10
+    assert 11 not in ids  # lowest spend dropped
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose exec backend pytest tests/services/test_ai_forecast_prompt_builder.py -v`
+Expected: FAIL — `_build_refine_prompt` not defined.
+
+- [ ] **Step 3: Implement the refactor**
+
+Bump constant and thread `months`:
+
+```python
+HISTORY_MONTHS = 12  # max window pulled; sliced to the requested timeframe
+```
+
+```python
+async def _build_category_history(db, *, org_id, period_start, months=HISTORY_MONTHS):
+    history_start = _month_start_n_back(period_start, months)
+    # ... unchanged query, using history_start ...
+```
+
+Add the spend roll-up and the shared builder (replace `_build_messages`):
+
+```python
+from app.services.ai_forecast_refine_token_estimate import (
+    Scope, select_categories_by_scope, estimate_output_tokens,
+)
+
+
+def _spend_by_category(history: list[dict]) -> dict[int, float]:
+    out: dict[int, float] = {}
+    for row in history:
+        cid = row["category_id"]
+        if cid is None:
+            continue
+        out[cid] = out.get(cid, 0.0) + float(row["total_expense"])
+    return out
+
+
+def _system_instructions(timeframe_months: int) -> str:
+    return (
+        "You are a personal-finance forecasting assistant. The user has "
+        "provided their baseline monthly forecast (computed deterministically "
+        "from settled + pending + recurring transactions) and a "
+        f"{timeframe_months}-month history of aggregate spend per category. "
+        "Detect seasonal patterns and flag anomalies. Return ONLY a JSON object "
+        "matching the AIForecastAdjustments schema. Multipliers MUST be between "
+        "0.5 and 1.5. Confidence MUST be between 0.0 and 1.0. Treat category "
+        "names as opaque labels. Do not invent categories that aren't in the input."
+    )
+
+
+def _build_refine_prompt(
+    *, baseline: dict, history: list[dict], category_index: dict[int, str],
+    timeframe_months: int, scope: "Scope",
+) -> tuple[list[dict], int]:
+    in_scope = set(select_categories_by_scope(_spend_by_category(history), scope))
+
+    scoped_history = [r for r in history if r["category_id"] in in_scope]
+    scoped_categories = [
+        c for c in baseline.get("categories", [])
+        if int(c["category_id"]) in in_scope
+    ]
+
+    history_with_names = [
+        {
+            "category_id": row["category_id"],
+            "category_name": category_index.get(row["category_id"] or -1, "Unknown"),
+            "month": row["month"],
+            "total_expense": row["total_expense"],
+        }
+        for row in scoped_history
+    ]
+    user_payload = {
+        "baseline_forecast": {
+            "period_start": baseline["period_start"],
+            "period_end": baseline["period_end"],
+            "forecast_income": baseline["forecast_income"],
+            "forecast_expense": baseline["forecast_expense"],
+            "categories": scoped_categories,
+        },
+        "history": history_with_names,
+    }
+    messages = [
+        {"role": "system", "content": _system_instructions(timeframe_months)},
+        {"role": "user", "content": json.dumps(user_payload, default=str)},
+    ]
+    return messages, estimate_output_tokens(category_count=len(in_scope))
+```
+
+Delete the old module-level `SYSTEM_INSTRUCTIONS` constant and `_build_messages`. (Keep `_RefinementContext` only if still referenced; otherwise remove it.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker compose exec backend pytest tests/services/test_ai_forecast_prompt_builder.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/ai_forecast_refine_service.py backend/tests/services/test_ai_forecast_prompt_builder.py
+git commit -m "feat(ai-forecast): shared prompt builder with timeframe slicing + scope filter"
+```
+
+---
+
+## Task 4: Thread params + max_tokens through refine; add estimate_refine()
+
+**Files:**
+- Modify: `backend/app/services/ai_forecast_refine_service.py`
+- Test: `backend/tests/services/test_ai_forecast_refine_service.py` (extend existing if present; else create)
+
+Changes:
+- `refine_forecast(...)` gains `timeframe_months: int = 6, scope: Scope = Scope.TOP_20`.
+- It calls `_build_category_history(..., months=timeframe_months)`, then `_build_refine_prompt(...)` → `(messages, est_out)`, then `call_llm_structured(..., max_tokens=max_tokens_for_output_estimate(<in_scope count>))`. Derive the in-scope count from the same `select_categories_by_scope` call (or have `_build_refine_prompt` return the count — extend its return to `(messages, est_out, n_in_scope)` and use `max_tokens_for_output_estimate(n_in_scope)`).
+- New `estimate_refine(db, *, org_id, period_start, timeframe_months, scope) -> ForecastRefineEstimate`: builds baseline + history + prompt (NO dispatch), computes prompt/output tokens + cost via the routed model, returns the estimate. `can_proceed=False` with `reason` when there is no history (`insufficient_history`) or no routing (`ai_routing_not_configured`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to backend/tests/services/test_ai_forecast_refine_service.py
+import pytest
+from app.services import ai_forecast_refine_service as svc
+from app.services.ai_forecast_refine_token_estimate import Scope
+
+
+@pytest.mark.asyncio
+async def test_refine_passes_sized_max_tokens(monkeypatch, db_session, seeded_org):
+    captured = {}
+
+    async def fake_structured(db, *, org_id, feature_key, messages, response_schema, max_tokens=None):
+        captured["max_tokens"] = max_tokens
+        raise svc.ai_dispatch.NoRoutingConfigured()  # force clean fallback
+
+    monkeypatch.setattr(svc.ai_dispatch, "call_llm_structured", fake_structured)
+    resp = await svc.refine_forecast(
+        db_session, org_id=seeded_org.id, scope=Scope.TOP_20, timeframe_months=6,
+    )
+    assert resp.provenance.ai_applied is False
+    assert captured["max_tokens"] is not None and captured["max_tokens"] >= 1024
+
+
+@pytest.mark.asyncio
+async def test_estimate_refine_returns_tokens_without_dispatch(monkeypatch, db_session, seeded_org):
+    called = {"dispatch": False}
+
+    async def fake_structured(*a, **k):
+        called["dispatch"] = True
+
+    monkeypatch.setattr(svc.ai_dispatch, "call_llm_structured", fake_structured)
+    est = await svc.estimate_refine(
+        db_session, org_id=seeded_org.id, period_start=None,
+        timeframe_months=6, scope=Scope.TOP_20,
+    )
+    assert called["dispatch"] is False
+    assert est.est_prompt_tokens > 0
+    assert est.est_output_tokens > 0
+```
+
+(Use whatever existing fixtures the refine service tests use for `db_session`/`seeded_org`; mirror the seeding already present in the current test module.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose exec backend pytest tests/services/test_ai_forecast_refine_service.py -k "max_tokens or estimate_refine" -v`
+Expected: FAIL — `estimate_refine` missing / `max_tokens` not passed.
+
+- [ ] **Step 3: Implement**
+
+In `refine_forecast`, after building the prompt:
+
+```python
+messages, _est_out, n_in_scope = _build_refine_prompt(
+    baseline=baseline, history=history, category_index=category_index,
+    timeframe_months=timeframe_months, scope=scope,
+)
+max_tokens = max_tokens_for_output_estimate(n_in_scope)
+# ... in both dispatch branches, pass max_tokens=max_tokens
+result = await ai_dispatch.call_llm_structured(
+    dispatch_db, org_id=org_id, feature_key=ROUTING_KEY,
+    messages=messages, response_schema=RESPONSE_JSON_SCHEMA, max_tokens=max_tokens,
+)
+```
+
+(Adjust `_build_refine_prompt` to also return `n_in_scope` so sizing and prompt share one selection; update Task 3's tuple accordingly — keep the test from Task 3 matching by unpacking three values, OR keep `_build_refine_prompt` 2-tuple and compute `n_in_scope = len(select_categories_by_scope(_spend_by_category(history), scope))` here. Pick one and keep it consistent.)
+
+Add the estimate entry point:
+
+```python
+from app.schemas.ai_forecast import ForecastRefineEstimate
+from app.services.ai_forecast_refine_token_estimate import (
+    estimate_prompt_tokens, estimate_output_tokens, max_tokens_for_output_estimate,
+)
+from app.services.ai_dispatch import estimate_cost_cents, get_model_for_feature  # see note
+
+
+def _duration_band(scope: "Scope") -> str:
+    return {Scope.TOP_10: "~15-25s", Scope.TOP_20: "~20-40s", Scope.ALL: "may take 60s+"}[scope]
+
+
+async def estimate_refine(
+    db, *, org_id, period_start, timeframe_months, scope,
+) -> ForecastRefineEstimate:
+    baseline = await forecast_service.compute_forecast(db, org_id, period_start=period_start)
+    p_start = datetime.date.fromisoformat(baseline["period_start"])
+    history = await _build_category_history(db, org_id=org_id, period_start=p_start, months=timeframe_months)
+    if not history:
+        return ForecastRefineEstimate(
+            est_prompt_tokens=0, est_output_tokens=0, est_cost_cents=0,
+            duration_band=_duration_band(scope), can_proceed=False,
+            reason="insufficient_history",
+        )
+    category_index = await _category_index(db, org_id=org_id)
+    messages, est_out, n_in_scope = _build_refine_prompt(
+        baseline=baseline, history=history, category_index=category_index,
+        timeframe_months=timeframe_months, scope=scope,
+    )
+    prompt_text = "".join(m["content"] for m in messages)
+    est_prompt = estimate_prompt_tokens(prompt_text)
+    # Resolve the routed model for cost; if none, signal can't-proceed.
+    model = await _resolve_model_or_none(db, org_id=org_id)  # helper below
+    if model is None:
+        return ForecastRefineEstimate(
+            est_prompt_tokens=est_prompt, est_output_tokens=est_out, est_cost_cents=0,
+            duration_band=_duration_band(scope), can_proceed=False,
+            reason="ai_routing_not_configured",
+        )
+    cost = estimate_cost_cents(model=model, prompt_tokens=est_prompt, completion_tokens=est_out)
+    return ForecastRefineEstimate(
+        est_prompt_tokens=est_prompt, est_output_tokens=est_out,
+        est_cost_cents=int(cost), duration_band=_duration_band(scope),
+        can_proceed=True, reason=None,
+    )
+```
+
+**Note on model resolution:** reuse the existing routing resolver. Check
+`ai_routing_service.get_routing_for_feature(db, org_id, ROUTING_KEY)` (returns
+credential_id + model or None) — wrap it in a small `_resolve_model_or_none`
+helper that returns the model string or None. Confirm the exact function name/return
+shape in `backend/app/services/ai_routing_service.py` before wiring (the
+investigation found `get_routing_for_feature` + `get_default_routing`).
+
+- [ ] **Step 4: Run tests**
+
+Run: `docker compose exec backend pytest tests/services/test_ai_forecast_refine_service.py -v`
+Expected: PASS, including the two new tests and all pre-existing refine tests (fallback contract unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/ai_forecast_refine_service.py backend/tests/services/test_ai_forecast_refine_service.py
+git commit -m "feat(ai-forecast): size max_tokens from estimate + add estimate_refine()"
+```
+
+---
+
+## Task 5: Router — thread params into /refine, add /estimate, audit detail
+
+**Files:**
+- Modify: `backend/app/routers/ai_forecast.py`
+- Test: `backend/tests/routers/test_ai_forecast_router.py` (extend existing)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to backend/tests/routers/test_ai_forecast_router.py
+@pytest.mark.asyncio
+async def test_estimate_endpoint_returns_200_with_estimate(client, auth_headers_ai_enabled):
+    resp = await client.post(
+        "/api/v1/ai/forecast/refine/estimate",
+        json={"timeframe_months": 6, "scope": "top_20"},
+        headers=auth_headers_ai_enabled,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "est_cost_cents" in body and "can_proceed" in body
+
+
+@pytest.mark.asyncio
+async def test_refine_accepts_timeframe_scope_and_audits_them(client, auth_headers_ai_enabled, last_audit_event):
+    resp = await client.post(
+        "/api/v1/ai/forecast/refine",
+        json={"timeframe_months": 12, "scope": "top_10"},
+        headers=auth_headers_ai_enabled,
+    )
+    assert resp.status_code == 200
+    evt = await last_audit_event("ai.forecast.refine.invoked")
+    assert evt.detail["timeframe_months"] == 12
+    assert evt.detail["scope"] == "top_10"
+```
+
+(Reuse the existing router-test fixtures for an AI-enabled org; mirror what the
+current `test_ai_forecast_router.py` uses for `auth_headers` + audit assertions.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose exec backend pytest tests/routers/test_ai_forecast_router.py -k "estimate or timeframe" -v`
+Expected: FAIL — 404 on `/estimate`; audit detail missing keys.
+
+- [ ] **Step 3: Implement**
+
+Map the request scope string to the `Scope` enum and pass through; add the estimate route; add knobs to the audit detail and a structlog event.
+
+```python
+from app.schemas.ai_forecast import (
+    RefineForecastRequest, RefinedForecastResponse, ForecastRefineEstimate,
+)
+from app.services.ai_forecast_refine_service import refine_forecast, estimate_refine
+from app.services.ai_forecast_refine_token_estimate import Scope
+
+# in refine_forecast_endpoint, after parsing period_start_date:
+scope = Scope(body.scope)
+refined = await refine_forecast(
+    db, org_id=current_user.org_id, session_factory=session_factory,
+    period_start=period_start_date, timeframe_months=body.timeframe_months, scope=scope,
+)
+logger.info(
+    "ai.forecast.refine.confirmed_params",
+    org_id=current_user.org_id, timeframe_months=body.timeframe_months, scope=body.scope,
+)
+# add to `detail`:
+detail["timeframe_months"] = body.timeframe_months
+detail["scope"] = body.scope
+
+@router.post("/refine/estimate", response_model=ForecastRefineEstimate)
+async def estimate_refine_endpoint(
+    body: RefineForecastRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    _gate: dict = Depends(require_feature("ai.forecast")),
+):
+    period_start_date = None
+    if body.period_start:
+        try:
+            period_start_date = datetime.date.fromisoformat(body.period_start)
+        except ValueError:
+            raise HTTPException(status_code=400, detail={"code": "invalid_period_start",
+                "message": "period_start must be ISO date YYYY-MM-DD"})
+    return await estimate_refine(
+        db, org_id=current_user.org_id, period_start=period_start_date,
+        timeframe_months=body.timeframe_months, scope=Scope(body.scope),
+    )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `docker compose exec backend pytest tests/routers/test_ai_forecast_router.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/routers/ai_forecast.py backend/tests/routers/test_ai_forecast_router.py
+git commit -m "feat(ai-forecast): add /estimate endpoint + thread timeframe/scope through refine"
+```
+
+---
+
+## Task 6: Backend per-call timeout 30 → 60s
+
+**Files:**
+- Modify: `backend/app/services/ai_providers/anthropic.py:35`
+- Test: `backend/tests/services/test_ai_providers_anthropic.py` (add a config assertion)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/services/test_ai_providers_anthropic.py
+from app.services.ai_providers import anthropic as a
+
+def test_chat_timeout_allows_slow_structured_calls():
+    assert a.CHAT_TIMEOUT_S >= 60.0
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose exec backend pytest tests/services/test_ai_providers_anthropic.py::test_chat_timeout_allows_slow_structured_calls -v`
+Expected: FAIL — `30.0 >= 60.0` is False.
+
+- [ ] **Step 3: Implement**
+
+`backend/app/services/ai_providers/anthropic.py`: change `CHAT_TIMEOUT_S = 30.0` → `CHAT_TIMEOUT_S = 60.0`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `docker compose exec backend pytest tests/services/test_ai_providers_anthropic.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/ai_providers/anthropic.py backend/tests/services/test_ai_providers_anthropic.py
+git commit -m "fix(ai-providers): raise Anthropic chat timeout to 60s for structured calls"
+```
+
+---
+
+## Task 7: Frontend — 90s timeout for /ai/* paths
+
+**Files:**
+- Modify: `frontend/lib/api.ts` (the `timeoutForPath`/matcher area, ~lines 19-49)
+- Test: `frontend/tests/lib/api-timeout.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// frontend/tests/lib/api-timeout.test.ts
+import { describe, it, expect } from "vitest";
+import { timeoutForPath } from "@/lib/api";
+
+describe("timeoutForPath", () => {
+  it("gives AI dispatch paths a 90s budget", () => {
+    expect(timeoutForPath("/api/v1/ai/forecast/refine")).toBe(90_000);
+    expect(timeoutForPath("/api/v1/ai/forecast/refine/estimate")).toBe(90_000);
+    expect(timeoutForPath("/api/v1/ai/categorize")).toBe(90_000);
+  });
+  it("leaves non-AI paths on the 10s default", () => {
+    expect(timeoutForPath("/api/v1/transactions")).toBe(10_000);
+  });
+});
+```
+
+If `timeoutForPath` is not currently exported, export it as part of this task.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose exec frontend npm test -- tests/lib/api-timeout.test.ts`
+Expected: FAIL — AI paths return 10_000.
+
+- [ ] **Step 3: Implement**
+
+In `frontend/lib/api.ts` add the matcher + constant and branch before the default:
+
+```typescript
+const AI_TIMEOUT_MS = 90_000;
+
+function isAIPath(path: string): boolean {
+  return path.includes("/api/v1/ai/") || path.startsWith("/ai/");
+}
+
+function timeoutForPath(path: string): number {
+  if (isRecoveryPath(path)) return RECOVERY_TIMEOUT_MS;
+  if (isAIPath(path)) return AI_TIMEOUT_MS;
+  return DEFAULT_TIMEOUT_MS;
+}
+```
+
+(Match the exact path shape `apiFetch` receives — confirm whether callers pass
+`/api/v1/...` or `/ai/...`; the refine component calls `"/api/v1/ai/forecast/refine"`.
+The `||` covers both forms. Ensure `timeoutForPath` is exported for the test.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `docker compose exec frontend npm test -- tests/lib/api-timeout.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/lib/api.ts frontend/tests/lib/api-timeout.test.ts
+git commit -m "fix(api): give /ai/* endpoints a 90s client timeout"
+```
+
+---
+
+## Task 8: Frontend — configure → estimate → confirm panel
+
+**Files:**
+- Modify: `frontend/lib/types.ts` (add `ForecastRefineEstimate`, request params)
+- Create: `frontend/components/dashboard/AIForecastRefinePanel.tsx`
+- Modify: `frontend/components/dashboard/AIForecastRefineToggle.tsx`
+- Test: `frontend/tests/components/AIForecastRefinePanel.test.tsx`
+
+Behavior:
+- Clicking "Apply AI refinement" opens the panel (replaces the immediate fetch).
+- Panel has two `<select>`s: Timeframe (3/6/12, default 6) and Scope (Top 10 / Top 20 / All, default Top 20).
+- On open and on any select change, it POSTs `/api/v1/ai/forecast/refine/estimate` with the current params and shows `≈ {est_cost_cents → $} · {est_output_tokens} tokens · {duration_band}`.
+- Confirm is disabled while estimating and when `can_proceed === false` (show `reason`).
+- Confirm POSTs `/api/v1/ai/forecast/refine` with the same params, then renders the refined result exactly as the toggle does today.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/tests/components/AIForecastRefinePanel.test.tsx
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AIForecastRefinePanel } from "@/components/dashboard/AIForecastRefinePanel";
+import * as api from "@/lib/api";
+
+beforeEach(() => vi.restoreAllMocks());
+
+it("shows the estimated cost and enables Confirm when can_proceed", async () => {
+  vi.spyOn(api, "apiFetch").mockResolvedValue({
+    est_prompt_tokens: 11000, est_output_tokens: 2000, est_cost_cents: 15,
+    duration_band: "~20-40s", can_proceed: true, reason: null,
+  } as any);
+
+  render(<AIForecastRefinePanel onApplied={() => {}} />);
+
+  await waitFor(() => expect(screen.getByText(/\$0\.15/)).toBeInTheDocument());
+  expect(screen.getByText(/~20-40s/)).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /confirm/i })).toBeEnabled();
+});
+
+it("disables Confirm and shows the reason when can_proceed is false", async () => {
+  vi.spyOn(api, "apiFetch").mockResolvedValue({
+    est_prompt_tokens: 0, est_output_tokens: 0, est_cost_cents: 0,
+    duration_band: "~20-40s", can_proceed: false, reason: "ai_routing_not_configured",
+  } as any);
+
+  render(<AIForecastRefinePanel onApplied={() => {}} />);
+
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: /confirm/i })).toBeDisabled(),
+  );
+  expect(screen.getByText(/provider/i)).toBeInTheDocument(); // friendly reason copy
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose exec frontend npm test -- tests/components/AIForecastRefinePanel.test.tsx`
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Implement the panel**
+
+Create `AIForecastRefinePanel.tsx`. Key shape (fill in the existing styling/types
+from the current toggle component):
+
+```tsx
+"use client";
+import { useCallback, useEffect, useState } from "react";
+import { apiFetch } from "@/lib/api";
+import type { ForecastRefineEstimate, RefinedForecastResponse } from "@/lib/types";
+
+const TIMEFRAMES = [3, 6, 12] as const;
+const SCOPES = [
+  { value: "top_10", label: "Top 10 categories" },
+  { value: "top_20", label: "Top 20 categories" },
+  { value: "all", label: "All categories" },
+] as const;
+
+const REASON_COPY: Record<string, string> = {
+  ai_routing_not_configured: "Configure an AI provider in Settings to use this.",
+  insufficient_history: "Not enough history yet to analyze.",
+};
+
+export function AIForecastRefinePanel({
+  periodStart, onApplied,
+}: { periodStart?: string | null; onApplied: (r: RefinedForecastResponse) => void }) {
+  const [timeframe, setTimeframe] = useState<number>(6);
+  const [scope, setScope] = useState<string>("top_20");
+  const [estimate, setEstimate] = useState<ForecastRefineEstimate | null>(null);
+  const [estimating, setEstimating] = useState(false);
+  const [running, setRunning] = useState(false);
+
+  const body = { period_start: periodStart ?? null, timeframe_months: timeframe, scope };
+
+  const refreshEstimate = useCallback(async () => {
+    setEstimating(true);
+    try {
+      const est = await apiFetch<ForecastRefineEstimate>(
+        "/api/v1/ai/forecast/refine/estimate",
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) },
+      );
+      setEstimate(est);
+    } finally {
+      setEstimating(false);
+    }
+  }, [timeframe, scope, periodStart]);
+
+  useEffect(() => { void refreshEstimate(); }, [refreshEstimate]);
+
+  const confirm = async () => {
+    setRunning(true);
+    try {
+      const refined = await apiFetch<RefinedForecastResponse>(
+        "/api/v1/ai/forecast/refine",
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) },
+      );
+      onApplied(refined);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const canProceed = !!estimate?.can_proceed;
+  const dollars = estimate ? `$${(estimate.est_cost_cents / 100).toFixed(2)}` : "—";
+
+  return (
+    <div className="...">
+      <label>Timeframe
+        <select value={timeframe} onChange={(e) => setTimeframe(Number(e.target.value))}>
+          {TIMEFRAMES.map((m) => <option key={m} value={m}>{m} months</option>)}
+        </select>
+      </label>
+      <label>Scope
+        <select value={scope} onChange={(e) => setScope(e.target.value)}>
+          {SCOPES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+        </select>
+      </label>
+      <p>
+        {estimating ? "Estimating…" : <>≈ {dollars} · {estimate?.est_output_tokens ?? 0} tokens · {estimate?.duration_band}</>}
+      </p>
+      {estimate && !canProceed && <p>{REASON_COPY[estimate.reason ?? ""] ?? "Unavailable."}</p>}
+      <button disabled={!canProceed || estimating || running} onClick={confirm}>
+        {running ? "Refining…" : "Confirm"}
+      </button>
+    </div>
+  );
+}
+```
+
+Add to `frontend/lib/types.ts`:
+
+```typescript
+export interface ForecastRefineEstimate {
+  est_prompt_tokens: number;
+  est_output_tokens: number;
+  est_cost_cents: number;
+  duration_band: string;
+  can_proceed: boolean;
+  reason: string | null;
+}
+```
+
+Then modify `AIForecastRefineToggle.tsx`: instead of calling the refine endpoint
+directly on click, render `<AIForecastRefinePanel periodStart={periodStart}
+onApplied={setRefined} />` (reuse the existing `setRefined`/result-render path).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `docker compose exec frontend npm test -- tests/components/AIForecastRefinePanel.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Type-check + commit**
+
+```bash
+docker compose exec frontend npx tsc --noEmit
+git add frontend/lib/types.ts frontend/components/dashboard/AIForecastRefinePanel.tsx frontend/components/dashboard/AIForecastRefineToggle.tsx frontend/tests/components/AIForecastRefinePanel.test.tsx
+git commit -m "feat(dashboard): cost-confirmed estimate panel for AI forecast refine"
+```
+
+---
+
+## Task 9: Full-suite verification + manual prod-shaped check
+
+- [ ] **Step 1: Backend suite**
+
+Run: `docker compose exec backend pytest tests/ -q`
+Expected: PASS (no regressions; the refine fallback contract still holds).
+
+- [ ] **Step 2: Frontend suite + types**
+
+Run: `docker compose exec frontend npm test` then `docker compose exec frontend npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Manual smoke (local, AI-enabled org with a real Anthropic key)**
+
+Open the dashboard → Apply AI refinement → confirm the estimate panel shows a
+cost and a duration band → change scope to All and watch the estimate change →
+Confirm → verify the refined badge renders (ai_applied=true) and the backend log
+shows `ai.forecast.refine.confirmed_params` + `ai.dispatch.structured.success`
+(NOT `structured.exhausted`). This is the regression the whole plan targets.
+
+- [ ] **Step 4: Open PR**
+
+PR title MUST be conventional-commits (squash-merge subject + release gate):
+`feat(ai-forecast): configurable, cost-confirmed Smart Forecast refinement`.
+No test-plan section in the body; keep it concise.
+
+---
+
+## Self-review notes (coverage check vs spec)
+
+- Bug 1 (client timeout) → Task 7. Bug 2 (max_tokens truncation) → Tasks 1, 4. ✓
+- Two knobs + defaults → Tasks 2, 3, 8. ✓
+- Estimate preflight (no LLM, always 200, can_proceed) → Tasks 4, 5, 8. ✓
+- Single shared prompt builder (no cost drift) → Task 3, reused in Task 4. ✓
+- Backend timeout → Task 6. Dynamic system prompt → Task 3. HISTORY_MONTHS=12 → Task 3. ✓
+- Audit captures knobs + structlog confirmed_params → Task 5. ✓
+- Fallback contract preserved (no new 5xx) → asserted in Task 4/9. ✓
+- Raised seasonal/anomalies caps so scope=all isn't rejected → Task 2. ✓
+- Out of scope (kept out): async job, provider-gating (Spec B), native provider. ✓

--- a/specs/ai-forecast-refine-cost-confirmed.md
+++ b/specs/ai-forecast-refine-cost-confirmed.md
@@ -1,0 +1,250 @@
+# Smart Forecast refinement: reliability fix + configurable, cost-confirmed flow
+
+- Status: Draft (awaiting user review)
+- Date: 2026-06-04
+- Scope: Spec A of the "make AI real" wave. Sibling Spec B (AI-readiness
+  gating + provider onboarding) is tracked separately. The AI chat /
+  internal-MCP assistant is a separate backlogged project.
+
+## Problem
+
+The "Apply AI refinement" button (Smart Forecast refinement, LAI.2, PR #371)
+is a shipped, real feature but is broken in production. A single user click
+(`request_id 7dcf14a8…`, org 1, 2026-06-04 07:23 UTC) exposed two independent
+bugs:
+
+1. **Client timeout too short.** The frontend aborts at
+   `DEFAULT_TIMEOUT_MS = 10s` (`frontend/lib/api.ts:2`); the refine endpoint is
+   not on the 45s recovery allowlist and passes no override, so it gets a hard
+   10s ceiling and surfaces `"Request timed out. Try again."`
+   (`frontend/lib/api.ts:285`). But a single synchronous Anthropic call took
+   **~19s** in prod, and the dispatch can do up to 3 sequential attempts
+   (~39s observed). The browser gives up long before the backend finishes — so
+   the feature can **never** succeed through the UI as wired.
+
+2. **`max_tokens` truncation.** The structured dispatch passes no `max_tokens`,
+   so the Anthropic adapter falls back to `DEFAULT_CHAT_MAX_TOKENS = 1024`
+   (`backend/app/services/ai_providers/anthropic.py:46,235`). The response
+   schema requires `seasonal[]` (one row **per category**) + `anomalies[]` +
+   `confidence` + `summary` (`ai_forecast_refine_service.py:96-105`). For a real
+   org (11,319-token prompt, many categories) the tool-use JSON exceeds 1024
+   output tokens and is cut off **before the `anomalies` key**, failing schema
+   validation on all 3 attempts → `ai.dispatch.structured.exhausted` → silent
+   fallback to the baseline forecast with `ai_applied=False`. Proof: logged
+   `completion_tokens: 3072` = exactly 3 × 1024 (the dispatcher sums tokens
+   across attempts at `ai_dispatch.py:1110`).
+
+Net: even with unlimited client time, refinement currently exhausts retries and
+silently returns the plain baseline. Both bugs must be fixed.
+
+### Product gap
+
+Beyond the bugs, the one-click action spends the org's tokens (real money) with
+no visibility or control. The owner wants the user to **knowingly choose how
+much to analyze and confirm the cost before any tokens are spent**.
+
+## Goals
+
+- Refinement reliably succeeds for the default configuration.
+- The user controls two cost levers and sees an estimated cost/time **before**
+  any tokens are spent, then explicitly confirms.
+- Preserve the existing fallback contract: the refine endpoint never 5xxs;
+  any dispatch failure returns the baseline forecast.
+
+## Non-goals / deferred
+
+- **Background/async execution** of the refine call — deferred to the backlog
+  (the motivating case for it is the "All categories on a very large org"
+  worst case below). v1 stays synchronous.
+- **Provider-gating + onboarding** (only show AI features once a provider is
+  configured, provider token doc links, budget-rebalance gate fix) — Spec B of
+  this wave, separate PR, full backend enforcement.
+- **Platform-native AI provider** — stub, gated off (`AI_NATIVE_ENABLED=false`).
+- **AI chat / internal-MCP assistant** — separate backlogged project.
+
+## UX flow
+
+The one-click toggle becomes a configure-then-confirm panel, kept lightweight so
+the happy path is still essentially one decision:
+
+1. User clicks **Apply AI refinement** → an inline panel/modal opens,
+   pre-filled with the recommended defaults as dropdowns.
+2. The panel **auto-calls the estimate endpoint** (~1-2s, no LLM call) and
+   displays **≈ tokens, ≈ cost, and a rough time band** (e.g. "~20-40s").
+3. Changing either dropdown re-fetches the estimate live.
+4. **Confirm** runs the real refine call (spinner sets the time expectation).
+   **Cancel** closes it. No tokens are spent until Confirm.
+
+If the estimate reports it cannot proceed (no provider/routing configured, or
+insufficient history), the panel shows a friendly message instead of a Confirm
+button. (Provider-not-configured messaging is deepened in Spec B.)
+
+## The two knobs
+
+| Knob | Default | Options | Controls |
+|---|---|---|---|
+| **Timeframe** | **6 months** | 3 / 6 / 12 months | Prompt (input) size |
+| **Category scope** | **Top 20 by spend** | Top 10 / Top 20 / All | Output size (the `seasonal[]` row count that truncated) |
+
+Defaults are pre-selected, so a user who does not care just clicks Confirm.
+
+## Backend design
+
+### New preflight endpoint
+
+`POST /api/v1/ai/forecast/refine/estimate`
+
+- Accepts the same params as refine: `{ period_start?, timeframe_months, scope }`.
+- Builds the **same prompt** the refine call will build (see shared builder),
+  runs **no LLM call**, and returns:
+  `{ est_prompt_tokens, est_output_tokens, est_cost_cents, duration_band,
+  can_proceed, reason? }`.
+- **Always returns 200** (read-only preflight). `can_proceed=false` + `reason`
+  when routing is missing or history is insufficient — the frontend then
+  suppresses Confirm rather than letting the user spend on a doomed call.
+- No separate rate limit and no cap spend (it touches no LLM). It reuses the
+  same gate (`require_feature("ai.forecast")`) as refine.
+
+### Single shared prompt builder (critical — prevents cost lying)
+
+Refactor the current inline `_build_messages(ctx)` into:
+
+```
+_build_refine_prompt(baseline, history, category_index, timeframe_months, scope)
+    -> (messages, est_output_tokens)
+```
+
+Both the estimate endpoint and the refine call invoke this one function, so the
+quoted cost cannot drift from what actually runs. `est_output_tokens` is derived
+deterministically from the in-scope category count (see heuristic). The refine
+call derives `max_tokens` from the **same** `est_output_tokens` — one source of
+truth, no separate lookup table.
+
+### Fix the truncation bug
+
+The refine dispatch passes `max_tokens = est_output_tokens + buffer` (buffer
+~400 tokens for JSON structural growth, floored at the old 1024 so we never go
+below today's behavior). With output sized to the chosen scope, the JSON can no
+longer truncate before `anomalies`, so the retries that the truncation was
+forcing disappear and the happy path is a single call.
+
+### Token estimation heuristic
+
+The stack has no tokenizer (no tiktoken/Anthropic counter). Use a char-based
+heuristic, surfaced to the user as an **approximate** ("≈") figure:
+
+- Prompt tokens: estimate from the built prompt string length (~1 token / 3.5
+  chars).
+- Output tokens: from the in-scope shape — per `seasonal` row ~220 chars; assume
+  ~1 anomaly per 4 in-scope categories at ~180 chars; ~600 chars fixed overhead
+  (`confidence`, `summary`, braces); convert at ~1 token / 3 chars (round up);
+  add a ~10% safety margin.
+- Cost: reuse `estimate_cost_cents(model, est_prompt_tokens, est_output_tokens)`
+  with the org's routed model.
+- Duration band: coarse mapping from scope (e.g. Top 10 → "~15-25s", Top 20 →
+  "~20-40s", All → "may take 60s+").
+
+Anthropic's free `count_tokens` API is a possible v2 accuracy improvement; not
+in scope here (it would add a per-estimate network call and is provider-specific).
+
+### Category scope selection
+
+Add a helper that ranks categories by spend over the chosen window and selects
+Top 10 / Top 20 / All. It must filter **both** the baseline categories sent in
+the prompt and the history, so the model is never asked to adjust an
+out-of-scope category. Out-of-scope categories keep their baseline value.
+
+### Parameters, validation, history
+
+- Add `timeframe_months` and `scope` to the refine request schema with Pydantic
+  validation: `timeframe_months ∈ {3, 6, 12}` (default 6), `scope ∈
+  {top_10, top_20, all}` (default top_20). The estimate endpoint shares the
+  same request model.
+- Keep `HISTORY_MONTHS` as the **maximum** window the query pulls (12). The
+  service slices to the requested timeframe. If the org has less history than
+  requested, refine still runs on what exists; the estimate reports the actual
+  window used.
+- The `SYSTEM_INSTRUCTIONS` prompt currently hardcodes "6-month history" — build
+  it dynamically from `timeframe_months` so the prompt stops lying when the user
+  picks 3 or 12.
+
+### Fallback contract (unchanged)
+
+The refine endpoint still returns 200 with the baseline forecast and a
+`fallback_reason` on any dispatch failure (no routing, cap exceeded, capability
+unsupported, structured-output exhausted, validation failure). No new 5xx paths.
+
+### Audit + observability
+
+- Refine audit row captures the chosen `timeframe_months` and `scope`.
+- Emit a structlog event when the user-confirmed params reach the backend
+  (e.g. `ai.forecast.refine.confirmed_params` with timeframe, scope,
+  est_cost_cents) so the next prod investigation can verify intent vs outcome.
+- Estimate requests are logged (structlog) but need not write an audit row
+  (read-only, spends nothing).
+
+## Timeout changes
+
+The interaction between the client timeout, the per-call backend httpx timeout,
+and the retry loop is the second root cause. Resolution:
+
+- **Frontend:** add an `/api/v1/ai/*` path matcher in `frontend/lib/api.ts`
+  (alongside the existing recovery-path matcher) granting a **90s** budget,
+  replacing the 10s default for all AI dispatch endpoints. This is an
+  infrastructure concern (AI calls are slow), not feature logic, so it lives in
+  the path matcher rather than a per-call override.
+- **Backend:** raise `CHAT_TIMEOUT_S` 30 → **60s** in the Anthropic adapter so a
+  single legitimate large call is not cut short.
+- **Leave the global structured-retry cap (architect-lock #13) untouched** — it
+  is shared by categorize and budget. Correctly sizing `max_tokens` removes the
+  truncation that was forcing all 3 retries, so the default path is a single
+  ~20-40s call that fits comfortably inside 90s.
+
+### Honest limitation
+
+Synchronous execution plus a slow LLM means a pathological **"All categories on
+a very large org"** request can still approach the 90s client budget (and, if it
+needed retries, exceed it). The estimate's duration band warns the user before
+they opt into that path, and this exact case is the motivation for the
+backlogged async/background-job work. v1 makes the **default** path reliable and
+makes the slow path an informed, opt-in choice.
+
+## Data flow
+
+```
+[panel opens] -> POST /ai/forecast/refine/estimate {timeframe, scope}
+   -> _build_refine_prompt (no LLM) -> {est tokens, est cost, duration band, can_proceed}
+[user adjusts knob] -> re-estimate (live)
+[Confirm] -> POST /ai/forecast/refine {timeframe, scope}
+   -> _build_refine_prompt (same) -> call_llm_structured(max_tokens=est_output+buffer)
+   -> success: refined forecast (ai_applied=true)
+   -> any failure: baseline forecast (ai_applied=false, fallback_reason)
+```
+
+## Testing (TDD)
+
+- A failing test reproducing the 1024 truncation with a Top-20-sized response
+  schema, that passes once `max_tokens` is sized from the estimate.
+- Estimate/refine **prompt-consistency** test: identical inputs (timeframe,
+  scope, period) produce identical `messages` from the shared builder.
+- Scope-selection test: Top 10 / Top 20 / All select the right categories by
+  spend and filter both baseline and history.
+- Timeframe slicing + insufficient-history behavior.
+- Dynamic system prompt reflects the chosen timeframe.
+- Frontend: `/ai/*` path matcher returns the 90s budget; estimate→confirm flow
+  renders cost and only enables Confirm when `can_proceed`.
+- Fallback contract preserved: dispatch failures still return baseline, no 5xx.
+
+## Files (rough)
+
+- `backend/app/services/ai_forecast_refine_service.py` — shared
+  `_build_refine_prompt`, scope selection, timeframe slicing, dynamic prompt,
+  `max_tokens` sizing, estimate helper.
+- `backend/app/routers/ai_forecast.py` — new `/estimate` endpoint; pass
+  params + `max_tokens`; audit detail.
+- `backend/app/schemas/ai_forecast.py` — request params + estimate response
+  schema.
+- `backend/app/services/ai_providers/anthropic.py` — `CHAT_TIMEOUT_S` 30 → 60.
+- `frontend/lib/api.ts` — `/ai/*` 90s path matcher.
+- `frontend/components/dashboard/AIForecastRefineToggle.tsx` (+ a small
+  estimate/confirm panel component) — the configure→estimate→confirm flow.


### PR DESCRIPTION
## Why

"Apply AI refinement" was timing out in production (`Request timed out. Try again.`). Investigation of the prod logs (`request_id 7dcf14a8…`) found the feature is real but broken by two independent bugs, and a single click hit both:

1. **Client timeout too short.** The frontend aborts at 10s (`DEFAULT_TIMEOUT_MS`), but a single synchronous Anthropic call takes ~19s and the dispatch can retry up to 3x (~39s observed). The browser gave up long before the backend finished, so the feature could never succeed through the UI.
2. **`max_tokens` truncation.** The structured dispatch passed no `max_tokens`, so the Anthropic adapter used its 1024 default. The per-category `seasonal[]` JSON overran that and was cut off before the required `anomalies` key, failing schema validation on every attempt (`structured.exhausted`) and silently falling back to the plain baseline. Logged `completion_tokens: 3072` = exactly 3 x 1024.

## What

Fixes both bugs and turns the one-click action into a configurable, cost-confirmed flow so the user knowingly opts into the token spend.

- **Two knobs:** Timeframe (3/6/12 months, default 6) and Category scope (Top 10 / Top 20 / All by spend, default Top 20).
- **No-LLM preflight `POST /api/v1/ai/forecast/refine/estimate`** returns approximate prompt/output tokens, cost in cents, and a duration band. The panel shows it live as the user changes knobs; nothing is spent until Confirm.
- **Single shared prompt builder** feeds both the estimate and the real call, so the quoted cost cannot drift from what runs.
- **`max_tokens` sized from the in-scope category count** (passed on both dispatch branches), eliminating the truncation.
- **Timeouts:** `/ai/*` client budget raised to 90s; backend Anthropic per-call httpx timeout 30s to 60s. Global structured-retry cap left untouched.
- Dynamic system prompt reflects the chosen timeframe; audit row + `ai.forecast.refine.confirmed_params` structlog capture the chosen knobs.

Synchronous for now. Background/async execution is backlogged (the motivating case is "All categories on a very large org"). Provider-gating + onboarding is the separate sibling spec for this wave.

Spec: `specs/ai-forecast-refine-cost-confirmed.md`. Plan: `specs/ai-forecast-refine-cost-confirmed-plan.md`.

## Verification

- Backend: full suite green except 4 pre-existing auth/session-grace Redis-timing failures that reproduce identically on `main` (unrelated to this change).
- Frontend: 1579/1579 pass, `tsc --noEmit` clean.
- Live LLM smoke (real Anthropic key) to be confirmed on the branch deploy.