### PR TITLE
fix(transactions): enforce both-type category on transfer edits

### DIFF
--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -535,6 +535,12 @@ async def update_transaction(
     new_type = TransactionType(body.type) if body.type is not None else old_type
     if body.category_id is not None or body.type is not None:
         await validate_category_for_type(db, new_category_id, org_id, new_type)
+    # Transfer legs share one category and only accept CategoryType.BOTH (the
+    # same rule create_transfer/_link_pair enforce). validate_category_for_type
+    # above would happily accept an expense-only category on an expense leg, so
+    # the transfer-specific guard is required on the edit path too.
+    if partner is not None and body.category_id is not None:
+        await validate_transfer_category(db, new_category_id, org_id)
 
     # 3. Lock affected accounts in sorted ID order
     account_ids_to_lock: set[int] = set()
@@ -563,6 +569,11 @@ async def update_transaction(
         _apply_field_updates(tx, body)
         if body.category_id is not None:
             tx.category_id = body.category_id
+            # Both transfer legs share one category. Mirror the change to the
+            # partner leg here so editing the single visible row (the partner
+            # is hidden in the list) keeps the pair consistent.
+            if partner is not None:
+                partner.category_id = body.category_id
         if body.account_id is not None and body.account_id != old_account_id:
             tx.account_id = body.account_id
         if body.status is not None:

--- a/backend/tests/services/test_transaction_service_transfer_category_guard.py
+++ b/backend/tests/services/test_transaction_service_transfer_category_guard.py
@@ -29,7 +29,7 @@ from app.models import Account, AccountType, Category, Organization, Transaction
 from app.models.base import Base
 from app.models.category import CategoryType
 from app.models.transaction import TransactionStatus, TransactionType
-from app.schemas.transaction import TransferCreate
+from app.schemas.transaction import TransactionUpdate, TransferCreate
 from app.services import transaction_service
 from app.services.exceptions import ValidationError
 
@@ -250,3 +250,93 @@ async def test_pair_existing_accepts_both_category(db_session):
     )
     assert e_tx.category_id == seed["other_both_id"]
     assert i_tx.category_id == seed["other_both_id"]
+
+
+# ── update_transaction (edit path) ─────────────────────────────────────────
+
+
+async def _make_transfer(db: AsyncSession, seed: dict) -> tuple[int, int]:
+    """Create a real linked transfer pair via the service. Returns
+    (expense_leg_id, income_leg_id)."""
+    body = TransferCreate(
+        from_account_id=seed["src_id"],
+        to_account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"],
+        amount=Decimal("50"),
+        date=date(2026, 5, 1),
+        status="settled",
+    )
+    expense_tx, income_tx = await transaction_service.create_transfer(
+        db, seed["org_id"], body
+    )
+    return expense_tx.id, income_tx.id
+
+
+async def test_update_transfer_leg_rejects_expense_only_category(db_session):
+    """Editing a transfer leg to an expense-only category is rejected,
+    even though that category is type-compatible with the expense leg."""
+    seed = await _seed(db_session)
+    expense_id, _ = await _make_transfer(db_session, seed)
+    with pytest.raises(ValidationError):
+        await transaction_service.update_transaction(
+            db_session,
+            seed["org_id"],
+            expense_id,
+            TransactionUpdate(category_id=seed["expense_only_id"]),
+        )
+
+
+async def test_update_transfer_leg_rejects_income_only_category(db_session):
+    """Same rejection editing the income leg to an income-only category."""
+    seed = await _seed(db_session)
+    _, income_id = await _make_transfer(db_session, seed)
+    with pytest.raises(ValidationError):
+        await transaction_service.update_transaction(
+            db_session,
+            seed["org_id"],
+            income_id,
+            TransactionUpdate(category_id=seed["income_only_id"]),
+        )
+
+
+async def test_update_transfer_leg_accepts_both_category_and_syncs_partner(db_session):
+    """Editing one leg's category to another BOTH category succeeds and the
+    partner leg receives the same category (pair stays in sync)."""
+    seed = await _seed(db_session)
+    expense_id, income_id = await _make_transfer(db_session, seed)
+    await transaction_service.update_transaction(
+        db_session,
+        seed["org_id"],
+        expense_id,
+        TransactionUpdate(category_id=seed["other_both_id"]),
+    )
+    # Drop identity-map state so the asserts read persisted DB rows, proving
+    # the partner cascade was committed (not just mutated in memory).
+    db_session.expire_all()
+    expense_tx = await db_session.get(Transaction, expense_id)
+    income_tx = await db_session.get(Transaction, income_id)
+    assert expense_tx.category_id == seed["other_both_id"]
+    assert income_tx.category_id == seed["other_both_id"]
+
+
+async def test_update_regular_transaction_category_unaffected(db_session):
+    """Regression: a non-transfer expense row can still take an expense-only
+    category (the transfer guard must not leak onto regular rows)."""
+    seed = await _seed(db_session)
+    tx = Transaction(
+        org_id=seed["org_id"], account_id=seed["src_id"],
+        category_id=seed["transfer_cat_id"],
+        description="lunch", amount=Decimal("10"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add(tx)
+    await db_session.commit()
+    await transaction_service.update_transaction(
+        db_session,
+        seed["org_id"],
+        tx.id,
+        TransactionUpdate(category_id=seed["expense_only_id"]),
+    )
+    refreshed = await db_session.get(Transaction, tx.id)
+    assert refreshed.category_id == seed["expense_only_id"]

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1441,7 +1441,7 @@ function TransactionsPageContent() {
                             </div>
                             <div>
                               <label htmlFor={`edit-cat-${tx.id}`} className={label}>Category</label>
-                              <CategorySelect aria-label="Category" id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editPartner ? undefined : editType} typeFilter={editPartner ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
+                              <CategorySelect aria-label="Category" id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={isTransfer ? undefined : editType} typeFilter={isTransfer ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
                               {categorizeAi?.entitled && !editPartner ? (
                                 <div className="mt-1">
                                   {categorizeAi.configured ? (
@@ -1752,7 +1752,7 @@ function TransactionsPageContent() {
                               </div>
                               <div>
                                 <label className={label}>Category</label>
-                                <CategorySelect aria-label="Category" id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editPartner ? undefined : editType} typeFilter={editPartner ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
+                                <CategorySelect aria-label="Category" id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={isTransfer ? undefined : editType} typeFilter={isTransfer ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
                                 {categorizeAi?.entitled && !editPartner ? (
                                   <div className="mt-1">
                                     {categorizeAi.configured ? (

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1441,7 +1441,7 @@ function TransactionsPageContent() {
                             </div>
                             <div>
                               <label htmlFor={`edit-cat-${tx.id}`} className={label}>Category</label>
-                              <CategorySelect aria-label="Category" id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
+                              <CategorySelect aria-label="Category" id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editPartner ? undefined : editType} typeFilter={editPartner ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
                               {categorizeAi?.entitled && !editPartner ? (
                                 <div className="mt-1">
                                   {categorizeAi.configured ? (
@@ -1752,7 +1752,7 @@ function TransactionsPageContent() {
                               </div>
                               <div>
                                 <label className={label}>Category</label>
-                                <CategorySelect aria-label="Category" id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
+                                <CategorySelect aria-label="Category" id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editPartner ? undefined : editType} typeFilter={editPartner ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
                                 {categorizeAi?.entitled && !editPartner ? (
                                   <div className="mt-1">
                                     {categorizeAi.configured ? (

--- a/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
+++ b/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import TransactionsPage from "@/app/transactions/page";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -162,6 +162,78 @@ describe("TransactionsPage - edit row layout (Punch-list Item 7)", () => {
     expect(desktopType?.tagName).toBe("SELECT");
     const typeLabels = Array.from(desktopType!.options).map((o) => o.textContent);
     expect(typeLabels).toEqual(["Expense", "Income"]);
+  });
+
+  it("edit category picker on a transfer row lists only both-type categories", async () => {
+    // A transfer's shared category must be a `both`-type category (the
+    // backend rejects income/expense-only categories on transfer legs).
+    // The edit picker on a transfer row must therefore offer only
+    // `both`-type categories, hiding the income- and expense-only ones.
+    const CAT_EXPENSE = {
+      id: 11, name: "Groceries", type: "expense" as const,
+      parent_id: null, parent_name: null, description: null,
+      slug: "groceries", is_system: false, transaction_count: 0,
+    };
+    const CAT_INCOME = {
+      id: 12, name: "Salary", type: "income" as const,
+      parent_id: null, parent_name: null, description: null,
+      slug: "salary", is_system: false, transaction_count: 0,
+    };
+    const CAT_BOTH = {
+      id: 13, name: "Transfer", type: "both" as const,
+      parent_id: null, parent_name: null, description: null,
+      slug: "transfer", is_system: false, transaction_count: 0,
+    };
+
+    // Transfer pair: the lower-id leg (200) is the single visible row; the
+    // higher-id leg (201) is hidden but present in the list so startEdit can
+    // resolve the partner synchronously and set editPartner.
+    const visibleLeg = makeTx({
+      id: 200, description: "Move money",
+      category_id: CAT_BOTH.id, category_name: CAT_BOTH.name,
+      type: "expense", linked_transaction_id: 201,
+    });
+    const hiddenLeg = makeTx({
+      id: 201, description: "Move money",
+      category_id: CAT_BOTH.id, category_name: CAT_BOTH.name,
+      type: "income", linked_transaction_id: 200,
+    });
+
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockReset();
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
+      if (url.startsWith("/api/v1/categories"))
+        return [CAT_EXPENSE, CAT_INCOME, CAT_BOTH] as never;
+      if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
+      if (url.startsWith("/api/v1/transactions") && method === "GET")
+        return { items: [visibleLeg, hiddenLeg], total: 2, limit: 25, offset: 0 } as never;
+      return null as never;
+    });
+
+    render(<TransactionsPage />);
+
+    await waitForStableTxList();
+    fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
+
+    // Open the desktop transfer-row category combobox by focusing its input.
+    // Both desktop + mobile CategorySelects render in jsdom; target the
+    // desktop one by its id.
+    const combos = await screen.findAllByRole("combobox", { name: "Category" });
+    const combo = combos.find((c) => c.id === "edit-cat-200") as HTMLInputElement;
+    expect(combo).toBeTruthy();
+    fireEvent.focus(combo);
+
+    // Scope option assertions to the desktop picker's listbox so the mobile
+    // picker (still closed) can't affect the result.
+    const listbox = await screen.findByRole("listbox");
+    const optionNames = within(listbox)
+      .getAllByRole("option")
+      .map((o) => o.textContent ?? "");
+    expect(optionNames.some((n) => /Transfer/.test(n))).toBe(true);
+    expect(optionNames.some((n) => /Groceries/.test(n))).toBe(false);
+    expect(optionNames.some((n) => /Salary/.test(n))).toBe(false);
   });
 
   it("desktop edit form Save/Cancel meet the 44px touch-target floor", async () => {

--- a/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
+++ b/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
@@ -236,6 +236,75 @@ describe("TransactionsPage - edit row layout (Punch-list Item 7)", () => {
     expect(optionNames.some((n) => /Salary/.test(n))).toBe(false);
   });
 
+  it("transfer edit picker stays both-only even when the partner leg is off-page (editPartner unresolved)", async () => {
+    // With server-side pagination the partner leg can be absent from the
+    // current page, so startEdit resolves editPartner asynchronously (and
+    // here never — the partner fetch returns null). The both-only constraint
+    // must NOT depend on editPartner: it is keyed off the synchronously-known
+    // tx.linked_transaction_id (isTransfer). Regression guard for the picker
+    // briefly showing income/expense-only categories during that window.
+    const CAT_EXPENSE = {
+      id: 11, name: "Groceries", type: "expense" as const,
+      parent_id: null, parent_name: null, description: null,
+      slug: "groceries", is_system: false, transaction_count: 0,
+    };
+    const CAT_INCOME = {
+      id: 12, name: "Salary", type: "income" as const,
+      parent_id: null, parent_name: null, description: null,
+      slug: "salary", is_system: false, transaction_count: 0,
+    };
+    const CAT_BOTH = {
+      id: 13, name: "Transfer", type: "both" as const,
+      parent_id: null, parent_name: null, description: null,
+      slug: "transfer", is_system: false, transaction_count: 0,
+    };
+
+    // Only the visible leg (200) is on this page; its partner (201) is NOT
+    // in the list, so startEdit must fetch it. We resolve that fetch to null
+    // so editPartner stays null for the whole assertion — isolating the
+    // isTransfer-driven constraint from editPartner.
+    const visibleLeg = makeTx({
+      id: 200, description: "Move money",
+      category_id: CAT_BOTH.id, category_name: CAT_BOTH.name,
+      type: "expense", linked_transaction_id: 201,
+    });
+
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockReset();
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
+      if (url.startsWith("/api/v1/categories"))
+        return [CAT_EXPENSE, CAT_INCOME, CAT_BOTH] as never;
+      if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
+      // Single-transaction GET for the off-page partner: resolve null so
+      // editPartner is never set.
+      if (url === "/api/v1/transactions/201" && method === "GET")
+        return null as never;
+      if (url.startsWith("/api/v1/transactions") && method === "GET")
+        return { items: [visibleLeg], total: 1, limit: 25, offset: 0 } as never;
+      return null as never;
+    });
+
+    render(<TransactionsPage />);
+
+    await waitForStableTxList();
+    fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
+
+    const combos = await screen.findAllByRole("combobox", { name: "Category" });
+    const combo = combos.find((c) => c.id === "edit-cat-200") as HTMLInputElement;
+    expect(combo).toBeTruthy();
+    fireEvent.focus(combo);
+
+    const listbox = await screen.findByRole("listbox");
+    const optionNames = within(listbox)
+      .getAllByRole("option")
+      .map((o) => o.textContent ?? "");
+    expect(optionNames.some((n) => /Transfer/.test(n))).toBe(true);
+    expect(optionNames.some((n) => /Groceries/.test(n))).toBe(false);
+    expect(optionNames.some((n) => /Salary/.test(n))).toBe(false);
+  });
+
   it("desktop edit form Save/Cancel meet the 44px touch-target floor", async () => {
     // Tablet portrait (md+) still receives the desktop layout, so a 36px
     // tap target would fall below the project a11y baseline shipped in

--- a/specs/transactions-transfer-category-and-batch-edit.md
+++ b/specs/transactions-transfer-category-and-batch-edit.md
@@ -1,0 +1,243 @@
+# Transactions page: transfer-category consistency, add-button cleanup, batch edit
+
+**Date:** 2026-06-05
+**Status:** Spec — ready for implementation plan
+**Branch target:** three independent feature branches off `main` (three PRs)
+
+## Overview
+
+Three independent fixes on the Transactions page, shipped as three separate PRs:
+
+1. **PR 1 (`fix`)** — Transfer category consistency: stop letting a transfer be
+   recategorized to a non-`both` category.
+2. **PR 2 (`feat`)** — Remove the redundant in-page "+ New Transaction" button +
+   inline form; port its "Make recurring" capability into the shared header
+   quick-add.
+3. **PR 3 (`feat`)** — Batch edit: multi-select + edit (category / status /
+   account / tags), mirroring the existing batch delete.
+
+**Ship order:** PR 1 → PR 3 (PR 3 reuses PR 1's guard). PR 2 is independent.
+
+**Data-cleanup note:** PR 1 validates the *target* category, not the existing
+one. The "Transfer" category is type `both`, so recategorizing an existing
+mis-categorized transfer *to* "Transfer" is always allowed, before or after
+PR 1. PR 1 does not freeze or migrate existing rows; mis-categorized transfers
+keep being (correctly) excluded from Forecast/Budget until manually fixed. Once
+PR 3 lands, the owner can fix them all in one batch operation.
+
+---
+
+## PR 1 — Transfer category consistency (`fix`)
+
+### Problem
+
+A transfer is two linked `Transaction` rows (one expense leg, one income leg)
+sharing one category, bound by `linked_transaction_id`
+(`backend/app/models/transaction.py`). Transfers are deliberately excluded from
+all income/expense aggregates via `reportable_transaction_filter()`
+(`backend/app/services/transaction_filters.py:37-51`, the
+`linked_transaction_id IS NULL` clause) — moving money between your own accounts
+is not spending. This exclusion is **correct and stays**.
+
+Transfer **creation** enforces "category must be `CategoryType.BOTH`":
+
+- Frontend picker passes `typeFilter="BOTH"`
+  (`frontend/components/ui/CategorySelect.tsx`).
+- Backend `validate_transfer_category()`
+  (`backend/app/services/transaction_service.py:187-211`) rejects any non-`both`
+  category.
+
+But every transfer **edit** path skips that rule:
+
+- The edit row passes `filterType={editType}` (expense/income), not `"BOTH"`
+  (`frontend/app/transactions/page.tsx` edit picker).
+- Backend `update_transaction()`
+  (`backend/app/services/transaction_service.py:443-691`) only calls
+  `validate_category_for_type()` (line ~537), which checks expense/income
+  compatibility — never the transfer `both` rule.
+
+Result: a transfer can be recategorized to an expense/income-only category
+(e.g. "Credit Cards" under master "Debit & Repayments"). It then silently
+vanishes from Forecast/Budget (still linked → still excluded), reading as a bug
+and inviting double-count misinterpretation (the underlying CC charge was
+already categorized when it was created).
+
+### Goal
+
+Make every category-write path obey the same rule creation already enforces:
+**a transfer leg (`linked_transaction_id IS NOT NULL`) may only carry a
+`CategoryType.BOTH` category.** Recategorizing among `both` categories stays
+allowed (so the owner can set them to "Transfer").
+
+### Backend — central guard
+
+Add one rule at the service layer and route all category writes through it:
+
+> If the transaction being written is a transfer leg
+> (`linked_transaction_id IS NOT NULL`) and the new `category_id` resolves to a
+> category whose `type != CategoryType.BOTH`, raise `ValidationError`
+> ("Transfer category must accept both income and expense") → HTTP 400.
+
+Apply in / verify coverage for the category writers enumerated below:
+
+| Path | File | Action |
+|------|------|--------|
+| Single update | `transaction_service.update_transaction` (~line 537/565) | Add transfer-leg `both` guard before assigning `category_id`. |
+| Batch update (PR 3) | new `bulk_update` service | Inherits guard by looping single-update. |
+| Reconciliation edit | `reconciliation_service.apply_edits_to_reconciliation_row` (~498) | Ensure guard applies if the row is a transfer leg. |
+| Recurring series sync | `transaction_service._propagate_fields_to_series` (~429/439) | Only touches PENDING non-transfer rows; confirm it cannot target a transfer leg. No change expected. |
+| Create / pair / link | `validate_transfer_category` + `_link_pair` | Already enforce `both` on create; no change. |
+
+Prefer a single shared helper (e.g. extend/compose `validate_category_for_type`
+with a transfer-aware check) so the rule lives in one place and cannot drift.
+
+### Backend — partner sync
+
+The list renders a transfer as **one visible row**; the partner leg is filtered
+out of the view (`selectionHiddenIds`, higher-ID leg). So editing the visible
+row's category must **cascade to the partner leg**, or the pair desyncs (hidden
+leg keeps the old category). Today `update_transaction` writes only the edited
+row. Add: when the edited row is a transfer leg and `category_id` changes,
+write the same `category_id` to the partner leg in the same transaction.
+
+### Frontend
+
+In the transactions edit row, pass `typeFilter="BOTH"` (the uppercase `both`
+filter) instead of `filterType={editType}` when the row being edited is a
+transfer leg (`linked_transaction_id != null`). The picker then offers only
+`both` categories — recategorizing a transfer stays possible, but only among
+`both` categories.
+
+### Out of scope
+
+Editing a master category's `type` (e.g. converting "Debit & Repayments" to
+`both`). Explicitly dropped — the owner uses the dedicated "Transfer" category
+instead.
+
+### Tests
+
+- Backend: `update_transaction` on a transfer leg rejects a non-`both` category
+  (400); accepts a `both` category; the accepted change cascades to the partner
+  leg. Regular (non-transfer) transactions are unaffected.
+- Backend: a bulk/reconciliation path cannot set a non-`both` category on a
+  transfer leg.
+- Frontend: editing a transfer row shows only `both` categories; editing a
+  regular row shows type-appropriate categories as before.
+
+---
+
+## PR 2 — Remove redundant in-page add button; port "Make recurring" (`feat`)
+
+### Problem
+
+The header quick-add (`components/AppShellAddTransactionCta.tsx` → slide-in
+`components/floating/TransactionForm.tsx` / `TransferForm.tsx`) is already
+present on the transactions page. The in-page "+ New Transaction" button + inline
+form (`frontend/app/transactions/page.tsx:1000-1212`) duplicates it. Two buttons
+with the same function on the same page is confusing.
+
+The only capability the inline form has that the header quick-add lacks is the
+**"Make recurring" / Repeats** controls (frequency + auto-settle), which the
+header `TransactionForm` deferred.
+
+### Goal
+
+One add entry point on the page (the header quick-add), with no loss of
+capability.
+
+### Changes
+
+1. Delete the in-page "+ New Transaction" button and its inline form card
+   (transaction + transfer modes) from `transactions/page.tsx`, plus now-unused
+   local state/handlers (`showForm`, inline submit handlers, etc.).
+2. Port the "Make recurring" controls into the shared `TransactionForm`
+   component used by the header quick-add: a "Repeats" toggle revealing
+   frequency + auto-settle, wired to the same create payload the inline form
+   used. Keep the existing "Save and add new" behavior.
+3. Transfer creation stays available via the header menu's "New transfer".
+
+### Tests
+
+- Frontend: the in-page add button/form is gone; the page still loads and lists
+  transactions.
+- Frontend: header quick-add `TransactionForm` exposes the Repeats controls and
+  creates a recurring transaction (same payload contract as the old inline
+  form).
+
+### Notes
+
+Confirm no other surface depends on the inline form's DOM/test ids before
+deleting; update or remove affected tests.
+
+---
+
+## PR 3 — Batch edit (`feat`)
+
+### Problem
+
+The page supports multi-select + bulk **delete**
+(`transactions/page.tsx:946-991` toolbar → `POST /api/v1/transactions/bulk-delete`
+→ `transaction_service.bulk_delete_transactions`), but there is no bulk
+**edit**. Recategorizing many transfers means editing one row at a time.
+
+### Goal
+
+Add a "Batch edit" action to the existing selection toolbar that edits the
+selected rows in one operation. Each field is optional — applied only when set.
+
+### Frontend
+
+- Add a "Batch edit" button to the sticky selection toolbar (next to "Delete
+  selected").
+- It opens a small form / panel with optional fields: **Category**, **Status**,
+  **Account**, **Tags**.
+- On submit, `POST /api/v1/transactions/bulk-update` with the selected ids and
+  only the fields that were set.
+- Show a partial-success summary using the response (updated vs skipped, with
+  reasons), reusing the bulk-delete result-messaging pattern. Refresh the list.
+
+### Backend
+
+New endpoint `POST /api/v1/transactions/bulk-update`:
+
+- Request: `{ ids: list[int] (deduped, capped like bulk-delete), category_id?,
+  status?, account_id?, tags? }`.
+- Implementation: loop the selected rows through the existing single-update
+  service so all validation, the PR 1 transfer guard, partner sync, and balance
+  bookkeeping apply uniformly. Partial-success: collect `skipped_ids` with
+  reasons instead of failing the whole batch.
+- Response: `{ requested_count, updated_count, skipped_ids }` (mirror
+  `BulkDeleteResponse`).
+
+### Transfer handling in batch
+
+| Field | Transfer-leg behavior |
+|-------|----------------------|
+| Category | Must be `both` (PR 1 guard); cascades to partner leg. Non-`both` target → those transfer rows go to `skipped_ids` with a reason. |
+| Status | Applies to both legs (kept in sync). |
+| Account | Ambiguous for a transfer (it is one side of the transfer) → transfer legs **skipped** for account changes, reported. |
+| Tags | Transfers do not support tags → transfer legs **skipped** for tags. |
+
+### Field semantics (regular transactions)
+
+- **Tags:** v1 = **add/merge** the given tags onto each selected row (no
+  removal). (Replace semantics can be a later iteration.)
+- **Account change:** for settled rows, reuse the bulk-delete balance-revert
+  pattern — revert the old account's balance and apply to the new account.
+- **Status / Category:** same validation as a single edit.
+
+### Tests
+
+- Backend: bulk-update sets category on a mix of regular + transfer rows;
+  transfer rows accept a `both` category (cascaded to partners) and are skipped
+  for a non-`both` category, account, and tags; partial-success counts correct.
+- Backend: bulk account change reverts/applies balances for settled rows.
+- Frontend: selecting rows + batch-editing category updates the list; skipped
+  rows are surfaced.
+
+### Notes
+
+- Selection already collapses transfer pairs to one visible row and locks
+  partners together — batch edit operates on the visible selection; partner
+  legs are handled in the service (category cascade, status sync).
+- Cap `ids` consistently with bulk-delete to bound the operation.


### PR DESCRIPTION
Transfer legs may only carry a both-type category, matching what transfer creation already enforces.

Problem: the edit path let a transfer be recategorized to an expense/income-only category (e.g. "Credit Cards"). The row then silently vanished from Forecast Plans and Budgets, because transfers are (correctly) excluded from those aggregates regardless of category, inviting misinterpretation.

Changes:
- Backend: `update_transaction` now rejects a non-both category on a transfer leg (reusing `validate_transfer_category`) and cascades the category change to the partner leg so the pair stays in sync.
- Frontend: the transactions edit-row category picker offers only both-type categories for transfer rows (desktop + mobile), mirroring transfer creation. Recategorizing a transfer stays possible, just constrained to both-type categories.
- Reconciliation edit path already hard-refuses transfer-leg edits, so no change needed there.

Out of scope: editing a master category's type; batch edit (separate PR).

This is PR 1 of 3 from specs/transactions-transfer-category-and-batch-edit.md.