### PR TITLE
feat(ai): provider-aware gating + "Set up AI" CTA across AI surfaces

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,7 @@ from app import redis_client
 from app.database import engine
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_ai_usage, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_rate_limit_overrides, admin_roles, admin_subscriptions, admin_users, ai_budget, ai_categorize, ai_forecast, ai_providers, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, settings, subscriptions, tags, transactions, users
+from app.routers import account_types, accounts, admin, admin_ai_usage, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_rate_limit_overrides, admin_roles, admin_subscriptions, admin_users, ai_budget, ai_categorize, ai_forecast, ai_providers, ai_status, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, settings, subscriptions, tags, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -491,6 +491,7 @@ app.include_router(notifications.router)
 app.include_router(reports.router)
 app.include_router(scenarios.router)
 app.include_router(ai_providers.router)
+app.include_router(ai_status.router)
 app.include_router(ai_budget.router)
 app.include_router(ai_categorize.router)
 app.include_router(ai_forecast.router)

--- a/backend/app/routers/ai_budget.py
+++ b/backend/app/routers/ai_budget.py
@@ -16,7 +16,7 @@ instead of crashing.
 from __future__ import annotations
 
 import structlog
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.auth.feature_deps import require_feature
@@ -25,7 +25,12 @@ from app.deps import get_current_user, get_session_factory
 from app.models.user import User
 from app.rate_limit import get_client_ip
 from app.schemas.budget_rebalance import BudgetRebalanceResponse
-from app.services import audit_service, budget_rebalance_service
+from app.services import ai_routing_service, audit_service, budget_rebalance_service
+from app.services.ai_feature_map import ui_to_routing
+
+# Source the routing name from the canonical map so it can't drift from the
+# entitlement/UI mapping (budget_rebalance_service exposes no ROUTING_KEY).
+_ROUTING_KEY = ui_to_routing("budget")
 
 
 logger = structlog.stdlib.get_logger()
@@ -60,6 +65,18 @@ async def rebalance(
     Audit-logged with the structural outcome + suggestion count only;
     no prompt / completion content, no category names.
     """
+    routing = await ai_routing_service.get_routing_for_feature(
+        db, org_id=current_user.org_id, feature_name=_ROUTING_KEY
+    )
+    if routing is None:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={
+                "code": "ai_provider_not_configured",
+                "message": "Configure an AI provider to use this feature.",
+            },
+        )
+
     response = await budget_rebalance_service.suggest_rebalance(
         db,
         org_id=current_user.org_id,

--- a/backend/app/routers/ai_forecast.py
+++ b/backend/app/routers/ai_forecast.py
@@ -8,11 +8,12 @@ so the UI always renders something useful.
 Gating:
 - ``require_feature("ai.forecast")``, the same feature gate the AI
   tier catalog defines. Closed gate returns 403 ``feature_not_enabled``.
-- BYO routing + cap enforcement happen inside
-  ``ai_dispatch.call_llm_structured``. Missing routing /
-  cap-exceeded surface as "fallback to baseline" with a typed reason
-  in ``provenance.fallback_reason``, NOT as a hard error, so the user
-  still gets a usable forecast.
+- No provider configured (no routing) is a precondition failure: the
+  route returns 412 ``ai_provider_not_configured`` BEFORE running.
+- Runtime AI failures (cap exceeded, structured-output exhausted,
+  invalid schema) still surface as "fallback to baseline" with a typed
+  reason in ``provenance.fallback_reason`` (HTTP 200), so the user still
+  gets a usable forecast.
 
 Audit: every call writes an ``ai.forecast.refine.invoked`` event with
 the outcome (``success`` for AI-applied, ``failure`` for fallback) and
@@ -38,8 +39,12 @@ from app.schemas.ai_forecast import (
     RefineForecastRequest,
     RefinedForecastResponse,
 )
-from app.services import audit_service
-from app.services.ai_forecast_refine_service import estimate_refine, refine_forecast
+from app.services import ai_routing_service, audit_service
+from app.services.ai_forecast_refine_service import (
+    ROUTING_KEY,
+    estimate_refine,
+    refine_forecast,
+)
 from app.services.ai_forecast_refine_token_estimate import Scope, _duration_band
 
 
@@ -75,6 +80,18 @@ async def refine_forecast_endpoint(
                     "message": "period_start must be ISO date YYYY-MM-DD",
                 },
             )
+
+    routing = await ai_routing_service.get_routing_for_feature(
+        db, org_id=current_user.org_id, feature_name=ROUTING_KEY
+    )
+    if routing is None:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={
+                "code": "ai_provider_not_configured",
+                "message": "Configure an AI provider to use this feature.",
+            },
+        )
 
     scope = Scope(body.scope)
     refined = await refine_forecast(

--- a/backend/app/routers/ai_status.py
+++ b/backend/app/routers/ai_status.py
@@ -1,0 +1,23 @@
+"""Authenticated endpoint: GET /api/v1/ai/status.
+
+Returns per-feature {entitled, configured} for the current user's org.
+Not in the public allowlist — requires a valid access token.
+"""
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models.user import User
+from app.schemas.ai_status import AIStatusResponse
+from app.services.ai_status_service import get_ai_feature_status
+
+router = APIRouter(prefix="/api/v1/ai", tags=["ai"])
+
+
+@router.get("/status", response_model=AIStatusResponse)
+async def ai_status(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await get_ai_feature_status(db, org_id=current_user.org_id)

--- a/backend/app/schemas/ai_status.py
+++ b/backend/app/schemas/ai_status.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel, StrictBool
+
+
+class AIFeatureState(BaseModel):
+    entitled: StrictBool
+    configured: StrictBool
+
+
+class AIStatusResponse(BaseModel):
+    categorize: AIFeatureState
+    forecast: AIFeatureState
+    budget: AIFeatureState

--- a/backend/app/services/ai_feature_map.py
+++ b/backend/app/services/ai_feature_map.py
@@ -1,0 +1,21 @@
+"""Canonical mapping for the 3 user-facing AI features.
+
+The entitlement key (feature catalog), the routing feature name (dispatch),
+and the UI id all differ. This is the ONE place that triple lives; any drift
+is a bug (guarded by tests/services/test_ai_feature_map.py).
+"""
+from __future__ import annotations
+
+# (entitlement_key, routing_name, ui_id)
+AI_FEATURE_MAP: tuple[tuple[str, str, str], ...] = (
+    ("ai.autocategorize", "categorize_transactions", "categorize"),
+    ("ai.forecast", "smart_forecast", "forecast"),
+    ("ai.budget", "smart_budget", "budget"),
+)
+
+
+def ui_to_routing(ui_id: str) -> str:
+    for _ent, routing, ui in AI_FEATURE_MAP:
+        if ui == ui_id:
+            return routing
+    raise KeyError(ui_id)

--- a/backend/app/services/ai_status_service.py
+++ b/backend/app/services/ai_status_service.py
@@ -1,0 +1,32 @@
+"""AI status service — per-feature {entitled, configured} for the authenticated org.
+
+`configured` is only evaluated when entitled, so an un-entitled org costs
+zero routing lookups.
+"""
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services import ai_routing_service, feature_service
+from app.services.ai_feature_map import AI_FEATURE_MAP
+
+
+async def get_ai_feature_status(
+    db: AsyncSession, *, org_id: int
+) -> dict[str, dict[str, bool]]:
+    """Return per-feature {entitled, configured} keyed by UI id.
+
+    Keys: "categorize", "forecast", "budget".
+    """
+    features = await feature_service.get_features(db, org_id)
+    out: dict[str, dict[str, bool]] = {}
+    for ent_key, routing_name, ui_id in AI_FEATURE_MAP:
+        entitled = bool(features.get(ent_key, False))
+        configured = False
+        if entitled:
+            routing = await ai_routing_service.get_routing_for_feature(
+                db, org_id=org_id, feature_name=routing_name
+            )
+            configured = routing is not None
+        out[ui_id] = {"entitled": entitled, "configured": configured}
+    return out

--- a/backend/app/services/budget_rebalance_service.py
+++ b/backend/app/services/budget_rebalance_service.py
@@ -67,7 +67,14 @@ from app.services.transaction_filters import reportable_transaction_filter
 logger = structlog.stdlib.get_logger()
 
 
-FEATURE_KEY = "ai.budget"
+# The dispatch feature_key MUST be the routable name (``smart_budget``), NOT the
+# entitlement key (``ai.budget``) — same convention as forecast (``smart_forecast``)
+# and categorize (``categorize_transactions``). ``call_llm_structured`` uses this
+# for routing lookup + cap/ledger accounting; using the entitlement key here would
+# silently ignore a per-feature ``smart_budget`` routing override and disagree with
+# the /ai/status gating signal. The 403 entitlement gate (``ai.budget``) lives in
+# the router via ``require_feature``.
+ROUTING_KEY = "smart_budget"
 
 
 # The structured-output schema the LLM must satisfy. ``call_llm_structured``
@@ -416,7 +423,7 @@ async def suggest_rebalance(
                 result = await call_llm_structured(
                     dispatch_db,
                     org_id=org_id,
-                    feature_key=FEATURE_KEY,
+                    feature_key=ROUTING_KEY,
                     messages=messages,
                     response_schema=LLM_RESPONSE_SCHEMA,
                 )
@@ -424,7 +431,7 @@ async def suggest_rebalance(
             result = await call_llm_structured(
                 db,
                 org_id=org_id,
-                feature_key=FEATURE_KEY,
+                feature_key=ROUTING_KEY,
                 messages=messages,
                 response_schema=LLM_RESPONSE_SCHEMA,
             )

--- a/backend/tests/routers/test_ai_budget_router.py
+++ b/backend/tests/routers/test_ai_budget_router.py
@@ -160,6 +160,9 @@ def test_feature_gate_open_returns_typed_response(
         suggestions=[],
     )
     with patch(
+        "app.routers.ai_budget.ai_routing_service.get_routing_for_feature",
+        new=AsyncMock(return_value=(1, "claude-test")),
+    ), patch(
         "app.services.budget_rebalance_service.suggest_rebalance",
         new=AsyncMock(return_value=fake),
     ):
@@ -175,6 +178,10 @@ def test_feature_gate_open_returns_typed_response(
 def test_llm_unavailable_response_still_returns_200(
     session_factory, org_and_user
 ):
+    """llm_unavailable (runtime dispatch failure) returns 200 — the
+    routing precondition passed, so the route reached the service.
+    This pins the contract that only pre-configured routing is 412;
+    a runtime dispatch failure is still a graceful 200 empty-state."""
     org, user = org_and_user
     app = _make_app(
         session_factory,
@@ -192,6 +199,9 @@ def test_llm_unavailable_response_still_returns_200(
         summary="AI rebalance is temporarily unavailable.",
     )
     with patch(
+        "app.routers.ai_budget.ai_routing_service.get_routing_for_feature",
+        new=AsyncMock(return_value=(1, "claude-test")),
+    ), patch(
         "app.services.budget_rebalance_service.suggest_rebalance",
         new=AsyncMock(return_value=fake),
     ):
@@ -227,6 +237,9 @@ def test_audit_row_written_with_outcome_and_count(
         suggestions=[],  # empty but ok status is success outcome
     )
     with patch(
+        "app.routers.ai_budget.ai_routing_service.get_routing_for_feature",
+        new=AsyncMock(return_value=(1, "claude-test")),
+    ), patch(
         "app.services.budget_rebalance_service.suggest_rebalance",
         new=AsyncMock(return_value=fake),
     ):
@@ -278,6 +291,9 @@ def test_audit_row_on_llm_unavailable_is_failure(
         summary="AI temporarily unavailable.",
     )
     with patch(
+        "app.routers.ai_budget.ai_routing_service.get_routing_for_feature",
+        new=AsyncMock(return_value=(1, "claude-test")),
+    ), patch(
         "app.services.budget_rebalance_service.suggest_rebalance",
         new=AsyncMock(return_value=fake),
     ):
@@ -329,6 +345,9 @@ def test_audit_row_on_empty_no_budgets_is_success(
         summary="No budgets are set.",
     )
     with patch(
+        "app.routers.ai_budget.ai_routing_service.get_routing_for_feature",
+        new=AsyncMock(return_value=(1, "claude-test")),
+    ), patch(
         "app.services.budget_rebalance_service.suggest_rebalance",
         new=AsyncMock(return_value=fake),
     ):
@@ -430,6 +449,9 @@ def test_endpoint_never_mutates_budgets_table(
         ],
     )
     with patch(
+        "app.routers.ai_budget.ai_routing_service.get_routing_for_feature",
+        new=AsyncMock(return_value=(1, "claude-test")),
+    ), patch(
         "app.services.budget_rebalance_service.suggest_rebalance",
         new=AsyncMock(return_value=fake),
     ):
@@ -451,3 +473,33 @@ def test_endpoint_never_mutates_budgets_table(
         "POST /rebalance must NEVER mutate the budgets table; "
         f"before={before}, after={after}"
     )
+
+
+# ---------- 412 no-provider precondition --------------------------------
+
+
+def test_rebalance_returns_412_when_no_provider_configured(
+    session_factory, org_and_user
+):
+    """Feature gate open + no routing configured -> 412 ai_provider_not_configured.
+
+    The route must short-circuit with HTTP 412 before invoking the
+    service, so an org that hasn't wired up an AI provider gets a
+    clear actionable error.
+    """
+    _, user = org_and_user
+    app = _make_app(
+        session_factory,
+        features={
+            "ai.budget": True,
+            "ai.forecast": False,
+            "ai.smart_plan": False,
+            "ai.autocategorize": False,
+        },
+        user=user,
+    )
+    # No routing row seeded for this org → precondition fires.
+    client = TestClient(app)
+    res = client.post("/api/v1/ai/budget/rebalance")
+    assert res.status_code == 412
+    assert res.json()["detail"]["code"] == "ai_provider_not_configured"

--- a/backend/tests/routers/test_ai_forecast_refine.py
+++ b/backend/tests/routers/test_ai_forecast_refine.py
@@ -274,12 +274,11 @@ async def test_feature_gate_closed_returns_403(session_factory):
 
 
 @pytest.mark.asyncio
-async def test_no_routing_falls_back_to_baseline(session_factory):
-    """Feature gate open + no AI routing -> baseline with typed reason.
+async def test_no_routing_returns_412(session_factory):
+    """Feature gate open + no AI routing -> 412 ai_provider_not_configured.
 
-    The service must NOT 5xx when routing is missing; it must return
-    the baseline forecast with provenance.ai_applied=False so the UI
-    keeps rendering something useful.
+    The contract changed: missing routing is now a precondition the
+    route enforces (412) rather than a graceful service-level fallback.
     """
     seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
 
@@ -292,14 +291,9 @@ async def test_no_routing_falls_back_to_baseline(session_factory):
         "/api/v1/ai/forecast/refine",
         json={"period_start": seed["period_start"]},
     )
