### PR TITLE
fix(ai-forecast): sanitize LLM refine output instead of all-or-nothing validation

### DIFF
--- a/backend/app/services/ai_forecast_refine_service.py
+++ b/backend/app/services/ai_forecast_refine_service.py
@@ -413,12 +413,15 @@ def _coerce_adjustments(parsed: Any) -> dict:
     for row in parsed.get("seasonal") or []:
         if not isinstance(row, dict):
             continue
-        try:
-            cid = int(row.get("category_id"))
-        except (TypeError, ValueError):
+        raw_cid = row.get("category_id")
+        if raw_cid is None:
             continue  # a seasonal adjustment is useless without a category id
+        try:
+            cid = int(raw_cid)
+        except (TypeError, ValueError):
+            continue
         name = row.get("category_name")
-        name = str(name) if name is not None else ""
+        name = name if isinstance(name, str) else ""
         if not name:
             continue
         seasonal.append(
@@ -435,7 +438,7 @@ def _coerce_adjustments(parsed: Any) -> dict:
         if not isinstance(row, dict):
             continue
         name = row.get("category_name")
-        name = str(name) if name is not None else ""
+        name = name if isinstance(name, str) else ""
         if not name:
             continue
         try:
@@ -454,9 +457,13 @@ def _coerce_adjustments(parsed: Any) -> dict:
             }
         )
 
+    # Truncate to the AIForecastAdjustments list caps (seasonal<=200,
+    # anomalies<=60) so an over-long list can't fail strict validation and
+    # trigger a full fallback. seasonal is bounded by the <=200 scope ceiling
+    # already (defensive); anomalies can genuinely exceed 60 at Scope.ALL.
     return {
-        "seasonal": seasonal,
-        "anomalies": anomalies,
+        "seasonal": seasonal[:200],
+        "anomalies": anomalies[:60],
         "confidence": _clamp(_as_float(parsed.get("confidence"), 0.5), 0.0, 1.0),
         "summary": str(parsed.get("summary") or "")[:480],
     }
@@ -612,13 +619,14 @@ async def refine_forecast(
             _coerce_adjustments(result.response.parsed)
         )
     except PydanticValidationError as exc:
