### PR TITLE
feat(transactions): batch edit selected transactions

### DIFF
--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -23,6 +23,9 @@ from app.schemas.import_batch import (
 from app.schemas.transaction import (
     BulkDeleteRequest,
     BulkDeleteResponse,
+    BulkUpdateRequest,
+    BulkUpdateResponse,
+    BulkUpdateSkip,
     ConvertToTransferRequest,
     PromoteToRecurringRequest,
     TransactionCreate,
@@ -502,4 +505,31 @@ async def bulk_delete_transactions(
         requested_count=len(unique_ids),
         deleted_count=deleted_count,
         skipped_ids=skipped_ids,
+    )
+
+
+@router.post("/bulk-update", response_model=BulkUpdateResponse)
+async def bulk_update_transactions(
+    body: BulkUpdateRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Apply optional field updates (category/status/account/tags) to many
+    transactions. Partial success: see skipped[] for rows that couldn't be
+    fully updated. Transfers accept category only.
+    """
+    updated_count, skipped = await svc.bulk_update_transactions(
+        db,
+        current_user.org_id,
+        body.ids,
+        category_id=body.category_id,
+        status=body.status,
+        account_id=body.account_id,
+        tags=body.tags,
+        actor_user_id=current_user.id,
+    )
+    return BulkUpdateResponse(
+        requested_count=len(dict.fromkeys(body.ids)),
+        updated_count=updated_count,
+        skipped=[BulkUpdateSkip(id=i, reason=r) for i, r in skipped],
     )

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -515,8 +515,13 @@ async def bulk_update_transactions(
     db: AsyncSession = Depends(get_db),
 ):
     """Apply optional field updates (category/status/account/tags) to many
-    transactions. Partial success: see skipped[] for rows that couldn't be
-    fully updated. Transfers accept category only.
+    transactions. Partial success: ``updated_count`` counts every row that
+    applied at least one field; ``skipped[]`` lists only rows where NO field
+    could be applied (not found, manual adjustment, or a transfer leg whose
+    sole requested fields were status/account/tags), each with a reason. A row
+    that applies some fields but not others (e.g. category applies but the tag
+    merge fails) still counts as updated and is NOT in skipped[]. Transfers
+    accept category only.
     """
     updated_count, skipped = await svc.bulk_update_transactions(
         db,

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -4,7 +4,7 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from app.schemas.tag import TagResponse
+from app.schemas.tag import MAX_TAGS_PER_TRANSACTION, TagResponse
 
 
 class TransactionCreate(BaseModel):
@@ -152,6 +152,42 @@ class BulkDeleteResponse(BaseModel):
     requested_count: int
     deleted_count: int
     skipped_ids: list[int]  # IDs that were requested but not found in this org
+
+
+class BulkUpdateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ids: list[int] = Field(..., min_length=1, max_length=500)
+    category_id: Optional[int] = None
+    status: Optional[Literal["settled", "pending"]] = None
+    account_id: Optional[int] = None
+    # Tags are ADDED (merged) to each eligible row, not replaced. Capped at the
+    # per-transaction max for the number you can add in one batch call.
+    tags: Optional[list[str]] = Field(default=None, max_length=MAX_TAGS_PER_TRANSACTION)
+
+    @model_validator(mode="after")
+    def _at_least_one_field(self) -> "BulkUpdateRequest":
+        # An empty tags list is a no-op (tags merge nothing), so it does not
+        # count as a provided field — reject it like an all-empty request.
+        if (
+            self.category_id is None
+            and self.status is None
+            and self.account_id is None
+            and not self.tags
+        ):
+            raise ValueError("Provide at least one field to update")
+        return self
+
+
+class BulkUpdateSkip(BaseModel):
+    id: int
+    reason: str
+
+
+class BulkUpdateResponse(BaseModel):
+    requested_count: int
+    updated_count: int
+    skipped: list[BulkUpdateSkip]
 
 
 class TransactionPairRequest(BaseModel):

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -1035,7 +1035,16 @@ async def bulk_update_transactions(
                     db, org_id, tx_id, TransactionUpdate(**update_kwargs)
                 )
                 applied = True
-            except (ValidationError, ConflictError, NotFoundError) as exc:
+            except (
+                ValidationError,
+                ConflictError,
+                NotFoundError,
+                IntegrityError,
+            ) as exc:
+                # Degrade a single bad row to a skip (and clear any half-open
+                # transaction) rather than aborting the whole batch — parity
+                # with the tags branch below.
+                await db.rollback()
                 skipped.append((tx_id, _reason(exc)))
                 continue
 

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -965,6 +965,128 @@ async def bulk_delete_transactions(
     return (len(found), skipped_ids)
 
 
+async def bulk_update_transactions(
+    db: AsyncSession,
+    org_id: int,
+    ids: list[int],
+    *,
+    category_id: int | None = None,
+    status: str | None = None,
+    account_id: int | None = None,
+    tags: list[str] | None = None,
+    actor_user_id: int,
+) -> tuple[int, list[tuple[int, str]]]:
+    """Apply an optional set of field updates to many transactions.
+
+    Per-row partial success: a row that successfully applies at least one field
+    counts as updated; a row that can apply nothing is returned in ``skipped``
+    with a human reason. Transfer legs only accept ``category_id`` (which
+    cascades to the partner via update_transaction); ``status``/``account_id``/
+    ``tags`` are skipped for them. Reuses update_transaction for all balance,
+    transfer-guard, and partner-cascade logic (it commits per row, so this is
+    naturally partial-success).
+
+    Returns (updated_count, skipped) where skipped is a list of (id, reason).
+    """
+    from app.services.tag_service import set_transaction_tags
+
+    requested = list(dict.fromkeys(ids))
+    updated = 0
+    skipped: list[tuple[int, str]] = []
+
+    def _reason(exc: Exception) -> str:
+        return getattr(exc, "detail", None) or str(exc)
+
+    for tx_id in requested:
+        row = await db.scalar(
+            select(Transaction)
+            .options(selectinload(Transaction.tags))
+            .where(Transaction.id == tx_id, Transaction.org_id == org_id)
+        )
+        if row is None:
+            skipped.append((tx_id, "Transaction not found"))
+            continue
+        if row.is_manual_adjustment:
+            skipped.append((tx_id, "Manual balance adjustments cannot be edited"))
+            continue
+
+        is_transfer = row.linked_transaction_id is not None
+        existing_tag_names = [t.name for t in row.tags]  # capture before commits
+        applied = False
+        row_notes: list[str] = []
+
+        # 1) category / status / account through update_transaction
+        update_kwargs: dict = {}
+        if category_id is not None:
+            update_kwargs["category_id"] = category_id
+        if status is not None:
+            if is_transfer:
+                row_notes.append("status not applied to transfers")
+            else:
+                update_kwargs["status"] = status
+        if account_id is not None:
+            if is_transfer:
+                row_notes.append("account not applied to transfers")
+            else:
+                update_kwargs["account_id"] = account_id
+        if update_kwargs:
+            try:
+                await update_transaction(
+                    db, org_id, tx_id, TransactionUpdate(**update_kwargs)
+                )
+                applied = True
+            except (ValidationError, ConflictError, NotFoundError) as exc:
+                skipped.append((tx_id, _reason(exc)))
+                continue
+
+        # 2) tags MERGE (regular rows only)
+        if tags:
+            if is_transfer:
+                row_notes.append("tags not applied to transfers")
+            else:
+                merged = list(dict.fromkeys([*existing_tag_names, *tags]))
+                try:
+                    await set_transaction_tags(
+                        db,
+                        org_id=org_id,
+                        transaction_id=tx_id,
+                        tag_names=merged,
+                        created_by_user_id=actor_user_id,
+                    )
+                    await db.commit()
+                    applied = True
+                except (
+                    ValidationError,
+                    ConflictError,
+                    NotFoundError,
+                    IntegrityError,
+                ) as exc:
+                    # Degrade a tag failure (incl. a tag-name unique-constraint
+                    # race) to a per-row skip rather than aborting the whole
+                    # batch. The field updates this row already committed via
+                    # update_transaction are preserved.
+                    await db.rollback()
+                    if applied:
+                        row_notes.append(f"tags not applied ({_reason(exc)})")
+                    else:
+                        skipped.append((tx_id, f"Tags: {_reason(exc)}"))
+                        continue
+
+        if applied:
+            updated += 1
+        else:
+            # Nothing applied — only happens for a transfer leg whose only
+            # requested fields were status/account/tags.
+            reason = (
+                "; ".join(row_notes)
+                if row_notes
+                else "No applicable changes for this row"
+            )
+            skipped.append((tx_id, reason))
+
+    return updated, skipped
+
+
 async def _link_pair(
     db: AsyncSession,
     *,

--- a/backend/tests/routers/test_transactions_bulk_update_route.py
+++ b/backend/tests/routers/test_transactions_bulk_update_route.py
@@ -1,0 +1,222 @@
+"""Router-level tests for POST /api/v1/transactions/bulk-update.
+
+Service-level behavior (per-row partial success, transfer gating, tag merge)
+is covered in tests/services/test_transaction_service_bulk_update.py. These
+tests focus on the HTTP contract:
+  - schema validation (extra=forbid, ids bounds, at-least-one-field),
+  - happy-path response shape + requested_count dedup,
+  - skipped[] surfacing with a reason.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Account, AccountType, Category, Organization, Transaction
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.transaction import TransactionStatus, TransactionType
+from app.models.user import Role, User
+from app.routers.transactions import router as transactions_router
+from app.security import hash_password
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    @app.exception_handler(NotFoundError)
+    async def _nf(_req, exc: NotFoundError):
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    @app.exception_handler(ValidationError)
+    async def _ve(_req, exc: ValidationError):
+        return JSONResponse(status_code=400, content={"detail": exc.detail})
+
+    @app.exception_handler(ConflictError)
+    async def _ce(_req, exc: ConflictError):
+        return JSONResponse(status_code=409, content={"detail": exc.detail})
+
+    app.include_router(transactions_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    async with factory() as db:
+        org = Organization(name="Test Org", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id, username="root", email="root@example.com",
+            password_hash=hash_password("pw-1234567"), role=Role.OWNER,
+            is_superadmin=True, is_active=True, email_verified=True,
+        )
+        at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+        db.add_all([user, at])
+        await db.flush()
+        acct = Account(
+            org_id=org.id, name="Acct A", account_type_id=at.id,
+            balance=Decimal("1000"), currency="EUR",
+        )
+        db.add(acct)
+        await db.flush()
+        groceries = Category(
+            org_id=org.id, name="Groceries", slug="groceries",
+            type=CategoryType.EXPENSE, is_system=False,
+        )
+        dining = Category(
+            org_id=org.id, name="Dining", slug="dining",
+            type=CategoryType.EXPENSE, is_system=False,
+        )
+        db.add_all([groceries, dining])
+        await db.flush()
+        rows = []
+        for i in range(2):
+            tx = Transaction(
+                org_id=org.id, account_id=acct.id, category_id=groceries.id,
+                description=f"row{i}", amount=Decimal("10"),
+                type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+                date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+            )
+            db.add(tx)
+            rows.append(tx)
+        await db.commit()
+        return {
+            "groceries_id": groceries.id,
+            "dining_id": dining.id,
+            "tx_ids": [r.id for r in rows],
+        }
+
+
+@pytest_asyncio.fixture
+async def client(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as c:
+        c.seed = seed  # type: ignore[attr-defined]
+        yield c
+
+
+def test_bulk_update_rejects_request_with_no_fields(client):
+    seed = client.seed
+    r = client.post("/api/v1/transactions/bulk-update", json={"ids": seed["tx_ids"]})
+    assert r.status_code == 422
+
+
+def test_bulk_update_rejects_empty_tags_only(client):
+    seed = client.seed
+    r = client.post(
+        "/api/v1/transactions/bulk-update",
+        json={"ids": seed["tx_ids"], "tags": []},
+    )
+    assert r.status_code == 422
+
+
+def test_bulk_update_rejects_empty_ids(client):
+    r = client.post(
+        "/api/v1/transactions/bulk-update",
+        json={"ids": [], "category_id": client.seed["dining_id"]},
+    )
+    assert r.status_code == 422
+
+
+def test_bulk_update_rejects_unknown_field(client):
+    seed = client.seed
+    r = client.post(
+        "/api/v1/transactions/bulk-update",
+        json={"ids": seed["tx_ids"], "category_id": seed["dining_id"], "bogus": 1},
+    )
+    assert r.status_code == 422
+
+
+def test_bulk_update_happy_path_response_shape(client):
+    seed = client.seed
+    r = client.post(
+        "/api/v1/transactions/bulk-update",
+        json={"ids": seed["tx_ids"], "category_id": seed["dining_id"]},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {
+        "requested_count": 2,
+        "updated_count": 2,
+        "skipped": [],
+    }
+
+
+def test_bulk_update_requested_count_dedupes(client):
+    seed = client.seed
+    one = seed["tx_ids"][0]
+    r = client.post(
+        "/api/v1/transactions/bulk-update",
+        json={"ids": [one, one], "category_id": seed["dining_id"]},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["requested_count"] == 1
+    assert body["updated_count"] == 1
+
+
+def test_bulk_update_reports_skipped_with_reason(client):
+    seed = client.seed
+    missing = 999999
+    r = client.post(
+        "/api/v1/transactions/bulk-update",
+        json={"ids": [seed["tx_ids"][0], missing], "category_id": seed["dining_id"]},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["updated_count"] == 1
+    assert len(body["skipped"]) == 1
+    assert body["skipped"][0]["id"] == missing
+    assert isinstance(body["skipped"][0]["reason"], str) and body["skipped"][0]["reason"]

--- a/backend/tests/services/test_transaction_service_bulk_update.py
+++ b/backend/tests/services/test_transaction_service_bulk_update.py
@@ -1,0 +1,362 @@
+"""bulk_update_transactions service tests (PR 3 — batch edit).
+
+Covers the contract for the batch-edit backend:
+
+- Category/status/account applied to regular rows via update_transaction.
+- Transfer legs accept category only (cascading to the partner); status,
+  account, and tags requested in the same call are skipped (not applied to
+  the transfer leg).
+- A non-BOTH category on a transfer leg is rejected by the guard, so the row
+  is skipped with a reason.
+- A transfer leg whose only requested field is status/account/tags applies
+  nothing and is reported in skipped.
+- Tags MERGE (union with existing) rather than replace.
+- Manual balance adjustments and unknown ids are reported as skipped, not
+  fatal (partial success).
+- Duplicate ids are deduped.
+
+Runs on SQLite in-memory; no MySQL.
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import selectinload
+from sqlalchemy.pool import StaticPool
+from sqlalchemy import select
+
+from app.models import Account, AccountType, Category, Organization, Transaction
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.transaction import TransactionStatus, TransactionType
+from app.models.user import Role, User
+from app.schemas.transaction import TransferCreate
+from app.security import hash_password
+from app.services import tag_service, transaction_service
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db: AsyncSession) -> dict:
+    org = Organization(name="T", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+
+    user = User(
+        org_id=org.id,
+        username="u-t",
+        email="u@t.example",
+        password_hash=hash_password("pw-1234567"),
+        role=Role.OWNER,
+        is_active=True,
+        email_verified=True,
+    )
+    db.add(user)
+    await db.flush()
+
+    at = AccountType(
+        org_id=org.id, name="Checking", slug="checking", is_system=True
+    )
+    db.add(at)
+    await db.flush()
+    src = Account(
+        org_id=org.id, name="Src", account_type_id=at.id,
+        balance=Decimal("1000"), currency="EUR",
+    )
+    dst = Account(
+        org_id=org.id, name="Dst", account_type_id=at.id,
+        balance=Decimal("0"), currency="EUR",
+    )
+    acct3 = Account(
+        org_id=org.id, name="Third", account_type_id=at.id,
+        balance=Decimal("0"), currency="EUR",
+    )
+    db.add_all([src, dst, acct3])
+    await db.flush()
+
+    transfer_cat = Category(
+        org_id=org.id, name="Transfer", slug="transfer",
+        type=CategoryType.BOTH, is_system=True,
+    )
+    expense_only = Category(
+        org_id=org.id, name="Groceries", slug="groceries",
+        type=CategoryType.EXPENSE,
+    )
+    other_expense = Category(
+        org_id=org.id, name="Dining", slug="dining",
+        type=CategoryType.EXPENSE,
+    )
+    income_only = Category(
+        org_id=org.id, name="Salary", slug="salary",
+        type=CategoryType.INCOME,
+    )
+    other_both = Category(
+        org_id=org.id, name="Internal", slug="internal",
+        type=CategoryType.BOTH,
+    )
+    db.add_all([transfer_cat, expense_only, other_expense, income_only, other_both])
+    await db.commit()
+
+    return {
+        "org_id": org.id,
+        "user_id": user.id,
+        "src_id": src.id,
+        "dst_id": dst.id,
+        "acct3_id": acct3.id,
+        "transfer_cat_id": transfer_cat.id,
+        "expense_only_id": expense_only.id,
+        "other_expense_id": other_expense.id,
+        "income_only_id": income_only.id,
+        "other_both_id": other_both.id,
+    }
+
+
+async def _make_transfer(db: AsyncSession, seed: dict) -> tuple[int, int]:
+    """Create a real linked transfer pair via the service. Returns
+    (expense_leg_id, income_leg_id)."""
+    body = TransferCreate(
+        from_account_id=seed["src_id"],
+        to_account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"],
+        amount=Decimal("50"),
+        date=date(2026, 5, 1),
+        status="settled",
+    )
+    expense_tx, income_tx = await transaction_service.create_transfer(
+        db, seed["org_id"], body
+    )
+    return expense_tx.id, income_tx.id
+
+
+async def _make_expense(db: AsyncSession, seed: dict, *, category_id: int) -> int:
+    """Insert a settled expense row on the src account and commit. Returns id."""
+    tx = Transaction(
+        org_id=seed["org_id"], account_id=seed["src_id"],
+        category_id=category_id,
+        description="lunch", amount=Decimal("10"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db.add(tx)
+    await db.commit()
+    return tx.id
+
+
+async def _make_manual_adjustment(db: AsyncSession, seed: dict) -> int:
+    """Insert a manual balance adjustment row and commit. Returns id."""
+    tx = Transaction(
+        org_id=seed["org_id"], account_id=seed["src_id"],
+        category_id=seed["expense_only_id"],
+        description="adj", amount=Decimal("5"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+        is_manual_adjustment=True,
+    )
+    db.add(tx)
+    await db.commit()
+    return tx.id
+
+
+async def test_bulk_update_sets_category_on_regular_rows(db_session):
+    """Category applied to multiple regular rows; updated_count correct."""
+    seed = await _seed(db_session)
+    a = await _make_expense(db_session, seed, category_id=seed["expense_only_id"])
+    b = await _make_expense(db_session, seed, category_id=seed["expense_only_id"])
+    updated, skipped = await transaction_service.bulk_update_transactions(
+        db_session, seed["org_id"], [a, b],
+        category_id=seed["other_expense_id"], actor_user_id=seed["user_id"],
+    )
+    assert updated == 2
+    assert skipped == []
+    assert (await db_session.get(Transaction, a)).category_id == seed["other_expense_id"]
+
+
+async def test_bulk_update_transfer_category_cascades_and_skips_other_fields(db_session):
+    """A transfer leg: category (BOTH) applies + cascades to partner; status and
+    account requested in the same call are skipped (not applied to the transfer)."""
+    seed = await _seed(db_session)
+    exp_id, inc_id = await _make_transfer(db_session, seed)  # both on transfer_cat
+    updated, skipped = await transaction_service.bulk_update_transactions(
+        db_session, seed["org_id"], [exp_id],
+        category_id=seed["other_both_id"], status="pending",
+        account_id=seed["acct3_id"], actor_user_id=seed["user_id"],
+    )
+    assert updated == 1  # category applied
+    # partner cascaded
+    assert (await db_session.get(Transaction, exp_id)).category_id == seed["other_both_id"]
+    assert (await db_session.get(Transaction, inc_id)).category_id == seed["other_both_id"]
+    # status/account NOT changed on the transfer leg
+    assert (await db_session.get(Transaction, exp_id)).status == TransactionStatus.SETTLED
+
+
+async def test_bulk_update_transfer_nonboth_category_skips_row(db_session):
+    """A non-BOTH category on a transfer leg is rejected by the guard → the row
+    is skipped with a reason (no other field requested)."""
+    seed = await _seed(db_session)
+    exp_id, _ = await _make_transfer(db_session, seed)
+    updated, skipped = await transaction_service.bulk_update_transactions(
+        db_session, seed["org_id"], [exp_id],
+        category_id=seed["expense_only_id"], actor_user_id=seed["user_id"],
+    )
+    assert updated == 0
+    assert len(skipped) == 1 and skipped[0][0] == exp_id
+
+
+async def test_bulk_update_transfer_only_account_requested_is_skipped(db_session):
+    """Transfer leg with ONLY account requested (no category): nothing applies →
+    row reported as skipped."""
+    seed = await _seed(db_session)
+    exp_id, _ = await _make_transfer(db_session, seed)
+    updated, skipped = await transaction_service.bulk_update_transactions(
+        db_session, seed["org_id"], [exp_id],
+        account_id=seed["acct3_id"], actor_user_id=seed["user_id"],
+    )
+    assert updated == 0
+    assert len(skipped) == 1 and skipped[0][0] == exp_id
+
+
+async def test_bulk_update_status_and_account_on_regular_row(db_session):
+    """Regular row: status + account both apply via update_transaction (balances
+    handled there)."""
+    seed = await _seed(db_session)
+    a = await _make_expense(db_session, seed, category_id=seed["expense_only_id"])
+    updated, skipped = await transaction_service.bulk_update_transactions(
+        db_session, seed["org_id"], [a],
+        status="pending", account_id=seed["acct3_id"], actor_user_id=seed["user_id"],
+    )
+    assert updated == 1 and skipped == []
+    row = await db_session.get(Transaction, a)
+    assert row.status == TransactionStatus.PENDING
+    assert row.account_id == seed["acct3_id"]
+
+
+async def test_bulk_update_merges_tags_on_regular_row(db_session):
+    """Tags MERGE (union) with existing, not replace."""
+    seed = await _seed(db_session)
+    a = await _make_expense(db_session, seed, category_id=seed["expense_only_id"])
+    await tag_service.set_transaction_tags(
+        db_session, org_id=seed["org_id"], transaction_id=a,
+        tag_names=["existing"], created_by_user_id=seed["user_id"],
+    )
+    await db_session.commit()
+    updated, skipped = await transaction_service.bulk_update_transactions(
+        db_session, seed["org_id"], [a], tags=["added"], actor_user_id=seed["user_id"],
+    )
+    assert updated == 1 and skipped == []
+    row = await db_session.scalar(
+        select(Transaction).options(selectinload(Transaction.tags)).where(Transaction.id == a)
+    )
+    names = sorted(t.name_normalized for t in row.tags)
+    assert names == ["added", "existing"]
+
+
+async def test_bulk_update_transfer_tags_skipped(db_session):
+    """Tags are not applied to transfer legs."""
+    seed = await _seed(db_session)
+    exp_id, _ = await _make_transfer(db_session, seed)
+    updated, skipped = await transaction_service.bulk_update_transactions(
+        db_session, seed["org_id"], [exp_id],
+        category_id=seed["other_both_id"], tags=["x"], actor_user_id=seed["user_id"],
+    )
+    assert updated == 1  # category applied; tags ignored for transfer
+    row = await db_session.scalar(
+        select(Transaction).options(selectinload(Transaction.tags)).where(Transaction.id == exp_id)
+    )
+    assert row.tags == []
+
+
+async def test_bulk_update_skips_manual_adjustment_and_missing(db_session):
+    """Manual adjustments and unknown ids are reported as skipped, not fatal."""
+    seed = await _seed(db_session)
+    a = await _make_expense(db_session, seed, category_id=seed["expense_only_id"])
+    adj = await _make_manual_adjustment(db_session, seed)
+    updated, skipped = await transaction_service.bulk_update_transactions(
+        db_session, seed["org_id"], [a, adj, 999999],
+        category_id=seed["other_expense_id"], actor_user_id=seed["user_id"],
+    )
+    assert updated == 1
+    skipped_ids = {s[0] for s in skipped}
+    assert skipped_ids == {adj, 999999}
+
+
+async def test_bulk_update_dedupes_ids(db_session):
+    seed = await _seed(db_session)
+    a = await _make_expense(db_session, seed, category_id=seed["expense_only_id"])
+    updated, skipped = await transaction_service.bulk_update_transactions(
+        db_session, seed["org_id"], [a, a],
+        category_id=seed["other_expense_id"], actor_user_id=seed["user_id"],
+    )
+    assert updated == 1 and skipped == []
+
+
+async def test_bulk_update_ignores_cross_org_ids(db_session):
+    """A row in this org is never touched when the call is scoped to another
+    org: the id is reported skipped (not found) and the row stays unchanged."""
+    seed = await _seed(db_session)
+    a = await _make_expense(db_session, seed, category_id=seed["expense_only_id"])
+    other_org = Organization(name="Other", billing_cycle_day=1)
+    db_session.add(other_org)
+    await db_session.commit()
+
+    updated, skipped = await transaction_service.bulk_update_transactions(
+        db_session, other_org.id, [a],
+        category_id=seed["other_expense_id"], actor_user_id=seed["user_id"],
+    )
+    assert updated == 0
+    assert {s[0] for s in skipped} == {a}
+    # Row untouched: still on its original category.
+    assert (await db_session.get(Transaction, a)).category_id == seed["expense_only_id"]
+
+
+async def test_bulk_update_counts_row_updated_when_fields_apply_but_tags_fail(db_session):
+    """The trickiest branch: category applies, but the tag merge exceeds the
+    per-transaction cap and fails. The row still counts as updated (the
+    committed category change is preserved), is NOT in skipped, and its tag set
+    is rolled back to the original."""
+    seed = await _seed(db_session)
+    a = await _make_expense(db_session, seed, category_id=seed["expense_only_id"])
+    # Fill the row to the 5-tag cap so adding one more overflows on merge.
+    full = ["t1", "t2", "t3", "t4", "t5"]
+    await tag_service.set_transaction_tags(
+        db_session, org_id=seed["org_id"], transaction_id=a,
+        tag_names=full, created_by_user_id=seed["user_id"],
+    )
+    await db_session.commit()
+
+    updated, skipped = await transaction_service.bulk_update_transactions(
+        db_session, seed["org_id"], [a],
+        category_id=seed["other_expense_id"], tags=["overflow"],
+        actor_user_id=seed["user_id"],
+    )
+    assert updated == 1
+    assert skipped == []  # category applied → row counted updated, not skipped
+    row = await db_session.scalar(
+        select(Transaction).options(selectinload(Transaction.tags)).where(Transaction.id == a)
+    )
+    assert row.category_id == seed["other_expense_id"]  # field change survived
+    assert sorted(t.name_normalized for t in row.tags) == full  # tags unchanged

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -19,6 +19,7 @@ import ConfirmModal from "@/components/ui/ConfirmModal";
 import LinkAsTransferModal from "@/components/transactions/LinkAsTransferModal";
 import MarkAsTransferModal from "@/components/transactions/MarkAsTransferModal";
 import UnpairTransferModal from "@/components/transactions/UnpairTransferModal";
+import BatchEditModal from "@/components/transactions/BatchEditModal";
 import TagChipInput from "@/components/transactions/TagChipInput";
 import SuggestCategoryButton from "@/components/transactions/SuggestCategoryButton";
 import { SetUpAiCta } from "@/components/ai/SetUpAiCta";
@@ -204,6 +205,8 @@ function TransactionsPageContent() {
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
   const [bulkDeleting, setBulkDeleting] = useState(false);
+  const [showBatchEdit, setShowBatchEdit] = useState(false);
+  const [batchEditing, setBatchEditing] = useState(false);
 
   // Transfer modals
   const [linkModalLegs, setLinkModalLegs] = useState<{ expense: Transaction; income: Transaction } | null>(null);
@@ -466,6 +469,38 @@ function TransactionsPageContent() {
       setError(extractErrorMessage(err));
     } finally {
       setBulkDeleting(false);
+    }
+  }
+
+  async function handleBatchEdit(payload: {
+    category_id?: number; status?: "settled" | "pending"; account_id?: number; tags?: string[];
+  }) {
+    setShowBatchEdit(false);
+    setError("");
+    setBatchEditing(true);
+    try {
+      const res = await apiFetch<{
+        requested_count: number;
+        updated_count: number;
+        skipped: { id: number; reason: string }[];
+      }>("/api/v1/transactions/bulk-update", {
+        method: "POST",
+        body: JSON.stringify({ ids: Array.from(selectedIds), ...payload }),
+      });
+      clearSelection();
+      await loadTransactions(page);
+      if (res.skipped.length > 0) {
+        setError(
+          `Updated ${res.updated_count} of ${res.requested_count}. ${res.skipped.length} skipped: ${res.skipped
+            .slice(0, 3)
+            .map((s) => s.reason)
+            .join("; ")}${res.skipped.length > 3 ? "…" : ""}`,
+        );
+      }
+    } catch (err) {
+      setError(extractErrorMessage(err));
+    } finally {
+      setBatchEditing(false);
     }
   }
 
@@ -810,9 +845,17 @@ function TransactionsPageContent() {
             )}
             <button
               type="button"
+              className={`${btnSecondary} inline-flex min-h-[44px] items-center`}
+              onClick={() => setShowBatchEdit(true)}
+              disabled={bulkDeleting || batchEditing}
+            >
+              {batchEditing ? "Applying…" : "Batch edit"}
+            </button>
+            <button
+              type="button"
               className={`${btnDangerSolid} inline-flex min-h-[44px] items-center`}
               onClick={() => setConfirmBulkDelete(true)}
-              disabled={bulkDeleting}
+              disabled={bulkDeleting || batchEditing}
             >
               {bulkDeleting ? "Deleting…" : "Delete selected"}
             </button>
@@ -1735,6 +1778,15 @@ function TransactionsPageContent() {
         variant="danger"
         onConfirm={handleBulkDelete}
         onCancel={() => setConfirmBulkDelete(false)}
+      />
+      <BatchEditModal
+        open={showBatchEdit}
+        count={selectedIds.size}
+        categories={categories}
+        accounts={accounts}
+        submitting={batchEditing}
+        onSubmit={handleBatchEdit}
+        onCancel={() => setShowBatchEdit(false)}
       />
       {linkModalLegs && (
         <LinkAsTransferModal

--- a/frontend/components/transactions/BatchEditModal.tsx
+++ b/frontend/components/transactions/BatchEditModal.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import CategorySelect from "@/components/ui/CategorySelect";
+import TagChipInput from "@/components/transactions/TagChipInput";
+import { btnPrimary, btnSecondary, input, label } from "@/lib/styles";
+import type { Account, Category } from "@/lib/types";
+
+export interface BatchEditPayload {
+  category_id?: number;
+  status?: "settled" | "pending";
+  account_id?: number;
+  tags?: string[];
+}
+
+interface Props {
+  open: boolean;
+  /** Number of selected transactions — surfaced in the title. */
+  count: number;
+  categories: Category[];
+  accounts: Account[];
+  submitting: boolean;
+  onSubmit: (payload: BatchEditPayload) => void;
+  onCancel: () => void;
+}
+
+export default function BatchEditModal({
+  open,
+  count,
+  categories,
+  accounts,
+  submitting,
+  onSubmit,
+  onCancel,
+}: Props) {
+  // Empty / "" means "no change" for every field. Tags default to an empty
+  // list; a non-empty list means the user wants to add those tags.
+  const [categoryId, setCategoryId] = useState<number | "">("");
+  const [status, setStatus] = useState<"" | "settled" | "pending">("");
+  const [accountId, setAccountId] = useState<number | "">("");
+  const [tags, setTags] = useState<string[]>([]);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Reset the form each time the modal opens so a previous edit doesn't leak
+  // into the next batch.
+  useEffect(() => {
+    if (open) {
+      setCategoryId("");
+      setStatus("");
+      setAccountId("");
+      setTags([]);
+    }
+  }, [open]);
+
+  // Focus management mirrors ConfirmModal: focus Cancel on open, restore the
+  // previously-focused element on close.
+  useEffect(() => {
+    if (open) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      cancelRef.current?.focus();
+    } else if (previousFocusRef.current) {
+      previousFocusRef.current.focus();
+      previousFocusRef.current = null;
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onCancel();
+        return;
+      }
+      if (e.key === "Tab") {
+        // Trap focus inside the dialog (matches ConfirmModal) so keyboard
+        // users can't tab out to the page behind this multi-field form.
+        const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onCancel]);
+
+  useEffect(() => {
+    if (open) document.body.style.overflow = "hidden";
+    else document.body.style.overflow = "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  const hasChange =
+    categoryId !== "" || status !== "" || accountId !== "" || tags.length > 0;
+
+  function handleApply() {
+    if (!hasChange || submitting) return;
+    const payload: BatchEditPayload = {};
+    if (categoryId !== "") payload.category_id = categoryId;
+    if (status !== "") payload.status = status;
+    if (accountId !== "") payload.account_id = accountId;
+    if (tags.length > 0) payload.tags = tags;
+    onSubmit(payload);
+  }
+
+  const activeAccounts = accounts.filter((a) => a.is_active);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
+      onClick={onCancel}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="batch-edit-modal-title"
+        className="w-full max-w-[min(32rem,calc(100vw-2rem))] max-h-[90vh] overflow-y-auto rounded-lg border border-border bg-surface p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3
+          id="batch-edit-modal-title"
+          className="text-lg font-semibold text-text-primary"
+        >
+          Batch edit {count} selected transaction{count === 1 ? "" : "s"}
+        </h3>
+        <p className="mt-2 text-sm text-text-secondary">
+          Account and tags are not applied to transfers. A transfer&apos;s
+          category must be a transfer-compatible (both) category.
+        </p>
+
+        <div className="mt-5 space-y-4">
+          <div>
+            <label htmlFor="batch-edit-category" className={label}>
+              Set category
+            </label>
+            <CategorySelect
+              id="batch-edit-category"
+              aria-label="Category"
+              categories={categories}
+              value={categoryId}
+              onChange={setCategoryId}
+              className={input}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="batch-edit-status" className={label}>
+              Status
+            </label>
+            <select
+              id="batch-edit-status"
+              aria-label="Status"
+              value={status}
+              onChange={(e) =>
+                setStatus(e.target.value as "" | "settled" | "pending")
+              }
+              className={input}
+            >
+              <option value="">No change</option>
+              <option value="settled">Settled</option>
+              <option value="pending">Pending</option>
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="batch-edit-account" className={label}>
+              Account
+            </label>
+            <select
+              id="batch-edit-account"
+              aria-label="Account"
+              value={accountId}
+              onChange={(e) =>
+                setAccountId(e.target.value === "" ? "" : Number(e.target.value))
+              }
+              className={input}
+            >
+              <option value="">No change</option>
+              {activeAccounts.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="batch-edit-tags" className={label}>
+              Add tags
+            </label>
+            <TagChipInput
+              id="batch-edit-tags"
+              ariaLabel="Add tags"
+              value={tags}
+              onChange={setTags}
+              categoryId={categoryId}
+            />
+            <p className="mt-1 text-xs text-text-muted">
+              Added to each transaction (existing tags kept).
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-col-reverse sm:flex-row sm:justify-end gap-2">
+          <button
+            type="button"
+            ref={cancelRef}
+            onClick={onCancel}
+            className={`${btnSecondary} w-full sm:w-auto min-h-[44px]`}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleApply}
+            disabled={!hasChange || submitting}
+            className={`${btnPrimary} w-full sm:w-auto`}
+          >
+            {submitting ? "Applying…" : "Apply"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/tests/app/transactions-batch-edit.test.tsx
+++ b/frontend/tests/app/transactions-batch-edit.test.tsx
@@ -1,0 +1,215 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import TransactionsPage from "@/app/transactions/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+import { waitForStableTxList } from "../utils/wait-for-stable-tx-list";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/transactions",
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const USER = {
+  id: 1, username: "user", email: "user@example.com",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner" as const, org_id: 1, org_name: "Org",
+  billing_cycle_day: 1, is_superadmin: false, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const ACCT_A = {
+  id: 100, name: "Checking A", account_type_id: 1,
+  account_type_name: "Checking", account_type_slug: "checking",
+  balance: 0, currency: "EUR", is_active: true,
+  close_day: null, is_default: true,
+};
+
+const CAT_GROCERIES = {
+  id: 11, name: "Groceries", type: "expense" as const,
+  parent_id: null, parent_name: null, description: null,
+  slug: "groceries", is_system: false, transaction_count: 0,
+};
+const CAT_DINING = {
+  id: 12, name: "Dining", type: "expense" as const,
+  parent_id: null, parent_name: null, description: null,
+  slug: "dining", is_system: false, transaction_count: 0,
+};
+
+type Tx = {
+  id: number;
+  account_id: number;
+  account_name: string;
+  category_id: number;
+  category_name: string;
+  description: string;
+  amount: number;
+  type: "income" | "expense";
+  status: "settled" | "pending";
+  linked_transaction_id: number | null;
+  recurring_id: number | null;
+  date: string;
+  settled_date: string | null;
+  is_imported: boolean;
+};
+
+function makeTx(over: Partial<Tx> = {}): Tx {
+  return {
+    id: 1,
+    account_id: ACCT_A.id,
+    account_name: ACCT_A.name,
+    category_id: CAT_GROCERIES.id,
+    category_name: CAT_GROCERIES.name,
+    description: "Coffee",
+    amount: 12.5,
+    type: "expense",
+    status: "settled",
+    linked_transaction_id: null,
+    recurring_id: null,
+    date: "2026-05-01",
+    settled_date: null,
+    is_imported: false,
+    ...over,
+  };
+}
+
+type BulkResponse = {
+  requested_count: number;
+  updated_count: number;
+  skipped: { id: number; reason: string }[];
+};
+
+function setupApiFetch(txs: Tx[], bulkResponse: BulkResponse) {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
+    if (url.startsWith("/api/v1/categories")) return [CAT_GROCERIES, CAT_DINING] as never;
+    if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
+    if (url === "/api/v1/transactions/bulk-update" && method === "POST")
+      return bulkResponse as never;
+    if (url.startsWith("/api/v1/transactions") && method === "GET")
+      return { items: txs, total: txs.length, limit: 25, offset: 0 } as never;
+    return null as never;
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(useAuth).mockReturnValue({
+    user: USER as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+});
+
+async function selectAllAndOpenModal() {
+  await waitForStableTxList();
+  // Select every row via the desktop select-all header checkbox.
+  fireEvent.click(screen.getByLabelText("Select all on page"));
+  // Toolbar appears with the count + Batch edit action.
+  const batchBtns = await screen.findAllByRole("button", { name: /^Batch edit$/i });
+  fireEvent.click(batchBtns[0]);
+  return screen.getByRole("dialog");
+}
+
+describe("TransactionsPage - batch edit wiring", () => {
+  it("posts bulk-update with selected ids + category and reloads the list", async () => {
+    const txs = [
+      makeTx({ id: 70, description: "One" }),
+      makeTx({ id: 71, description: "Two" }),
+    ];
+    setupApiFetch(txs, { requested_count: 2, updated_count: 2, skipped: [] });
+    render(<TransactionsPage />);
+
+    const dialog = await selectAllAndOpenModal();
+
+    // Set a category inside the modal.
+    const combo = within(dialog).getByRole("combobox", { name: /category/i });
+    fireEvent.focus(combo);
+    const listbox = await within(dialog).findByRole("listbox");
+    fireEvent.click(within(listbox).getByText("Dining"));
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /apply/i }));
+
+    const apiFetchMock = vi.mocked(apiFetch);
+    await waitFor(() => {
+      const post = apiFetchMock.mock.calls.find(
+        (c) =>
+          c[0] === "/api/v1/transactions/bulk-update" &&
+          (c[1] as RequestInit | undefined)?.method === "POST",
+      );
+      expect(post).toBeTruthy();
+    });
+
+    const post = apiFetchMock.mock.calls.find(
+      (c) =>
+        c[0] === "/api/v1/transactions/bulk-update" &&
+        (c[1] as RequestInit | undefined)?.method === "POST",
+    )!;
+    const body = JSON.parse((post[1] as RequestInit).body as string);
+    expect(body.ids.slice().sort((a: number, b: number) => a - b)).toEqual([70, 71]);
+    expect(body.category_id).toBe(CAT_DINING.id);
+
+    // List reloads: at least one more GET fires after the POST.
+    const postIdx = apiFetchMock.mock.calls.indexOf(post);
+    await waitFor(() => {
+      const reload = apiFetchMock.mock.calls
+        .slice(postIdx + 1)
+        .find(
+          (c) =>
+            typeof c[0] === "string" &&
+            (c[0] as string).startsWith("/api/v1/transactions?") &&
+            ((c[1] as RequestInit | undefined)?.method ?? "GET") === "GET",
+        );
+      expect(reload).toBeTruthy();
+    });
+  });
+
+  it("surfaces a skipped summary in the error banner when the response has skips", async () => {
+    const txs = [
+      makeTx({ id: 80, description: "One" }),
+      makeTx({ id: 81, description: "Two" }),
+    ];
+    setupApiFetch(txs, {
+      requested_count: 2,
+      updated_count: 1,
+      skipped: [{ id: 81, reason: "Manual balance adjustments cannot be edited" }],
+    });
+    render(<TransactionsPage />);
+
+    const dialog = await selectAllAndOpenModal();
+
+    const combo = within(dialog).getByRole("combobox", { name: /category/i });
+    fireEvent.focus(combo);
+    const listbox = await within(dialog).findByRole("listbox");
+    fireEvent.click(within(listbox).getByText("Dining"));
+    fireEvent.click(within(dialog).getByRole("button", { name: /apply/i }));
+
+    expect(
+      await screen.findByText(/Updated 1 of 2\..*1 skipped.*Manual balance adjustments/i),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/tests/components/transactions/batch-edit-modal.test.tsx
+++ b/frontend/tests/components/transactions/batch-edit-modal.test.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import BatchEditModal from "@/components/transactions/BatchEditModal";
+import type { Account, Category } from "@/lib/types";
+
+// TagChipInput hits apiFetch for autocomplete suggestions on type. Mock it so
+// the component renders without a network call in the test harness.
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn(async () => ({ suggestions: [] })) };
+});
+
+const CATEGORIES: Category[] = [
+  {
+    id: 11,
+    name: "Groceries",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "groceries",
+    is_system: false,
+    transaction_count: 0,
+  },
+  {
+    id: 12,
+    name: "Salary",
+    type: "income",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "salary",
+    is_system: false,
+    transaction_count: 0,
+  },
+];
+
+const ACCOUNTS: Account[] = [
+  {
+    id: 100,
+    name: "Checking",
+    account_type_id: 1,
+    account_type_name: "Bank",
+    account_type_slug: "bank",
+    balance: 0,
+    currency: "EUR",
+    is_active: true,
+    close_day: null,
+    is_default: true,
+  },
+  {
+    id: 101,
+    name: "Old Savings",
+    account_type_id: 1,
+    account_type_name: "Bank",
+    account_type_slug: "bank",
+    balance: 0,
+    currency: "EUR",
+    is_active: false,
+    close_day: null,
+    is_default: false,
+  },
+];
+
+function renderModal(over: Partial<React.ComponentProps<typeof BatchEditModal>> = {}) {
+  const onSubmit = vi.fn();
+  const onCancel = vi.fn();
+  render(
+    <BatchEditModal
+      open
+      count={3}
+      categories={CATEGORIES}
+      accounts={ACCOUNTS}
+      submitting={false}
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+      {...over}
+    />,
+  );
+  return { onSubmit, onCancel };
+}
+
+describe("BatchEditModal", () => {
+  it("renders nothing when open is false", () => {
+    const { container } = render(
+      <BatchEditModal
+        open={false}
+        count={3}
+        categories={CATEGORIES}
+        accounts={ACCOUNTS}
+        submitting={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the selected count, the four controls, and the transfer hint", () => {
+    renderModal({ count: 5 });
+
+    // Count surfaces in the dialog (title).
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText(/5/)).toBeTruthy();
+
+    // Category picker (CategorySelect renders a combobox).
+    expect(screen.getByRole("combobox", { name: /category/i })).toBeTruthy();
+
+    // Status select with a "No change" default option.
+    const status = screen.getByLabelText(/status/i) as HTMLSelectElement;
+    expect(status.tagName).toBe("SELECT");
+    expect(status.options[0].textContent).toMatch(/no change/i);
+
+    // Account select with a "No change" default option.
+    const account = screen.getByLabelText(/account/i) as HTMLSelectElement;
+    expect(account.tagName).toBe("SELECT");
+    expect(account.options[0].textContent).toMatch(/no change/i);
+
+    // Tags input.
+    expect(screen.getByLabelText(/add tags/i)).toBeTruthy();
+
+    // Transfer hint paragraph.
+    expect(
+      screen.getByText(
+        /Account and tags are not applied to transfers\. A transfer's category must be a transfer-compatible \(both\) category\./i,
+      ),
+    ).toBeTruthy();
+  });
+
+  it("disables Apply with nothing set and does not call onSubmit", () => {
+    const { onSubmit } = renderModal();
+    const apply = screen.getByRole("button", { name: /apply/i }) as HTMLButtonElement;
+    expect(apply.disabled).toBe(true);
+    fireEvent.click(apply);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("setting only Status=pending submits exactly { status: 'pending' }", () => {
+    const { onSubmit } = renderModal();
+    const status = screen.getByLabelText(/status/i);
+    fireEvent.change(status, { target: { value: "pending" } });
+
+    const apply = screen.getByRole("button", { name: /apply/i }) as HTMLButtonElement;
+    expect(apply.disabled).toBe(false);
+    fireEvent.click(apply);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({ status: "pending" });
+  });
+
+  it("setting a Category submits { category_id }", () => {
+    const { onSubmit } = renderModal();
+    const combo = screen.getByRole("combobox", { name: /category/i });
+    fireEvent.focus(combo);
+    // Pick "Groceries" (id 11) from the open listbox.
+    const listbox = screen.getByRole("listbox");
+    fireEvent.click(within(listbox).getByText("Groceries"));
+
+    const apply = screen.getByRole("button", { name: /apply/i }) as HTMLButtonElement;
+    expect(apply.disabled).toBe(false);
+    fireEvent.click(apply);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({ category_id: 11 });
+  });
+});


### PR DESCRIPTION
Adds a Batch edit action to the transactions selection toolbar (alongside Delete selected): select multiple rows and set Category, Status, Account, and/or add Tags in one operation.

Backend: new POST /api/v1/transactions/bulk-update loops the existing single-update service per row, reusing its validation, balance revert/apply, transfer both-guard, and partner category cascade, plus a tag-merge wrapper. Partial success: each row that applies at least one field counts as updated; rows that can't are returned in skipped[] with a reason. Tag failures (incl. a unique-constraint race) degrade to a per-row skip instead of aborting the batch.

Transfers accept Category only (cascaded to the partner, must be a both-type category); Status, Account, and Tags are skipped for transfer legs (the modal states this upfront). Tags are added/merged (existing tags kept). Manual balance adjustments are skipped. Cap 500 ids/request.

This is PR 3 of 3 from the transactions-page fixes spec; it reuses PR 1's transfer guard.