-    assert resp.status_code == 200, resp.text
+    assert resp.status_code == 412, resp.text
     body = resp.json()
-    assert body["provenance"]["ai_applied"] is False
-    assert body["provenance"]["fallback_reason"] == "ai_routing_not_configured"
-    # Baseline still computed correctly.
-    assert body["baseline_forecast_expense"] == body["refined_forecast_expense"]
-    # The seeded category appears in the response with multiplier=1.0.
-    assert any(c["category_id"] == seed["category_id"] for c in body["categories"])
+    assert body["detail"]["code"] == "ai_provider_not_configured"
 
 
 @pytest.mark.asyncio
@@ -353,6 +347,9 @@ async def test_happy_path_applies_multiplier(session_factory):
     app = _make_app(session_factory, resolver)
     client = TestClient(app)
     with patch(
+        "app.routers.ai_forecast.ai_routing_service.get_routing_for_feature",
+        return_value=(1, "claude-test"),
+    ), patch(
         "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
         return_value=fake_response,
     ):
@@ -421,6 +418,9 @@ async def test_out_of_band_multiplier_is_clamped_not_rejected(session_factory):
     app = _make_app(session_factory, resolver)
     client = TestClient(app)
     with patch(
+        "app.routers.ai_forecast.ai_routing_service.get_routing_for_feature",
+        return_value=(1, "claude-test"),
+    ), patch(
         "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
         return_value=fake_response,
     ):
@@ -450,6 +450,9 @@ async def test_structured_output_exhausted_falls_back(session_factory):
     app = _make_app(session_factory, resolver)
     client = TestClient(app)
     with patch(
+        "app.routers.ai_forecast.ai_routing_service.get_routing_for_feature",
+        return_value=(1, "claude-test"),
+    ), patch(
         "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
         side_effect=StructuredOutputError(),
     ):
@@ -541,6 +544,9 @@ async def test_audit_row_written_on_success(session_factory):
     app = _make_app(session_factory, resolver)
     client = TestClient(app)
     with patch(
+        "app.routers.ai_forecast.ai_routing_service.get_routing_for_feature",
+        return_value=(1, "claude-test"),
+    ), patch(
         "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
         return_value=fake_response,
     ):
@@ -563,10 +569,12 @@ async def test_audit_row_written_on_success(session_factory):
 
 
 @pytest.mark.asyncio
-async def test_audit_row_user_state_preconditions_are_success(session_factory):
-    """No-routing / cap-exceeded / insufficient-history are clean
-    preconditions, not system failures. The audit outcome must be
-    'success' for those so ops dashboards aren't polluted with noise."""
+async def test_no_routing_412_writes_no_audit_row(session_factory):
+    """No routing configured → route raises 412 before any audit write.
+
+    The precondition check short-circuits before the service + audit
+    path, so no audit row should be written.
+    """
     seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
 
     async def resolver(_factory):
@@ -574,21 +582,15 @@ async def test_audit_row_user_state_preconditions_are_success(session_factory):
 
     app = _make_app(session_factory, resolver)
     client = TestClient(app)
-    # No routing configured by default in the seed → service returns
-    # 'ai_routing_not_configured', a precondition.
     resp = client.post(
         "/api/v1/ai/forecast/refine",
         json={"period_start": seed["period_start"]},
     )
-    assert resp.status_code == 200
-    assert resp.json()["provenance"]["fallback_reason"] == "ai_routing_not_configured"
+    assert resp.status_code == 412
+    assert resp.json()["detail"]["code"] == "ai_provider_not_configured"
 
     rows = await _audit_rows(session_factory)
-    assert len(rows) == 1
-    assert rows[0].outcome.value == "success", (
-        "ai_routing_not_configured is a user-state precondition, not a system failure"
-    )
-    assert (rows[0].detail or {}).get("fallback_reason") == "ai_routing_not_configured"
+    assert len(rows) == 0, "412 precondition fires before audit — no row expected"
 
 
 @pytest.mark.asyncio
@@ -603,6 +605,9 @@ async def test_audit_row_system_failure_marks_failure(session_factory):
     app = _make_app(session_factory, resolver)
     client = TestClient(app)
     with patch(
+        "app.routers.ai_forecast.ai_routing_service.get_routing_for_feature",
+        return_value=(1, "claude-test"),
+    ), patch(
         "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
         side_effect=StructuredOutputError(),
     ):
@@ -635,6 +640,9 @@ async def test_native_not_available_falls_back_to_baseline(session_factory):
     app = _make_app(session_factory, resolver)
     client = TestClient(app)
     with patch(
+        "app.routers.ai_forecast.ai_routing_service.get_routing_for_feature",
+        return_value=(1, "claude-test"),
+    ), patch(
         "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
         side_effect=NativeNotAvailable(),
     ):
@@ -661,6 +669,9 @@ async def test_cap_exceeded_falls_back_to_baseline(session_factory):
     app = _make_app(session_factory, resolver)
     client = TestClient(app)
     with patch(
+        "app.routers.ai_forecast.ai_routing_service.get_routing_for_feature",
+        return_value=(1, "claude-test"),
+    ), patch(
         "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
         side_effect=AICapExceeded(),
     ):
@@ -685,6 +696,9 @@ async def test_dispatch_failed_falls_back_with_code(session_factory):
     app = _make_app(session_factory, resolver)
     client = TestClient(app)
     with patch(
+        "app.routers.ai_forecast.ai_routing_service.get_routing_for_feature",
+        return_value=(1, "claude-test"),
+    ), patch(
         "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
         side_effect=AIDispatchFailed("connection_error"),
     ):