+        errors = exc.errors()
         logger.warning(
             "ai.forecast.refine.invalid_schema",
             org_id=org_id,
-            error_count=len(exc.errors()),
+            error_count=len(errors),
             error_fields=[
                 {"loc": ".".join(str(p) for p in e["loc"]), "type": e["type"]}
-                for e in exc.errors()[:20]
+                for e in errors[:20]
             ],
         )
         return _baseline_response(

--- a/backend/app/services/ai_forecast_refine_service.py
+++ b/backend/app/services/ai_forecast_refine_service.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import math
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Any, Optional
 
@@ -399,9 +400,14 @@ def _coerce_adjustments(parsed: Any) -> dict:
     """
     def _as_float(v: Any, default: float) -> float:
         try:
-            return float(v)
+            f = float(v)
         except (TypeError, ValueError):
             return default
+        # Reject non-finite (nan/inf): a garbage value should map to the
+        # neutral default (1.0 multiplier / 0.5 confidence), not be absorbed
+        # to a clamp bound. Also avoids relying on _clamp's arg order to
+        # swallow NaN.
+        return f if math.isfinite(f) else default
 
     def _clamp(v: float, lo: float, hi: float) -> float:
         return max(lo, min(hi, v))

--- a/backend/app/services/ai_forecast_refine_service.py
+++ b/backend/app/services/ai_forecast_refine_service.py
@@ -213,8 +213,11 @@ def _system_instructions(timeframe_months: int) -> str:
         f"{timeframe_months}-month history of aggregate spend per category. "
         "Detect seasonal patterns and flag anomalies. Return ONLY a JSON object "
         "matching the AIForecastAdjustments schema. Multipliers MUST be between "
-        "0.5 and 1.5. Confidence MUST be between 0.0 and 1.0. Treat category "
-        "names as opaque labels. Do not invent categories that aren't in the input."
+        "0.5 and 1.5. Confidence MUST be between 0.0 and 1.0. Each rationale MUST "
+        "be under 240 characters and the summary under 480 characters. Each "
+        "anomaly severity MUST be exactly one of: info, warning, alert. Treat "
+        "category names as opaque labels. Do not invent categories that aren't in "
+        "the input."
     )
 
 
@@ -380,6 +383,85 @@ async def _resolve_model_or_none(
     return model
 
 
+def _coerce_adjustments(parsed: Any) -> dict:
+    """Sanitize the model's structured output into a shape the strict
+    ``AIForecastAdjustments`` will accept.
+
+    LLM output is non-deterministic: multipliers drift outside [0.5, 1.5],
+    rationales run long, ``severity`` comes back as a freeform word, numbers
+    arrive as strings. The OLD path validated the raw dict and fell back to
+    baseline on the FIRST violation, discarding the entire refinement (the prod
+    ``ai_response_invalid_schema`` failure, error_count ~= #categories). Instead
+    we clamp/truncate/coerce per field and drop only individual unusable rows,
+    so one stray field never nukes the whole response. Safety is preserved: the
+    multiplier stays bounded to [0.5, 1.5], so the baseline math can't be blown
+    out.
+    """
+    def _as_float(v: Any, default: float) -> float:
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return default
+
+    def _clamp(v: float, lo: float, hi: float) -> float:
+        return max(lo, min(hi, v))
+
+    if not isinstance(parsed, dict):
+        parsed = {}
+
+    seasonal: list[dict] = []
+    for row in parsed.get("seasonal") or []:
+        if not isinstance(row, dict):
+            continue
+        try:
+            cid = int(row.get("category_id"))
+        except (TypeError, ValueError):
+            continue  # a seasonal adjustment is useless without a category id
+        name = row.get("category_name")
+        name = str(name) if name is not None else ""
+        if not name:
+            continue
+        seasonal.append(
+            {
+                "category_id": cid,
+                "category_name": name,
+                "multiplier": _clamp(_as_float(row.get("multiplier"), 1.0), 0.5, 1.5),
+                "rationale": str(row.get("rationale") or "")[:240],
+            }
+        )
+
+    anomalies: list[dict] = []
+    for row in parsed.get("anomalies") or []:
+        if not isinstance(row, dict):
+            continue
+        name = row.get("category_name")
+        name = str(name) if name is not None else ""
+        if not name:
+            continue
+        try:
+            cid = int(row["category_id"]) if row.get("category_id") is not None else None
+        except (TypeError, ValueError):
+            cid = None
+        severity = row.get("severity")
+        if severity not in ("info", "warning", "alert"):
+            severity = "info"
+        anomalies.append(
+            {
+                "category_id": cid,
+                "category_name": name,
+                "description": str(row.get("description") or "")[:240],
+                "severity": severity,
+            }
+        )
+
+    return {
+        "seasonal": seasonal,
+        "anomalies": anomalies,
+        "confidence": _clamp(_as_float(parsed.get("confidence"), 0.5), 0.0, 1.0),
+        "summary": str(parsed.get("summary") or "")[:480],
+    }
+
+
 async def refine_forecast(
     db: AsyncSession,
     *,
@@ -518,17 +600,26 @@ async def refine_forecast(
             baseline=baseline, fallback_reason=f"ai_dispatch_failed:{exc.code}"
         )
 
-    # Validate the parsed JSON against the strict Pydantic shape.
-    # Pydantic rejects out-of-band multipliers (>1.5, <0.5), negative
-    # confidence, missing fields. We never apply an unvalidated dict
-    # to the baseline math.
+    # Sanitize the model output (clamp multipliers, truncate text, coerce
+    # types, drop unusable rows) BEFORE the strict validation, so a single
+    # stray field on one row no longer discards the entire refinement. We
+    # still validate the coerced dict as the final safety gate — if it
+    # somehow fails we log the exact failing fields (loc + type, never the
+    # values, to keep user-typed category names out of the logs) and fall
+    # back, but this should now be unreachable for normal model drift.
     try:
-        adjustments = AIForecastAdjustments.model_validate(result.response.parsed)
+        adjustments = AIForecastAdjustments.model_validate(
+            _coerce_adjustments(result.response.parsed)
+        )
     except PydanticValidationError as exc:
         logger.warning(
             "ai.forecast.refine.invalid_schema",
             org_id=org_id,
             error_count=len(exc.errors()),
+            error_fields=[
+                {"loc": ".".join(str(p) for p in e["loc"]), "type": e["type"]}
+                for e in exc.errors()[:20]
+            ],
         )
         return _baseline_response(
             baseline=baseline,

--- a/backend/tests/routers/test_ai_forecast_refine.py
+++ b/backend/tests/routers/test_ai_forecast_refine.py
@@ -377,12 +377,14 @@ async def test_happy_path_applies_multiplier(session_factory):
 
 
 @pytest.mark.asyncio
-async def test_out_of_band_multiplier_falls_back_to_baseline(session_factory):
-    """LLM returns multiplier=5.0 -> Pydantic rejects -> baseline served.
+async def test_out_of_band_multiplier_is_clamped_not_rejected(session_factory):
+    """LLM returns multiplier=5.0 -> CLAMPED to 1.5 and applied.
 
-    This is the primary safety control: a misbehaving model cannot
-    blow up a forecast line. Out-of-band response triggers a fallback
-    with ``ai_response_invalid_schema``.
+    This is the primary safety control: a misbehaving model cannot blow up
+    a forecast line. We clamp the multiplier into [0.5, 1.5] rather than
+    discarding the entire refinement (the old all-or-nothing validation fell
+    back to baseline on a single out-of-band field, which is how the prod
+    ``ai_response_invalid_schema`` failure nuked every refinement).
     """
     seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
 
@@ -428,10 +430,13 @@ async def test_out_of_band_multiplier_falls_back_to_baseline(session_factory):
         )
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert body["provenance"]["ai_applied"] is False
-    assert body["provenance"]["fallback_reason"] == "ai_response_invalid_schema"
-    # Refined equals baseline because no multiplier was applied.
-    assert body["refined_forecast_expense"] == body["baseline_forecast_expense"]
+    # AI is applied; the rogue 5.0 multiplier was clamped to the 1.5 ceiling.
+    assert body["provenance"]["ai_applied"] is True
+    assert body["provenance"]["fallback_reason"] is None
+    row = next(
+        c for c in body["categories"] if c["category_id"] == seed["category_id"]
+    )
+    assert row["multiplier"] == 1.5  # clamped, never the rogue 5.0
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_ai_forecast_refine_coerce.py
+++ b/backend/tests/services/test_ai_forecast_refine_coerce.py
@@ -60,6 +60,27 @@ def test_coerce_drops_unusable_rows_but_keeps_good_ones():
     assert [s.category_id for s in adj.seasonal] == [9]
 
 
+def test_coerce_truncates_lists_to_schema_caps():
+    # A model returning more rows than the schema allows must NOT trigger a
+    # full fallback; coercion truncates to the AIForecastAdjustments caps.
+    parsed = {
+        "seasonal": [
+            {"category_id": i, "category_name": f"C{i}", "multiplier": 1.0, "rationale": "r"}
+            for i in range(1, 260)  # 259 > 200 cap
+        ],
+        "anomalies": [
+            {"category_id": i, "category_name": f"C{i}", "description": "d", "severity": "info"}
+            for i in range(1, 120)  # 119 > 60 cap
+        ],
+        "confidence": 0.5,
+        "summary": "ok",
+    }
+    coerced = _coerce_adjustments(parsed)
+    adj = AIForecastAdjustments.model_validate(coerced)  # must not raise
+    assert len(adj.seasonal) == 200
+    assert len(adj.anomalies) == 60
+
+
 def test_coerce_supplies_defaults_for_missing_required_fields():
     # Model omits confidence/summary/rationale entirely.
     parsed = {"seasonal": [{"category_id": 1, "category_name": "A", "multiplier": 1.0}]}

--- a/backend/tests/services/test_ai_forecast_refine_coerce.py
+++ b/backend/tests/services/test_ai_forecast_refine_coerce.py
@@ -1,0 +1,70 @@
+"""LAI.2 — the model's structured output is non-deterministic; validation must
+sanitize/clamp it instead of rejecting the whole response on one stray field.
+
+Reproduces the prod failure (`ai_response_invalid_schema`, error_count ~= #cats):
+the dispatch succeeds but strict Pydantic rejected ~1 field per seasonal row,
+nuking the entire refinement to baseline.
+"""
+from app.schemas.ai_forecast import AIForecastAdjustments
+from app.services.ai_forecast_refine_service import _coerce_adjustments
+
+
+def test_coerce_clamps_out_of_range_and_truncates_then_validates():
+    # A realistic "misbehaving" model response that the OLD strict validation
+    # would reject wholesale.
+    parsed = {
+        "seasonal": [
+            # multiplier above the 1.5 cap -> clamp, not reject
+            {"category_id": 1, "category_name": "Rent", "multiplier": 1.8,
+             "rationale": "x" * 500},                       # over 240 chars
+            # multiplier below 0.5 -> clamp up
+            {"category_id": "2", "category_name": "Food", "multiplier": 0.1,
+             "rationale": "down"},                          # category_id as str
+        ],
+        "anomalies": [
+            {"category_id": 3, "category_name": "Travel",
+             "description": "y" * 500, "severity": "critical"},  # bad severity + long
+        ],
+        "confidence": 2.0,                                  # above 1.0
+        "summary": "z" * 1000,                              # over 480
+    }
+
+    coerced = _coerce_adjustments(parsed)
+
+    # The coerced dict must pass the strict model (no fallback).
+    adj = AIForecastAdjustments.model_validate(coerced)
+
+    assert adj.seasonal[0].multiplier == 1.5               # clamped down
+    assert adj.seasonal[1].multiplier == 0.5               # clamped up
+    assert adj.seasonal[1].category_id == 2                # coerced str->int
+    assert len(adj.seasonal[0].rationale) <= 240
+    assert adj.anomalies[0].severity == "info"             # bad sev -> default
+    assert len(adj.anomalies[0].description) <= 240
+    assert adj.confidence == 1.0                            # clamped
+    assert len(adj.summary) <= 480
+
+
+def test_coerce_drops_unusable_rows_but_keeps_good_ones():
+    parsed = {
+        "seasonal": [
+            {"category_name": "NoId", "multiplier": 1.0, "rationale": "r"},   # missing category_id -> drop
+            {"category_id": 9, "category_name": "Keep", "multiplier": 1.1, "rationale": "r"},
+            "not-a-dict",                                                     # junk -> drop
+        ],
+        "anomalies": [],
+        "confidence": 0.7,
+        "summary": "ok",
+    }
+    coerced = _coerce_adjustments(parsed)
+    adj = AIForecastAdjustments.model_validate(coerced)
+    assert [s.category_id for s in adj.seasonal] == [9]
+
+
+def test_coerce_supplies_defaults_for_missing_required_fields():
+    # Model omits confidence/summary/rationale entirely.
+    parsed = {"seasonal": [{"category_id": 1, "category_name": "A", "multiplier": 1.0}]}
+    coerced = _coerce_adjustments(parsed)
+    adj = AIForecastAdjustments.model_validate(coerced)
+    assert adj.seasonal[0].rationale == ""
+    assert 0.0 <= adj.confidence <= 1.0
+    assert isinstance(adj.summary, str)

--- a/backend/tests/services/test_ai_forecast_refine_coerce.py
+++ b/backend/tests/services/test_ai_forecast_refine_coerce.py
@@ -81,6 +81,21 @@ def test_coerce_truncates_lists_to_schema_caps():
     assert len(adj.anomalies) == 60
 
 
+def test_coerce_maps_non_finite_numbers_to_neutral_default():
+    # nan/inf from the model must become the neutral default (multiplier 1.0,
+    # confidence 0.5), not be absorbed to a clamp bound (e.g. 1.5).
+    for bad in ("nan", "inf", "-inf"):
+        parsed = {
+            "seasonal": [{"category_id": 1, "category_name": "A", "multiplier": bad, "rationale": "r"}],
+            "anomalies": [],
+            "confidence": bad,
+            "summary": "ok",
+        }
+        adj = AIForecastAdjustments.model_validate(_coerce_adjustments(parsed))
+        assert adj.seasonal[0].multiplier == 1.0
+        assert adj.confidence == 0.5
+
+
 def test_coerce_supplies_defaults_for_missing_required_fields():
     # Model omits confidence/summary/rationale entirely.
     parsed = {"seasonal": [{"category_id": 1, "category_name": "A", "multiplier": 1.0}]}

--- a/frontend/components/dashboard/AIForecastRefineToggle.tsx
+++ b/frontend/components/dashboard/AIForecastRefineToggle.tsx
@@ -6,6 +6,26 @@ import { ApiResponseError } from "@/lib/api";
 import { card } from "@/lib/styles";
 import { AIForecastRefinePanel } from "@/components/dashboard/AIForecastRefinePanel";
 
+// Friendly copy for the typed backend fallback_reason codes, so the badge
+// never shows a raw code like "ai_response_invalid_schema" to the user.
+const FALLBACK_REASON_COPY: Record<string, string> = {
+  ai_response_invalid_schema: "The AI response could not be applied this time, showing your baseline.",
+  ai_structured_output_failed: "The AI response could not be read, showing your baseline.",
+  ai_routing_not_configured: "Configure an AI provider in Settings to use this.",
+  ai_cap_exceeded: "Your AI usage limit for this period has been reached.",
+  ai_capability_not_supported: "The selected AI provider does not support this feature.",
+  ai_native_not_available: "The built-in AI provider is not available yet.",
+  insufficient_history: "Not enough history yet to analyze.",
+  history_build_failed: "Could not load your history, showing your baseline.",
+};
+
+function fallbackReasonLabel(reason: string | null): string {
+  if (!reason) return "Showing your baseline.";
+  if (FALLBACK_REASON_COPY[reason]) return FALLBACK_REASON_COPY[reason];
+  // ai_dispatch_failed:<code> and any unmapped code -> generic, never raw.
+  return "AI is temporarily unavailable, showing your baseline.";
+}
+
 // Mirrors backend/app/schemas/ai_forecast.RefinedForecastResponse.
 export interface RefinedCategoryRow {
   category_id: number;
@@ -161,7 +181,7 @@ export default function AIForecastRefineToggle({
             </>
           ) : (
             <span data-testid="ai-fallback-reason" className="text-xs">
-              {refined.provenance.fallback_reason ?? "Falling back to baseline"}
+              {fallbackReasonLabel(refined.provenance.fallback_reason)}
             </span>
           )}
         </div>

--- a/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
+++ b/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
@@ -195,9 +195,10 @@ describe("AIForecastRefineToggle - fallback handling", () => {
       expect(screen.getByTestId("ai-fallback-badge")).toBeInTheDocument(),
     );
     expect(screen.queryByTestId("ai-refined-badge")).toBeNull();
-    expect(screen.getByTestId("ai-fallback-reason").textContent).toContain(
-      "ai_routing_not_configured",
-    );
+    // Friendly copy, never the raw code.
+    const reasonText = screen.getByTestId("ai-fallback-reason").textContent ?? "";
+    expect(reasonText).toContain("Configure an AI provider");
+    expect(reasonText).not.toContain("ai_routing_not_configured");
   });
 
   it("hides itself entirely when the estimate call returns a 403 (feature gate closed)", async () => {


### PR DESCRIPTION
## Why

After #394 deployed, "Apply AI refinement" still fell back to baseline with `ai_response_invalid_schema`. Prod logs showed the dispatch **succeeding** (no truncation, the max_tokens fix works) but the strict `AIForecastAdjustments` validation rejecting the whole response (`error_count` ≈ number of categories).

Reproduced against a **real Sonnet 4.6 call** locally — 13 validation errors, all text/enum, not the multiplier range:
- rationale too long (>240) — one per seasonal row
- anomaly description too long (>240) — one per anomaly
- severity outside `{info,warning,alert}` (model returns "high"/"medium"/"critical")
- summary too long (>480)

The old all-or-nothing validation discarded the entire refinement on the first violation.

## What

- **`_coerce_adjustments`** sanitizes the model output before strict validation: clamps multipliers into `[0.5,1.5]`, truncates rationale/description/summary to their limits, defaults an invalid severity to `info`, coerces types, and drops only individual unusable rows. Safety is preserved (multipliers stay bounded); we just stop throwing away good data. Verified: the same real response that produced 13 errors now validates and keeps all rows.
- Enrich the `invalid_schema` log with failing field `loc`+`type` (no values, to keep category names out of logs) so any residual is diagnosable.
- System prompt now asks for concise rationale/summary and a valid severity, reducing wasted tokens on text we would truncate.
- **Frontend:** the fallback badge maps `fallback_reason` codes to friendly copy instead of showing raw codes like `ai_response_invalid_schema`.