### PR TITLE
docs(stack): correct Next.js version to 16 in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ The Better Decision is a personal finance management application. FastAPI backen
 ## Stack
 
 - **Backend:** Python 3.12, FastAPI, SQLAlchemy 2.0 (async), Alembic, Pydantic v2
-- **Frontend:** Next.js 15 (App Router), React 19, TypeScript, Tailwind CSS, SWR
+- **Frontend:** Next.js 16 (App Router), React 19, TypeScript, Tailwind CSS, SWR
 - **Database:** MySQL 8.0
 - **Auth:** JWT (access + refresh tokens), bcrypt via passlib
 - **Reverse proxy:** nginx (single entry point on port 80)


### PR DESCRIPTION
CLAUDE.md's stack line said "Next.js 15"; the project is on next@16.2.4 (frontend/package.json). The rest of the stack line is accurate (Python 3.12, React 19.2, SQLAlchemy 2.0.41, Pydantic 2.11, FastAPI 0.115, MySQL 8.0). codebase_shape already reflects 16; frontend "Next 15+" code comments are accurate API-history notes and were left as-is.