@@ -709,6 +723,9 @@ async def test_capability_not_supported_falls_back(session_factory):
     app = _make_app(session_factory, resolver)
     client = TestClient(app)
     with patch(
+        "app.routers.ai_forecast.ai_routing_service.get_routing_for_feature",
+        return_value=(1, "claude-test"),
+    ), patch(
         "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
         side_effect=AICapabilityNotSupported(
             capability="structured_output",
@@ -785,20 +802,48 @@ async def test_estimate_endpoint_returns_200_on_unexpected_error(session_factory
 async def test_refine_accepts_timeframe_scope_and_audits_them(session_factory):
     """POST /refine with timeframe_months=12 and scope='top_10' must pass those
     params into the service and write them into the audit detail row.
+
+    Routing is mocked to return a valid routing so the precondition
+    passes and the happy-path (with a mocked dispatch) is exercised.
     """
     seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
 
     async def resolver(_factory):
         return await _get_user(session_factory, seed["owner_id"])
 
+    from app.services.ai_providers.base import StructuredResponse
+    from app.services.ai_dispatch import StructuredDispatchResult
+
+    fake_response = StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed={
+                "seasonal": [],
+                "anomalies": [],
+                "confidence": 0.8,
+                "summary": "ok",
+            },
+            raw_text="{}",
+            prompt_tokens=1,
+            completion_tokens=1,
+            model="m",
+            retries_used=0,
+        ),
+        ledger_id=1,
+    )
+
     app = _make_app(session_factory, resolver)
     client = TestClient(app)
-    # No routing configured → baseline fallback, but the params are still
-    # threaded through and the audit row is still written.
-    resp = client.post(
-        "/api/v1/ai/forecast/refine",
-        json={"timeframe_months": 12, "scope": "top_10"},
-    )
+    with patch(
+        "app.routers.ai_forecast.ai_routing_service.get_routing_for_feature",
+        return_value=(1, "claude-test"),
+    ), patch(
+        "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
+        return_value=fake_response,
+    ):
+        resp = client.post(
+            "/api/v1/ai/forecast/refine",
+            json={"timeframe_months": 12, "scope": "top_10"},
+        )
     assert resp.status_code == 200, resp.text
 
     rows = await _audit_rows(session_factory)
@@ -876,6 +921,9 @@ async def test_endpoint_never_mutates_user_data_tables(session_factory):
     app = _make_app(session_factory, resolver)
     client = TestClient(app)
     with patch(
+        "app.routers.ai_forecast.ai_routing_service.get_routing_for_feature",
+        return_value=(1, "claude-test"),
+    ), patch(
         "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
         return_value=fake_response,
     ):
@@ -892,3 +940,29 @@ async def test_endpoint_never_mutates_user_data_tables(session_factory):
         "POST /refine must NOT mutate Transaction / Category / Budget rows; "
         "this feature is suggestion-only by contract."
     )
+
+
+# ---------- 412 no-provider precondition --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refine_returns_412_when_no_provider_configured(session_factory):
+    """Feature gate open + no routing configured -> 412 ai_provider_not_configured.
+
+    The route must short-circuit with HTTP 412 before calling the service so
+    the user gets a clear actionable error rather than a silent baseline.
+    """
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_f):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    # No routing configured for this org -> precondition fails.
+    resp = client.post(
+        "/api/v1/ai/forecast/refine",
+        json={"timeframe_months": 6, "scope": "top_20"},
+    )
+    assert resp.status_code == 412
+    assert resp.json()["detail"]["code"] == "ai_provider_not_configured"

--- a/backend/tests/routers/test_ai_status.py
+++ b/backend/tests/routers/test_ai_status.py
@@ -1,0 +1,62 @@
+"""Task 2 — unit tests for ai_status_service + a 403 (no-auth) smoke test for the endpoint.
+
+Service tests use monkeypatch to avoid DB/routing round-trips.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.ai_status import router as ai_status_router
+from app.services import ai_status_service
+
+
+@pytest.mark.asyncio
+async def test_get_ai_feature_status_shape(monkeypatch):
+    async def fake_features(db, org_id):
+        return {"ai.autocategorize": True, "ai.forecast": True, "ai.budget": False}
+
+    async def fake_routing(db, *, org_id, feature_name):
+        return (1, "claude-x") if feature_name == "smart_forecast" else None
+
+    monkeypatch.setattr(ai_status_service.feature_service, "get_features", fake_features)
+    monkeypatch.setattr(
+        ai_status_service.ai_routing_service, "get_routing_for_feature", fake_routing
+    )
+    out = await ai_status_service.get_ai_feature_status(None, org_id=1)
+    assert out["categorize"] == {"entitled": True, "configured": False}
+    assert out["forecast"] == {"entitled": True, "configured": True}
+    assert out["budget"] == {"entitled": False, "configured": False}
+
+
+def test_endpoint_requires_auth():
+    """GET /api/v1/ai/status must return 403 (no credentials supplied)."""
+    app = FastAPI()
+    app.include_router(ai_status_router)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/v1/ai/status")
+    # HTTPBearer returns 403 when the Authorization header is absent.
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_not_entitled_skips_routing_lookup(monkeypatch):
+    """Un-entitled features must never trigger a routing lookup (cost guard)."""
+    routing_called: list[str] = []
+
+    async def fake_features(db, org_id):
+        return {"ai.autocategorize": False, "ai.forecast": False, "ai.budget": False}
+
+    async def fake_routing(db, *, org_id, feature_name):
+        routing_called.append(feature_name)
+        return None
+
+    monkeypatch.setattr(ai_status_service.feature_service, "get_features", fake_features)
+    monkeypatch.setattr(
+        ai_status_service.ai_routing_service, "get_routing_for_feature", fake_routing
+    )
+    out = await ai_status_service.get_ai_feature_status(None, org_id=1)
+    assert routing_called == [], "routing should not be called for un-entitled features"
+    for state in out.values():
+        assert state == {"entitled": False, "configured": False}

--- a/backend/tests/services/test_ai_feature_map.py
+++ b/backend/tests/services/test_ai_feature_map.py
@@ -1,0 +1,18 @@
+from app.services.ai_feature_map import AI_FEATURE_MAP, ui_to_routing
+from app.auth.feature_catalog import FeatureKey  # Literal of entitlement keys
+from app.models.org_ai_routing import ROUTABLE_FEATURE_NAMES
+import typing
+
+
+def test_map_keys_align_with_catalog_and_routing():
+    catalog_keys = set(typing.get_args(FeatureKey))
+    for ent_key, routing_name, ui_id in AI_FEATURE_MAP:
+        assert ent_key in catalog_keys, f"{ent_key} missing from feature catalog"
+        assert routing_name in ROUTABLE_FEATURE_NAMES, f"{routing_name} not routable"
+
+
+def test_ui_to_routing_resolves_and_rejects_unknown():
+    assert ui_to_routing("forecast") == "smart_forecast"
+    import pytest
+    with pytest.raises(KeyError):
+        ui_to_routing("nope")

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -17,6 +17,8 @@ import ConfirmModal from "@/components/ui/ConfirmModal";
 import { chartColor } from "@/lib/chart-colors";
 import { BudgetSpentBarShape, type BudgetSpentBarShapeProps } from "@/lib/chart-shapes";
 import { useTransactionAddedListener } from "@/lib/hooks/use-transaction-added";
+import { useAiStatus } from "@/lib/hooks/use-ai-status";
+import { SetUpAiCta } from "@/components/ai/SetUpAiCta";
 import BudgetRebalanceModal from "@/components/budgets/BudgetRebalanceModal";
 
 export default function BudgetsPage() {
@@ -51,6 +53,10 @@ export default function BudgetsPage() {
   // and never auto-applies; user accept/skip per row, then Apply
   // writes via existing PUT /budgets/{id}.
   const [rebalanceOpen, setRebalanceOpen] = useState(false);
+
+  const ai = useAiStatus();
+  const budgetAi = ai?.budget;
+  const role = user?.role ?? null;
 
   const selectedPeriod = periods.length > 0 ? periods[periodIdx] : null;
   const periodStart = selectedPeriod?.start_date ?? "";
@@ -226,14 +232,21 @@ export default function BudgetsPage() {
               From Forecast
             </button>
           )}
-          {isCurrentPeriod && budgets.length > 0 && (
-            <button
-              onClick={() => setRebalanceOpen(true)}
-              className="min-h-[44px] sm:min-h-0 rounded-md border border-border-subtle bg-surface-raised px-4 py-2 text-sm font-medium text-text-primary hover:bg-surface-overlay"
-              data-testid="suggest-rebalance-btn"
-            >
-              Suggest rebalance
-            </button>
+          {isCurrentPeriod && budgets.length > 0 && budgetAi?.entitled && (
+            budgetAi.configured ? (
+              <button
+                onClick={() => setRebalanceOpen(true)}
+                className="min-h-[44px] sm:min-h-0 rounded-md border border-border-subtle bg-surface-raised px-4 py-2 text-sm font-medium text-text-primary hover:bg-surface-overlay"
+                data-testid="suggest-rebalance-btn"
+              >
+                Suggest rebalance
+              </button>
+            ) : (
+              <SetUpAiCta
+                role={role}
+                className="min-h-[44px] sm:min-h-0 rounded-md border border-border-subtle bg-surface-raised px-4 py-2 text-sm font-medium text-text-primary hover:bg-surface-overlay"
+              />
+            )
           )}
           {isCurrentPeriod && availableCategories.length > 0 && (
             <button onClick={() => setShowForm(!showForm)} className={`${btnPrimary} sm:min-h-0`}>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -22,6 +22,8 @@ import UnpairTransferModal from "@/components/transactions/UnpairTransferModal";
 import TagChipInput from "@/components/transactions/TagChipInput";
 import DescriptionAutocomplete from "@/components/transactions/DescriptionAutocomplete";
 import SuggestCategoryButton from "@/components/transactions/SuggestCategoryButton";
+import { SetUpAiCta } from "@/components/ai/SetUpAiCta";
+import { useAiStatus } from "@/lib/hooks/use-ai-status";
 import ResetSortFiltersButton from "@/components/ui/ResetSortFiltersButton";
 import {
   FILTERS_KEY_TRANSACTIONS,
@@ -72,6 +74,9 @@ export default function TransactionsPage() {
 
 function TransactionsPageContent() {
   const { user, loading } = useAuth();
+  const role = user?.role ?? null;
+  const ai = useAiStatus();
+  const categorizeAi = ai?.categorize;
   const searchParams = useSearchParams();
   const urlFiltersSyncedRef = useRef(false);
   const categoryUrlSyncedRef = useRef(false);
@@ -197,12 +202,6 @@ function TransactionsPageContent() {
   const [periods, setPeriods] = useState<{ id: number; start_date: string; end_date: string | null }[]>([]);
   const [periodsLoaded, setPeriodsLoaded] = useState(false);
 
-  // LAI.1: whether the "Suggest category" affordance should show on the
-  // edit row. True when the org has ai.autocategorize enabled AND has at
-  // least one AI credential configured. We fail closed (no button) on any
-  // load error; the backend still gates the endpoint independently.
-  const [aiSuggestAvailable, setAiSuggestAvailable] = useState(false);
-
   // Form
   const [formMode, setFormMode] = useState<"transaction" | "transfer">("transaction");
   const [formAccountId, setFormAccountId] = useState<number | "">("");
@@ -250,28 +249,6 @@ function TransactionsPageContent() {
     setCategories(cats ?? []);
     setPeriods(pers ?? []);
     setPeriodsLoaded(true);
-
-    // LAI.1 visibility probe. We only check the org-level feature
-    // flag here — the credentials-list endpoint
-    // (/api/v1/settings/ai-providers) is admin-gated, so probing it
-    // would 403 for regular org members and hide the affordance from
-    // users who SHOULD see it. The categorize endpoint itself is
-    // gated by the feature flag only; if the org has the feature on
-    // but no credentials configured, the click surfaces a friendly
-    // 412 error (and the button is already soft-fail).
-    //
-    // The backend re-checks the feature gate on every request, so an
-    // adversary cannot escalate by tampering with this probe.
-    try {
-      const sub = await apiFetch<{ plan?: { features?: Record<string, boolean> } }>(
-        "/api/v1/subscriptions",
-      );
-      setAiSuggestAvailable(
-        sub?.plan?.features?.["ai.autocategorize"] === true,
-      );
-    } catch {
-      setAiSuggestAvailable(false);
-    }
   }, []);
 
   const loadTransactions = useCallback(async (p: number) => {
@@ -1465,13 +1442,17 @@ function TransactionsPageContent() {
                             <div>
                               <label htmlFor={`edit-cat-${tx.id}`} className={label}>Category</label>
                               <CategorySelect aria-label="Category" id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
-                              {aiSuggestAvailable && !editPartner ? (
+                              {categorizeAi?.entitled && !editPartner ? (
                                 <div className="mt-1">
-                                  <SuggestCategoryButton
-                                    transactionId={tx.id}
-                                    onSuggested={(s) => setEditCategoryId(s.category_id)}
-                                    testIdPrefix={`ai-suggest-${tx.id}`}
-                                  />
+                                  {categorizeAi.configured ? (
+                                    <SuggestCategoryButton
+                                      transactionId={tx.id}
+                                      onSuggested={(s) => setEditCategoryId(s.category_id)}
+                                      testIdPrefix={`ai-suggest-${tx.id}`}
+                                    />
+                                  ) : (
+                                    <SetUpAiCta role={role} />
+                                  )}
                                 </div>
                               ) : null}
                             </div>
@@ -1766,13 +1747,17 @@ function TransactionsPageContent() {
                               <div>
                                 <label className={label}>Category</label>
                                 <CategorySelect aria-label="Category" id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
-                                {aiSuggestAvailable && !editPartner ? (
+                                {categorizeAi?.entitled && !editPartner ? (
                                   <div className="mt-1">
-                                    <SuggestCategoryButton
-                                      transactionId={tx.id}
-                                      onSuggested={(s) => setEditCategoryId(s.category_id)}
-                                      testIdPrefix={`ai-suggest-mobile-${tx.id}`}
-                                    />
+                                    {categorizeAi.configured ? (
+                                      <SuggestCategoryButton
+                                        transactionId={tx.id}
+                                        onSuggested={(s) => setEditCategoryId(s.category_id)}
+                                        testIdPrefix={`ai-suggest-mobile-${tx.id}`}
+                                      />
+                                    ) : (
+                                      <SetUpAiCta role={role} />
+                                    )}
                                   </div>
                                 ) : null}
                               </div>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1451,7 +1451,10 @@ function TransactionsPageContent() {
                                       testIdPrefix={`ai-suggest-${tx.id}`}
                                     />
                                   ) : (
-                                    <SetUpAiCta role={role} />
+                                    <SetUpAiCta
+                                      role={role}
+                                      className="text-xs text-text-secondary underline hover:text-text-primary"
+                                    />
                                   )}
                                 </div>
                               ) : null}
@@ -1756,7 +1759,10 @@ function TransactionsPageContent() {
                                         testIdPrefix={`ai-suggest-mobile-${tx.id}`}
                                       />
                                     ) : (
-                                      <SetUpAiCta role={role} />
+                                      <SetUpAiCta
+                                        role={role}
+                                        className="text-xs text-text-secondary underline hover:text-text-primary"
+                                      />
                                     )}
                                   </div>
                                 ) : null}

--- a/frontend/components/ai/SetUpAiCta.tsx
+++ b/frontend/components/ai/SetUpAiCta.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import Link from "next/link";
+
+const ADMIN_ROLES = new Set(["owner", "admin"]);
+
+export function SetUpAiCta({ role, className }: { role: string | null; className?: string }) {
+  if (role && ADMIN_ROLES.has(role)) {
+    return (
+      <Link href="/settings/ai-providers" className={className}>
+        Set up AI
+      </Link>
+    );
+  }
+  return (
+    <span className={className} aria-disabled="true">
+      Set up AI (ask your organization admin)
+    </span>
+  );
+}

--- a/frontend/components/dashboard/AIForecastRefineToggle.tsx
+++ b/frontend/components/dashboard/AIForecastRefineToggle.tsx
@@ -103,8 +103,12 @@ export default function AIForecastRefineToggle({
 
   if (!visible || gateBlocked) return null;
 
-  if (forecastAi && !forecastAi.entitled) return null;
-  if (forecastAi && forecastAi.entitled && !forecastAi.configured) {
+  // Fail CLOSED, consistent with the budgets + transactions surfaces: while
+  // useAiStatus() is still resolving (undefined), `!forecastAi?.entitled` is
+  // true, so we render nothing until the gating signal is known (no flash of
+  // the live toggle for non-entitled orgs).
+  if (!forecastAi?.entitled) return null;
+  if (!forecastAi.configured) {
     return (
       <SetUpAiCta
         role={role}

--- a/frontend/components/dashboard/AIForecastRefineToggle.tsx
+++ b/frontend/components/dashboard/AIForecastRefineToggle.tsx
@@ -5,6 +5,9 @@ import { Sparkles, AlertTriangle } from "lucide-react";
 import { ApiResponseError } from "@/lib/api";
 import { card } from "@/lib/styles";
 import { AIForecastRefinePanel } from "@/components/dashboard/AIForecastRefinePanel";
+import { useAiStatus } from "@/lib/hooks/use-ai-status";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { SetUpAiCta } from "@/components/ai/SetUpAiCta";
 
 // Friendly copy for the typed backend fallback_reason codes, so the badge
 // never shows a raw code like "ai_response_invalid_schema" to the user.
@@ -93,7 +96,22 @@ export default function AIForecastRefineToggle({
   const [gateBlocked, setGateBlocked] = useState(false);
   const [tooltipOpen, setTooltipOpen] = useState(false);
 
+  const ai = useAiStatus();
+  const forecastAi = ai?.forecast;
+  const { user } = useAuth();
+  const role = user?.role ?? null;
+
   if (!visible || gateBlocked) return null;
+
+  if (forecastAi && !forecastAi.entitled) return null;
+  if (forecastAi && forecastAi.entitled && !forecastAi.configured) {
+    return (
+      <SetUpAiCta
+        role={role}
+        className="rounded border border-border bg-bg-secondary px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-bg-tertiary disabled:opacity-50"
+      />
+    );
+  }
 
   // When the panel calls onApplied (after a successful Confirm), store the
   // result and close the panel so the refined-result view renders below.

--- a/frontend/lib/hooks/use-ai-status.ts
+++ b/frontend/lib/hooks/use-ai-status.ts
@@ -10,6 +10,9 @@ export function useAiStatus() {
   const { data } = useSWR<AIStatus>("/api/v1/ai/status", (url: string) => apiFetch<AIStatus>(url), {
     shouldRetryOnError: false,
     revalidateOnFocus: false,
+    // Surfaces hide on failure; log so a broken /ai/status is triageable in prod.
+    onError: (err) =>
+      console.warn("useAiStatus: /api/v1/ai/status failed; AI surfaces hidden", err),
   });
   return data;
 }

--- a/frontend/lib/hooks/use-ai-status.ts
+++ b/frontend/lib/hooks/use-ai-status.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import useSWR from "swr";
+import { apiFetch } from "@/lib/api";
+import type { AIStatus } from "@/lib/types";
+
+export function useAiStatus() {
+  // SWR dedupes so all surfaces share one request. AI is opt-in/non-critical,
+  // so failures resolve to undefined (surfaces hide rather than error).
+  const { data } = useSWR<AIStatus>("/api/v1/ai/status", (url: string) => apiFetch<AIStatus>(url), {
+    shouldRetryOnError: false,
+    revalidateOnFocus: false,
+  });
+  return data;
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -796,3 +796,7 @@ export interface RateLimitOverrideListResponse {
   total: number;
 }
 
+// AI readiness gating — PR1
+export interface AIFeatureState { entitled: boolean; configured: boolean }
+export interface AIStatus { categorize: AIFeatureState; forecast: AIFeatureState; budget: AIFeatureState }
+

--- a/frontend/tests/app/budgets-ai-gate.test.tsx
+++ b/frontend/tests/app/budgets-ai-gate.test.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import BudgetsPage from "@/app/budgets/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+import { useAiStatus } from "@/lib/hooks/use-ai-status";
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/lib/hooks/use-ai-status", () => ({
+  useAiStatus: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/budgets",
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner" as const,
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+  allow_manual_balance_adjustment: false,
+};
+
+const PERIOD_OPEN = { id: 1, start_date: "2026-05-01", end_date: null };
+
+const BUDGET = {
+  id: 1,
+  category_id: 10,
+  category_name: "Groceries",
+  amount: "500",
+  spent: "200",
+  percent_used: 40,
+};
+
+function setupAuth(role: string = "owner") {
+  vi.mocked(useAuth).mockReturnValue({
+    user: { ...USER, role } as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  } as never);
+}
+
+function setupApiFetch() {
+  vi.mocked(apiFetch).mockImplementation(async (url: string) => {
+    if (url.startsWith("/api/v1/categories")) return [] as never;
+    if (url.startsWith("/api/v1/settings/billing-periods")) return [PERIOD_OPEN] as never;
+    if (url.startsWith("/api/v1/budgets")) return [BUDGET] as never;
+    return null as never;
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(apiFetch).mockReset();
+  vi.mocked(useAiStatus).mockReset();
+  setupAuth();
+});
+
+describe("Budgets page — AI rebalance button 3-state gating", () => {
+  it("not entitled: renders neither the rebalance button nor Set up AI", async () => {
+    vi.mocked(useAiStatus).mockReturnValue({
+      categorize: { entitled: false, configured: false },
+      forecast: { entitled: false, configured: false },
+      budget: { entitled: false, configured: false },
+    });
+    setupApiFetch();
+
+    render(<BudgetsPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("suggest-rebalance-btn")).toBeNull();
+    });
+    expect(screen.queryByText(/set up ai/i)).toBeNull();
+  });
+
+  it("entitled but not configured: renders Set up AI, no rebalance button", async () => {
+    vi.mocked(useAiStatus).mockReturnValue({
+      categorize: { entitled: false, configured: false },
+      forecast: { entitled: false, configured: false },
+      budget: { entitled: true, configured: false },
+    });
+    setupApiFetch();
+
+    render(<BudgetsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/set up ai/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("suggest-rebalance-btn")).toBeNull();
+  });
+
+  it("entitled and configured: renders the rebalance button, no Set up AI", async () => {
+    vi.mocked(useAiStatus).mockReturnValue({
+      categorize: { entitled: false, configured: false },
+      forecast: { entitled: false, configured: false },
+      budget: { entitled: true, configured: true },
+    });
+    setupApiFetch();
+
+    render(<BudgetsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("suggest-rebalance-btn")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/set up ai/i)).toBeNull();
+  });
+});

--- a/frontend/tests/components/SetUpAiCta.test.tsx
+++ b/frontend/tests/components/SetUpAiCta.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { SetUpAiCta } from "@/components/ai/SetUpAiCta";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/",
+}));
+
+describe("SetUpAiCta", () => {
+  it("admin sees a link to settings", () => {
+    render(<SetUpAiCta role="owner" />);
+    const link = screen.getByRole("link", { name: /set up ai/i });
+    expect(link).toHaveAttribute("href", "/settings/ai-providers");
+  });
+  it("member sees an ask-admin message, no link", () => {
+    render(<SetUpAiCta role="member" />);
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText(/ask your.*admin/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
+++ b/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
@@ -10,7 +10,20 @@ vi.mock("@/lib/api", async () => {
   return { ...actual, apiFetch: vi.fn() };
 });
 
+vi.mock("@/lib/hooks/use-ai-status", () => ({
+  useAiStatus: vi.fn(() => ({
+    forecast: { entitled: true, configured: true },
+    categorize: { entitled: true, configured: true },
+    budget: { entitled: true, configured: true },
+  })),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(() => ({ user: { role: "owner" } })),
+}));
+
 import { apiFetch, ApiResponseError } from "@/lib/api";
+import { useAiStatus } from "@/lib/hooks/use-ai-status";
 
 const mockedFetch = apiFetch as unknown as ReturnType<typeof vi.fn>;
 
@@ -224,5 +237,20 @@ describe("AIForecastRefineToggle - visibility prop", () => {
       <AIForecastRefineToggle periodStart="2026-05-01" visible={false} />,
     );
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("AIForecastRefineToggle - AI status gating", () => {
+  it("shows Set up AI CTA (not the toggle) when entitled but not configured", () => {
+    (useAiStatus as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      forecast: { entitled: true, configured: false },
+      categorize: { entitled: true, configured: true },
+      budget: { entitled: true, configured: true },
+    });
+
+    render(<AIForecastRefineToggle periodStart="2026-05-01" />);
+
+    expect(screen.queryByTestId("ai-forecast-refine-toggle")).toBeNull();
+    expect(screen.getByText(/set up ai/i)).toBeInTheDocument();
   });
 });

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -54,3 +54,12 @@ vi.mock("@/components/notifications/NotificationBell", () => ({
   __esModule: true,
   default: () => null,
 }));
+
+// Same reasoning: AI surfaces call ``useAiStatus`` which fires
+// ``GET /api/v1/ai/status`` via SWR. Default it to ``undefined`` (status
+// unresolved -> AI affordances stay hidden) so ad-hoc ``mockResolvedValueOnce``
+// queues aren't consumed by the status call. Tests that exercise the gating
+// (budgets-ai-gate, ai-forecast-refine-toggle) declare their own ``vi.mock``.
+vi.mock("@/lib/hooks/use-ai-status", () => ({
+  useAiStatus: () => undefined,
+}));

--- a/specs/ai-readiness-gating-onboarding-pr1-plan.md
+++ b/specs/ai-readiness-gating-onboarding-pr1-plan.md
@@ -1,0 +1,571 @@
+# AI Readiness — PR1 (provider-aware gating) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the three AI surfaces render by true state — hidden (not entitled) / "Set up AI" CTA (entitled, no provider) / live action (entitled + configured) — backed by one authenticated AI-status source, and hard-block the routes with 412 when no provider is configured.
+
+**Architecture:** A new authenticated `GET /api/v1/ai/status` returns per-feature `{entitled, configured}`, computed from `feature_service.get_features` + `ai_routing_service.get_routing_for_feature` via a single canonical entitlement↔routing↔UI mapping. The frontend reads it through a `useAiStatus()` SWR hook; a shared `<SetUpAiCta>` renders the role-aware not-configured state on each surface. Forecast + budget routes gain a 412 precondition (categorize already has it).
+
+**Tech Stack:** FastAPI + SQLAlchemy async + Pydantic v2 (backend); Next.js 15 + React 19 + SWR + TS (frontend). Tests: pytest / vitest+RTL.
+
+**Spec:** `specs/ai-readiness-gating-onboarding.md` (note: this plan corrects the spec's `/auth/status` location to a dedicated authenticated `/api/v1/ai/status` — `/auth/status` is public/pre-auth and has no org context).
+
+**Branch:** `feat/ai-readiness-gating-onboarding` (already exists, rebased on `main`; the Spec B + backlog docs are already committed here).
+
+**Test command reminder:** backend `docker compose exec backend pytest <path> -v`; frontend `docker compose exec frontend npm test -- <path>`; types `docker compose exec frontend npx tsc --noEmit`. Default compose project (sequential). Keep tests minimal (operator is compute-capped).
+
+---
+
+## File structure
+
+Backend:
+- `backend/app/services/ai_feature_map.py` — **new**: canonical `AI_FEATURE_MAP` triple (entitlement key, routing name, UI id) + `entitlement_to_routing` / iteration helper. Single source of truth for the name mismatch.
+- `backend/app/services/ai_status_service.py` — **new**: `get_ai_feature_status(db, *, org_id) -> dict[str, dict[str,bool]]`.
+- `backend/app/routers/ai_status.py` — **new**: authenticated `GET /api/v1/ai/status`.
+- `backend/app/schemas/ai_status.py` — **new**: `AIFeatureState`, `AIStatusResponse`.
+- `backend/app/main.py` — register the new router.
+- `backend/app/routers/ai_forecast.py`, `backend/app/routers/ai_budget.py` — add the 412 no-provider precondition.
+
+Frontend:
+- `frontend/lib/types.ts` — `AIFeatureState`, `AIStatus`.
+- `frontend/lib/hooks/use-ai-status.ts` — **new**: `useAiStatus()` SWR hook.
+- `frontend/components/ai/SetUpAiCta.tsx` — **new**: shared role-aware "Set up AI" CTA.
+- `frontend/app/budgets/page.tsx`, `frontend/app/transactions/page.tsx`, `frontend/components/dashboard/AIForecastRefineToggle.tsx` — 3-state wiring.
+
+---
+
+## Task 1: canonical feature mapping + drift guard
+
+**Files:**
+- Create: `backend/app/services/ai_feature_map.py`
+- Test: `backend/tests/services/test_ai_feature_map.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/services/test_ai_feature_map.py
+from app.services.ai_feature_map import AI_FEATURE_MAP, ui_to_routing
+from app.auth.feature_catalog import FeatureKey  # Literal of entitlement keys
+from app.models.org_ai_routing import ROUTABLE_FEATURE_NAMES
+import typing
+
+
+def test_map_keys_align_with_catalog_and_routing():
+    catalog_keys = set(typing.get_args(FeatureKey))
+    for ent_key, routing_name, ui_id in AI_FEATURE_MAP:
+        assert ent_key in catalog_keys, f"{ent_key} missing from feature catalog"
+        assert routing_name in ROUTABLE_FEATURE_NAMES, f"{routing_name} not routable"
+
+
+def test_ui_to_routing_resolves_and_rejects_unknown():
+    assert ui_to_routing("forecast") == "smart_forecast"
+    import pytest
+    with pytest.raises(KeyError):
+        ui_to_routing("nope")
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `docker compose exec backend pytest tests/services/test_ai_feature_map.py -v`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement**
+
+```python
+# backend/app/services/ai_feature_map.py
+"""Canonical mapping for the 3 user-facing AI features.
+
+The entitlement key (feature catalog), the routing feature name (dispatch),
+and the UI id all differ. This is the ONE place that triple lives; any drift
+is a bug (guarded by tests/services/test_ai_feature_map.py).
+"""
+from __future__ import annotations
+
+# (entitlement_key, routing_name, ui_id)
+AI_FEATURE_MAP: tuple[tuple[str, str, str], ...] = (
+    ("ai.autocategorize", "categorize_transactions", "categorize"),
+    ("ai.forecast", "smart_forecast", "forecast"),
+    ("ai.budget", "smart_budget", "budget"),
+)
+
+
+def ui_to_routing(ui_id: str) -> str:
+    for _ent, routing, ui in AI_FEATURE_MAP:
+        if ui == ui_id:
+            return routing
+    raise KeyError(ui_id)
+```
+
+(Confirm `FeatureKey` is importable from `app.auth.feature_catalog` and is a
+`typing.Literal`; if its location differs, import the actual key set the catalog
+exposes. `ROUTABLE_FEATURE_NAMES` is in `app/models/org_ai_routing.py`.)
+
+- [ ] **Step 4: Run, expect PASS**
+
+Run: `docker compose exec backend pytest tests/services/test_ai_feature_map.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/ai_feature_map.py backend/tests/services/test_ai_feature_map.py
+git commit -m "feat(ai): canonical AI feature mapping + drift guard"
+```
+
+---
+
+## Task 2: AI status service + authenticated endpoint
+
+**Files:**
+- Create: `backend/app/services/ai_status_service.py`, `backend/app/schemas/ai_status.py`, `backend/app/routers/ai_status.py`
+- Modify: `backend/app/main.py` (register router)
+- Test: `backend/tests/routers/test_ai_status.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/routers/test_ai_status.py
+import pytest
+from app.services import ai_status_service
+
+
+@pytest.mark.asyncio
+async def test_get_ai_feature_status_shape(monkeypatch):
+    async def fake_features(db, org_id):
+        return {"ai.autocategorize": True, "ai.forecast": True, "ai.budget": False}
+
+    async def fake_routing(db, *, org_id, feature_name):
+        return (1, "claude-x") if feature_name == "smart_forecast" else None
+
+    monkeypatch.setattr(ai_status_service.feature_service, "get_features", fake_features)
+    monkeypatch.setattr(
+        ai_status_service.ai_routing_service, "get_routing_for_feature", fake_routing
+    )
+    out = await ai_status_service.get_ai_feature_status(None, org_id=1)
+    assert out["categorize"] == {"entitled": True, "configured": False}
+    assert out["forecast"] == {"entitled": True, "configured": True}
+    assert out["budget"] == {"entitled": False, "configured": False}
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `docker compose exec backend pytest tests/routers/test_ai_status.py -v`
+Expected: FAIL — `ai_status_service` missing.
+
+- [ ] **Step 3: Implement the service**
+
+```python
+# backend/app/services/ai_status_service.py
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services import ai_routing_service, feature_service
+from app.services.ai_feature_map import AI_FEATURE_MAP
+
+
+async def get_ai_feature_status(
+    db: AsyncSession, *, org_id: int
+) -> dict[str, dict[str, bool]]:
+    """Per-feature {entitled, configured} keyed by UI id. `configured` is only
+    evaluated when entitled, so an un-entitled org costs zero routing lookups.
+    """
+    features = await feature_service.get_features(db, org_id)
+    out: dict[str, dict[str, bool]] = {}
+    for ent_key, routing_name, ui_id in AI_FEATURE_MAP:
+        entitled = bool(features.get(ent_key, False))
+        configured = False
+        if entitled:
+            routing = await ai_routing_service.get_routing_for_feature(
+                db, org_id=org_id, feature_name=routing_name
+            )
+            configured = routing is not None
+        out[ui_id] = {"entitled": entitled, "configured": configured}
+    return out
+```
+
+(Verify `feature_service.get_features(db, org_id)` and
+`ai_routing_service.get_routing_for_feature(db, *, org_id, feature_name)`
+signatures match; adjust the call if positional/kw differs.)
+
+- [ ] **Step 4: Implement schema + endpoint + register**
+
+```python
+# backend/app/schemas/ai_status.py
+from pydantic import BaseModel, StrictBool
+
+
+class AIFeatureState(BaseModel):
+    entitled: StrictBool
+    configured: StrictBool
+
+
+class AIStatusResponse(BaseModel):
+    categorize: AIFeatureState
+    forecast: AIFeatureState
+    budget: AIFeatureState
+```
+
+```python
+# backend/app/routers/ai_status.py
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models.user import User
+from app.schemas.ai_status import AIStatusResponse
+from app.services.ai_status_service import get_ai_feature_status
+
+router = APIRouter(prefix="/api/v1/ai", tags=["ai"])
+
+
+@router.get("/status", response_model=AIStatusResponse)
+async def ai_status(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await get_ai_feature_status(db, org_id=current_user.org_id)
+```
+
+In `backend/app/main.py`, import and `app.include_router(ai_status.router)`
+alongside the other AI routers (match the existing registration style).
+
+- [ ] **Step 5: Run, expect PASS**
+
+Run: `docker compose exec backend pytest tests/routers/test_ai_status.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/ai_status_service.py backend/app/schemas/ai_status.py backend/app/routers/ai_status.py backend/app/main.py backend/tests/routers/test_ai_status.py
+git commit -m "feat(ai): authenticated GET /api/v1/ai/status (entitled+configured per feature)"
+```
+
+---
+
+## Task 3: 412 no-provider precondition on forecast + budget routes
+
+**Files:**
+- Modify: `backend/app/routers/ai_forecast.py` (the `/refine` handler), `backend/app/routers/ai_budget.py` (the `/rebalance` handler)
+- Test: extend `backend/tests/routers/test_ai_forecast_refine.py`
+
+Behavior: before invoking the service, if no routing is configured for the
+feature, raise `HTTPException(412, {"code": "ai_provider_not_configured", ...})`.
+Other (runtime) fallbacks in the service are untouched.
+
+- [ ] **Step 1: Write the failing test** (forecast; mirror existing fixtures)
+
+```python
+# add to backend/tests/routers/test_ai_forecast_refine.py
+@pytest.mark.asyncio
+async def test_refine_returns_412_when_no_provider_configured(session_factory):
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_f):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    # No routing configured for this org -> precondition fails.
+    resp = client.post("/api/v1/ai/forecast/refine",
+                       json={"timeframe_months": 6, "scope": "top_20"})
+    assert resp.status_code == 412
+    assert resp.json()["detail"]["code"] == "ai_provider_not_configured"
+```
+
+(If the existing seed already configures routing, ensure this test path has
+NONE. The existing `no routing -> baseline` test will need updating to the new
+412 contract — update it to assert 412 instead of the baseline fallback.)
+
+- [ ] **Step 2: Run, expect FAIL** (currently returns 200 baseline)
+
+Run: `docker compose exec backend pytest tests/routers/test_ai_forecast_refine.py -k "412" -v`
+
+- [ ] **Step 3: Implement** — in `ai_forecast.py` `refine_forecast_endpoint`, before the `refine_forecast(...)` call:
+
+```python
+from app.services import ai_routing_service
+from app.services.ai_forecast_refine_service import ROUTING_KEY  # "smart_forecast"
+
+routing = await ai_routing_service.get_routing_for_feature(
+    db, org_id=current_user.org_id, feature_name=ROUTING_KEY
+)
+if routing is None:
+    raise HTTPException(
+        status_code=status.HTTP_412_PRECONDITION_FAILED,
+        detail={"code": "ai_provider_not_configured",
+                "message": "Configure an AI provider to use this feature."},
+    )
+```
+
+Apply the same precondition in `ai_budget.py`'s rebalance handler using its
+routing key (`"smart_budget"`). (Use each router's existing routing-key constant
+if present; otherwise the literal.)
+
+Also update the pre-existing forecast "no routing -> baseline" router test to
+expect 412 (the contract changed by design).
+
+- [ ] **Step 4: Run, expect PASS**
+
+Run: `docker compose exec backend pytest tests/ -k "ai_forecast or ai_budget" -q`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/routers/ai_forecast.py backend/app/routers/ai_budget.py backend/tests/routers/test_ai_forecast_refine.py
+git commit -m "feat(ai): 412 ai_provider_not_configured on forecast+budget when no provider routed"
+```
+
+---
+
+## Task 4: frontend `useAiStatus` hook + shared `SetUpAiCta`
+
+**Files:**
+- Modify: `frontend/lib/types.ts`
+- Create: `frontend/lib/hooks/use-ai-status.ts`, `frontend/components/ai/SetUpAiCta.tsx`
+- Test: `frontend/tests/components/SetUpAiCta.test.tsx`
+
+- [ ] **Step 1: Types**
+
+```typescript
+// frontend/lib/types.ts
+export interface AIFeatureState { entitled: boolean; configured: boolean }
+export interface AIStatus { categorize: AIFeatureState; forecast: AIFeatureState; budget: AIFeatureState }
+```
+
+- [ ] **Step 2: Hook** (match the app's existing SWR hook style under `frontend/lib/hooks/`; if none exist, this is the pattern)
+
+```typescript
+// frontend/lib/hooks/use-ai-status.ts
+import useSWR from "swr";
+import { apiFetch } from "@/lib/api";
+import type { AIStatus } from "@/lib/types";
+
+export function useAiStatus() {
+  // SWR dedupes so all surfaces share one request. AI is opt-in/non-critical,
+  // so failures resolve to undefined (surfaces hide rather than error).
+  const { data } = useSWR<AIStatus>("/api/v1/ai/status", (url) => apiFetch<AIStatus>(url), {
+    shouldRetryOnError: false,
+    revalidateOnFocus: false,
+  });
+  return data;
+}
+```
+
+- [ ] **Step 3: Write the failing test for SetUpAiCta**
+
+```tsx
+// frontend/tests/components/SetUpAiCta.test.tsx
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { SetUpAiCta } from "@/components/ai/SetUpAiCta";
+
+describe("SetUpAiCta", () => {
+  it("admin sees a link to settings", () => {
+    render(<SetUpAiCta role="owner" />);
+    const link = screen.getByRole("link", { name: /set up ai/i });
+    expect(link).toHaveAttribute("href", "/settings/ai-providers");
+  });
+  it("member sees an ask-admin message, no link", () => {
+    render(<SetUpAiCta role="member" />);
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText(/ask your.*admin/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 4: Run, expect FAIL**
+
+Run: `docker compose exec frontend npm test -- tests/components/SetUpAiCta.test.tsx`
+
+- [ ] **Step 5: Implement the component**
+
+```tsx
+// frontend/components/ai/SetUpAiCta.tsx
+import Link from "next/link";
+
+const ADMIN_ROLES = new Set(["owner", "admin"]);
+
+export function SetUpAiCta({ role, className }: { role: string | null; className?: string }) {
+  if (role && ADMIN_ROLES.has(role)) {
+    return (
+      <Link href="/settings/ai-providers" className={className}>
+        Set up AI
+      </Link>
+    );
+  }
+  return (
+    <span className={className} aria-disabled="true">
+      Set up AI (ask your organization admin)
+    </span>
+  );
+}
+```
+
+(Match the existing button/link Tailwind classes used by the surfaces; the
+caller passes `className`. Keep copy em-dash-free.)
+
+- [ ] **Step 6: Run, expect PASS** + commit
+
+Run: `docker compose exec frontend npm test -- tests/components/SetUpAiCta.test.tsx`
+```bash
+git add frontend/lib/types.ts frontend/lib/hooks/use-ai-status.ts frontend/components/ai/SetUpAiCta.tsx frontend/tests/components/SetUpAiCta.test.tsx
+git commit -m "feat(ai): useAiStatus hook + shared SetUpAiCta (role-aware)"
+```
+
+---
+
+## Task 5: budget rebalance surface — 3-state
+
+**Files:**
+- Modify: `frontend/app/budgets/page.tsx` (the Suggest-rebalance button block, ~lines 229-237)
+- Test: `frontend/tests/app/budgets-ai-gate.test.tsx` (one focused test)
+
+Replace the ungated button with the 3-state. Read `useAiStatus()` + `useAuth().user?.role`.
+
+- [ ] **Step 1: Implement** — replace the existing block:
+
+```tsx
+// near other hooks in budgets/page.tsx:
+const ai = useAiStatus();
+const role = /* from useAuth() */ null;
+const budgetAi = ai?.budget;
+
+// in the toolbar, replacing the old `{isCurrentPeriod && budgets.length > 0 && (<button…/>)}`:
+{isCurrentPeriod && budgets.length > 0 && budgetAi?.entitled && (
+  budgetAi.configured ? (
+    <button onClick={() => setRebalanceOpen(true)} className="<existing classes>"
+            data-testid="suggest-rebalance-btn">
+      Suggest rebalance
+    </button>
+  ) : (
+    <SetUpAiCta role={role} className="<existing classes>" />
+  )
+)}
+```
+
+(Get `role` from the auth context — find how `budgets/page.tsx` or a sibling
+reads the current user; reuse that. Keep the existing button classes verbatim.)
+
+- [ ] **Step 2: Failing test → implement → pass** (one test, mocking the hook)
+
+```tsx
+// frontend/tests/app/budgets-ai-gate.test.tsx — mock useAiStatus + auth, render the toolbar
+// Assert: not-entitled -> no suggest-rebalance-btn and no Set up AI;
+//         entitled+!configured -> "Set up AI" shown, no suggest-rebalance-btn;
+//         entitled+configured -> suggest-rebalance-btn shown.
+```
+
+Mock `@/lib/hooks/use-ai-status` and the auth hook. Mirror the mocking style of
+existing `frontend/tests/app/budgets-*.test.tsx`.
+
+- [ ] **Step 3: tsc + commit**
+
+```bash
+docker compose exec frontend npx tsc --noEmit
+git add frontend/app/budgets/page.tsx frontend/tests/app/budgets-ai-gate.test.tsx
+git commit -m "feat(budgets): provider-aware 3-state gating for Suggest rebalance"
+```
+
+---
+
+## Task 6: transactions categorize surface — 3-state + delete the bespoke probe
+
+**Files:**
+- Modify: `frontend/app/transactions/page.tsx` (the `ai.autocategorize` probe ~254-274; the `SuggestCategoryButton` render sites ~1470, ~1771)
+
+- [ ] **Step 1: Implement** — delete the `/api/v1/subscriptions` probe + its state; derive visibility from `useAiStatus()`:
+
+```tsx
+const ai = useAiStatus();
+const categorizeAi = ai?.categorize;
+// remove: the useEffect that fetched /api/v1/subscriptions and set the
+// `ai.autocategorize` boolean, plus that piece of state.
+```
+
+At each `SuggestCategoryButton` site, branch:
+```tsx
+{categorizeAi?.entitled && (
+  categorizeAi.configured
+    ? <SuggestCategoryButton ... />
+    : <SetUpAiCta role={role} className="<existing inline classes>" />
+)}
+```
+
+(Keep the button's existing props/behavior; only the wrapper changes. Reuse the
+same `role` source as Task 5.)
+
+- [ ] **Step 2: Run the existing transactions tests** (ensure the probe removal didn't break them) → fix mocks if they referenced `/subscriptions`:
+
+Run: `docker compose exec frontend npm test -- tests/app/transactions-page.test.tsx`
+
+- [ ] **Step 3: tsc + commit**
+
+```bash
+docker compose exec frontend npx tsc --noEmit
+git add frontend/app/transactions/page.tsx
+git commit -m "feat(transactions): provider-aware gating for Suggest category; drop bespoke subscriptions probe"
+```
+
+---
+
+## Task 7: forecast refine surface — 3-state
+
+**Files:**
+- Modify: `frontend/components/dashboard/AIForecastRefineToggle.tsx`
+
+Today the toggle hides on a 403 from the estimate call. Add the up-front state
+read so an entitled-but-unconfigured org sees the CTA instead of the live toggle.
+
+- [ ] **Step 1: Implement** — at the top of the component:
+
+```tsx
+const ai = useAiStatus();
+const forecastAi = ai?.forecast;
+const role = /* same role source */ null;
+
+// after the existing `if (!visible || gateBlocked) return null;`:
+if (forecastAi && !forecastAi.entitled) return null;
+if (forecastAi && forecastAi.entitled && !forecastAi.configured) {
+  return <SetUpAiCta role={role} className="<existing toggle button classes>" />;
+}
+// else: existing toggle/panel flow (entitled + configured, or status still loading)
+```
+
+(Keep the existing estimate/confirm/refine flow for the configured case. The
+existing 403 self-hide stays as a backstop.)
+
+- [ ] **Step 2: Run the toggle test** (update mocks if needed so `useAiStatus` returns configured for the happy-path tests):
+
+Run: `docker compose exec frontend npm test -- tests/components/dashboard/ai-forecast-refine-toggle.test.tsx`
+
+- [ ] **Step 3: tsc + commit**
+
+```bash
+docker compose exec frontend npx tsc --noEmit
+git add frontend/components/dashboard/AIForecastRefineToggle.tsx frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
+git commit -m "feat(dashboard): provider-aware 3-state for AI forecast refine"
+```
+
+---
+
+## Task 8: full-suite verification + PR
+
+- [ ] **Step 1:** `docker compose exec backend pytest tests/ -q` (note the 4 pre-existing auth/session-grace failures that also fail on main; everything else green).
+- [ ] **Step 2:** `docker compose exec frontend npm test` then `docker compose exec frontend npx tsc --noEmit` — green/clean.
+- [ ] **Step 3: Manual smoke (local, has the Anthropic credential):** with a provider configured, all 3 surfaces show the live action. Temporarily remove the default routing (or test an org without it) → surfaces show "Set up AI"; a direct `POST /ai/forecast/refine` returns 412 `ai_provider_not_configured`.
+- [ ] **Step 4: Open PR** titled `feat(ai): provider-aware gating + "Set up AI" CTA across AI surfaces`. Concise body, no test-plan section.
+
+---
+
+## Self-review (coverage vs spec)
+
+- `ai` status source of truth → Tasks 1-2 (corrected to authenticated `/api/v1/ai/status`). ✓
+- Canonical mapping + drift guard → Task 1. ✓
+- 3-state on all 3 surfaces + role-aware CTA → Tasks 4-7. ✓
+- Budget-rebalance gate fix → Task 5. ✓
+- Delete bespoke `/subscriptions` probe → Task 6. ✓
+- 412 enforcement (forecast+budget; categorize already) → Task 3. ✓
+- No migrations; tests minimal. ✓
+- Deferred to PR2: help tooltips, `/docs` section, provider doc links, label rename. (Not in this plan.)

--- a/specs/ai-readiness-gating-onboarding.md
+++ b/specs/ai-readiness-gating-onboarding.md
@@ -1,0 +1,169 @@
+# AI readiness: gating, "Set up AI" CTA, discoverability & onboarding
+
+- Status: Draft (awaiting user review)
+- Date: 2026-06-04
+- Scope: Spec B of the "make AI real" wave. Sibling to the merged Spec A
+  (forecast-refine reliability, #394) and the in-flight #395 (lenient LLM-output
+  validation). The AI chat / internal-MCP assistant remains a separate backlog
+  project (`specs/ai-assistant-mcp-chat-backlog.md`).
+
+## Problem
+
+The three shipped AI features are scattered, undiscoverable, and not clearly
+gated:
+
+- **Auto-categorize** ("✨ Suggest category", transactions edit row) is hidden
+  unless `ai.autocategorize` is entitled — so an org without that flag never
+  learns it exists.
+- **Forecast refine** ("Apply AI refinement", dashboard) — the label is vague
+  and has no help.
+- **Budget rebalance** ("Suggest rebalance", budgets toolbar) renders
+  **ungated** — it shows even when the org isn't entitled and no provider is
+  configured, then dead-ends.
+
+Worse, **entitlement and provider-configured are independent layers**: a feature
+flag can be ON while the org has no routed AI provider, so an affordance appears
+but the action fails. There's no single signal for "is this feature actually
+usable", no guidance to set up a provider, and no in-app docs.
+
+## Goals
+
+- One server-computed source of truth for each AI feature's real state.
+- Each AI surface renders one of three clear states, consistently.
+- When a feature is entitled but no provider is configured, guide the user to
+  set one up (role-aware), instead of hiding it or letting it dead-end.
+- Make the features discoverable and self-explanatory (help + docs).
+- Smooth provider onboarding (where to get an API key).
+
+## Non-goals / deferred
+
+- A central "AI hub" page (chose in-context + docs instead).
+- Payments / plan-upsell messaging for not-entitled orgs (payments parked).
+- The platform-native managed provider (still a stub, gated off).
+- Live config invalidation: `/auth/status` is read at mount, so after
+  configuring a provider the user reloads to see surfaces flip CTA → live.
+  Documented limitation, acceptable for v1.
+- AI chat / internal-MCP assistant (separate backlog project).
+
+## Decisions (frozen)
+
+1. **Not-configured state → "Set up AI" CTA** (not hidden), role-aware.
+2. **Discoverability via in-context help tooltips + a `/docs` section** (reuse
+   the existing help system); no central hub.
+3. **Hard-block all 3 routes with 412** on the *no-provider precondition* —
+   forecast/budget join categorize in returning `412 ai_provider_not_configured`
+   when routing is missing. Genuine *runtime* AI failures (cap exceeded, LLM
+   error, invalid schema) still return 200 + a usable baseline (the Spec A/#395
+   fallback contract is preserved). Frontend gating means users never hit the
+   412 from the UI; it's contract-hardening for direct/stale callers.
+4. **Two focused PRs** (functional core, then discoverability).
+
+## Architecture
+
+### Foundation — `ai` block on `GET /api/v1/auth/status`
+
+`/auth/status` is already fetched once at mount by `AuthProvider`. Add an `ai`
+map giving each feature's true state:
+
+```json
+"ai": {
+  "categorize": {"entitled": true,  "configured": false},
+  "forecast":   {"entitled": true,  "configured": true},
+  "budget":     {"entitled": false, "configured": false}
+}
+```
+
+- `entitled` ← `feature_service.get_features(db, org_id)[<entitlement_key>]`.
+- `configured` ← `ai_routing_service.get_routing_for_feature(db, org_id,
+  <routing_name>) is not None`. Only evaluated when `entitled` is true, so an
+  un-entitled org costs zero routing lookups; a fully-entitled org costs ≤3
+  indexed lookups on a call that already runs once per session.
+
+### Canonical feature mapping (kills the key-name drift)
+
+The entitlement key, routing name, and UI id differ
+(`ai.autocategorize`/`categorize_transactions`/`categorize`). Put the single
+canonical triple in **one** backend module (e.g.
+`backend/app/auth/ai_feature_map.py`), consumed by the status helper and any
+route that needs it, plus a tiny **drift-guard test** asserting every
+entitlement key is in the feature catalog and every routing name is in
+`ROUTABLE_FEATURE_NAMES`. The frontend mirrors the UI ids only.
+
+### Frontend — the 3-state pattern (reused on all 3 surfaces)
+
+`AuthProvider` exposes `ai` (from status) and the existing `user.role`. Each AI
+affordance branches:
+
+| State | Condition | Renders |
+|---|---|---|
+| Hidden | `!entitled` | nothing |
+| **Set up AI** | `entitled && !configured` | a CTA. **owner/admin** → links to Settings → AI Providers. **member** → disabled control + tooltip "Ask your org admin to set up an AI provider." |
+| Live | `entitled && configured` | the real AI action |
+
+This **fixes the budget-rebalance gate** (it joins the pattern) and **makes
+auto-categorize discoverable** (CTA instead of silent hide). It also **removes
+the bespoke `/api/v1/subscriptions` probe** the transactions page does today —
+visibility now comes from `useAuth().ai`.
+
+### Backend — full enforcement (precondition 412)
+
+Each AI route already calls `require_feature(...)` (→403 if not entitled). Add:
+on `get_routing_for_feature(...) is None`, return **`412` with code
+`ai_provider_not_configured`** — categorize already does this; convert
+forecast's and budget's "no routing → graceful fallback" branch to the 412.
+Every *other* fallback branch (cap, capability, structured-exhausted, invalid
+schema) stays as a 200 baseline/empty result. The forecast service's broad
+fallback contract is otherwise untouched.
+
+### Discoverability — help + docs (reuse existing system)
+
+- A **`HelpTooltip`** (info icon) beside each of the 3 AI actions:
+  `ai.categorize` / `ai.forecast` / `ai.budget` entries in
+  `frontend/lib/help/tooltips.ts`, each stating what the feature does and that
+  it uses the org's configured AI provider (tokens cost money), with
+  `learnMoreSection: "ai-features"` deep-linking to docs.
+- A new **"AI features"** section in `frontend/app/docs/page.tsx` (add to the
+  `sections` array + a `<section id="ai-features">` block): setup prerequisite
+  (configure a provider), then one subsection per feature.
+- Rename the vague **"Apply AI refinement"** to something clearer (e.g. "Refine
+  forecast with AI") alongside its tooltip.
+
+### Onboarding — provider doc links
+
+In the Settings → AI Providers add-credential form, render a per-provider
+**"Get an API key →"** link based on the selected provider:
+`anthropic` → console.anthropic.com keys, `openai` → platform.openai.com keys,
+`ollama` → ollama.ai download, `openai_compatible` → a generic
+OpenAI-compatible-server doc. (URLs centralized in one map with a "may drift"
+note.)
+
+## PR breakdown
+
+**PR 1 — functional core** (`feat(ai): provider-aware gating + Set up AI CTA`)
+- `ai_feature_map.py` + drift-guard test.
+- `ai` block on `/auth/status` (+ Pydantic schema) and its helper.
+- `AuthProvider` exposes `ai` + `role`.
+- 3-state rendering on all 3 surfaces (categorize, forecast toggle, budget
+  rebalance); delete the transactions `/subscriptions` probe.
+- Backend: forecast + budget routes return `412 ai_provider_not_configured` on
+  missing routing.
+
+**PR 2 — discoverability & onboarding** (`feat(ai): help tooltips, docs, provider links`)
+- `HelpTooltip` entries on the 3 surfaces + the label rename.
+- `/docs` "AI features" section.
+- Per-provider "Get an API key" links in the AI Providers form.
+
+## Testing (minimal — operator is compute-capped)
+
+- Backend: `/auth/status` returns the correct `ai` block for
+  entitled/configured permutations (mock `get_features` +
+  `get_routing_for_feature`); the drift-guard test; one route returns `412
+  ai_provider_not_configured` when routing is missing.
+- Frontend: one surface renders all three states from a mocked `useAuth().ai`
+  (hidden / CTA / live), and the member-role CTA shows the "ask admin" variant.
+- No new frontend tests beyond the one 3-state spec; reuse existing surface
+  tests where possible.
+
+## No migrations
+
+Pure read/derive + UI. No new tables, no schema changes.

--- a/specs/ai-refinement-tweaks-backlog.md
+++ b/specs/ai-refinement-tweaks-backlog.md
@@ -1,0 +1,53 @@
+# AI refinement tweaks (backlog)
+
+Ideas to refine the existing AI features (categorize / forecast refine / budget
+rebalance). Each needs its own brainstorm → spec when picked up. Filed
+2026-06-04 during the "make AI real" wave (Spec A #394/#395 shipped).
+
+## 1. Expose AI generation parameters to the user (seed, temperature, etc.)
+
+Operator idea: let users tune the model's generation parameters — a **fixed seed**
+(to reduce run-to-run deviation / make suggestions reproducible), **temperature**,
+top_p, etc. Surface these with **proper documentation and warnings** so a user
+only changes them deliberately (e.g. "lower temperature = more consistent, less
+creative; a fixed seed makes repeated runs return the same suggestion").
+
+Notes / open questions for the eventual spec:
+- Where do these live? Per-org settings (like `forecast_input_granularity`) vs
+  per-request (in the estimate/refine panel) vs per-provider-routing.
+- Provider support varies: Anthropic supports `temperature`/`top_p` but **not a
+  seed** (as of now); OpenAI supports `seed`. The adapter layer
+  (`ai_providers/*`) would need to pass these through `chat_structured`, and the
+  UI must only offer params the routed provider supports.
+- Sensible defaults + guardrails (clamp temperature to a safe range).
+- Reproducibility caveat: even with a seed, providers don't guarantee identical
+  output across model versions.
+- Pairs with the cost-confirmed flow ([[ai-forecast-refine-cost-confirmed]]):
+  these are "advanced" knobs behind a disclosure, not front-and-center.
+
+## 2. Forecast refine: review-then-apply (instead of auto-preview + Revert)
+
+Today "Apply AI refinement" shows the AI-refined forecast immediately as an
+**ephemeral on-screen overlay** (no data is persisted; "Revert to baseline" just
+clears local React state). It works, but the UX reads as "it applied without
+asking." The budget-rebalance feature already does **per-row accept/skip** in its
+modal — forecast refine could adopt the same review-then-apply pattern, or at
+minimum frame the result clearly as a *preview* of suggestions.
+
+Notes:
+- Confirm whether "apply" should ever *persist* into the forecast plan, or stay a
+  display overlay. Currently it's display-only; if persistence is desired that's
+  a bigger change (write to `forecast_plan_items`).
+- Per-category accept/skip would mirror `BudgetRebalanceModal`'s pattern for
+  consistency across AI features.
+- Low risk today (nothing is mutated), so this is UX-clarity, not a data-safety
+  fix.
+
+## Related backlog
+
+- Async/background refine execution (the synchronous-timeout worst case) — noted
+  in [[ai-forecast-refine-cost-confirmed]].
+- `estimate_refine` spend-cap pre-check (don't show can_proceed=true when the org
+  is at its hard cap).
+- AI chat / internal-MCP assistant — separate project
+  (`specs/ai-assistant-mcp-chat-backlog.md`).


### PR DESCRIPTION
PR1 of the AI-readiness wave (spec `specs/ai-readiness-gating-onboarding.md`). Makes the three AI surfaces render by true state and hard-blocks the routes when no provider is configured. PR2 (help tooltips, docs, provider links) follows.

## What

- **One source of truth:** new authenticated `GET /api/v1/ai/status` returns per-feature `{entitled, configured}` (categorize/forecast/budget), computed from `feature_service.get_features` + `ai_routing_service.get_routing_for_feature` via a single canonical `AI_FEATURE_MAP` (entitlement↔routing↔UI) with a drift-guard test. (The spec said `/auth/status`, but that endpoint is public/pre-auth with no org context, so this is a dedicated authenticated endpoint.)
- **3-state on all three surfaces** (transactions "Suggest category", dashboard "Apply AI refinement", budgets "Suggest rebalance"): hidden when not entitled / a role-aware **"Set up AI"** CTA when entitled but no provider (admin links to Settings, member sees "ask your org admin") / the live action when entitled + configured. Read via a shared `useAiStatus()` SWR hook + `SetUpAiCta` component.
- **Fixes the ungated budget-rebalance button** and **removes the bespoke `/api/v1/subscriptions` probe** the transactions page used.
- **412 `ai_provider_not_configured`** on the forecast + budget routes when no provider is routed (categorize already did this). Runtime AI failures (cap, LLM/schema errors) still return a graceful 200 baseline.

## Notes

- No migrations (read/derive + UI).
- Backend 2130 pass (4 pre-existing auth/session-grace Redis-timing failures unrelated to this branch, also fail on main); frontend 1586 pass + tsc clean.