### PR TITLE
fix(accounts): overflow menu for row actions so Account column fits

### DIFF
--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -416,7 +416,7 @@ export default function AccountsPage() {
   // the inline buttons (Edit, optional Adjust balance) plus the "..."
   // overflow trigger. Without Adjust balance only Edit + "..." sit there
   // (~5rem); with it the column needs room for "Adjust balance" too
-  // (~11rem). The first column stays minmax(0,1fr) so the account name
+  // (~12rem). The first column stays minmax(0,1fr) so the account name
   // takes all the freed space.
   const accountsGridTemplate = canAdjustBalance
     ? "md:grid-cols-[minmax(0,1fr)_8rem_8rem_12rem]"

--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -24,6 +24,7 @@ import { input, label, btnPrimary, card, cardHeader, cardTitle, error as errorCl
 import { useTransactionAddedListener } from "@/lib/hooks/use-transaction-added";
 import type { Account, AccountType, Transaction } from "@/lib/types";
 import ConfirmModal from "@/components/ui/ConfirmModal";
+import OverflowMenu, { type OverflowMenuItem } from "@/components/ui/OverflowMenu";
 import AdjustBalanceModal from "@/components/accounts/AdjustBalanceModal";
 
 // Sortable column identifiers for the accounts list.
@@ -354,6 +355,13 @@ export default function AccountsPage() {
     } catch (err) { setError(extractErrorMessage(err)); }
   }
 
+  async function handleSetDefault(account: Account) {
+    try {
+      await apiFetch(`/api/v1/accounts/${account.id}`, { method: "PUT", body: JSON.stringify({ is_default: true }) });
+      await reload();
+    } catch (err) { setError(extractErrorMessage(err)); }
+  }
+
   // Per-account pending totals. Income contributes positively, expense
   // negatively (so for a CC, pending is normally negative — money owed).
   // The display below renders Math.abs() and the "Pending:" label, so
@@ -401,6 +409,18 @@ export default function AccountsPage() {
     },
     [sortField, sortDir, setSort],
   );
+
+  // Shared grid template for the accounts list. The header <tr> and each
+  // row <article> MUST use the IDENTICAL template string so the columns
+  // line up. The trailing action column is a small FIXED width sized for
+  // the inline buttons (Edit, optional Adjust balance) plus the "..."
+  // overflow trigger. Without Adjust balance only Edit + "..." sit there
+  // (~5rem); with it the column needs room for "Adjust balance" too
+  // (~11rem). The first column stays minmax(0,1fr) so the account name
+  // takes all the freed space.
+  const accountsGridTemplate = canAdjustBalance
+    ? "md:grid-cols-[minmax(0,1fr)_8rem_8rem_12rem]"
+    : "md:grid-cols-[minmax(0,1fr)_8rem_8rem_5rem]";
 
   return (
     <AppShell>
@@ -602,7 +622,7 @@ export default function AccountsPage() {
                   className="hidden w-full border-b border-border-subtle md:table"
                 >
                   <thead>
-                    <tr className="grid grid-cols-[minmax(0,1fr)_8rem_8rem_auto] items-center gap-4 px-3">
+                    <tr className={`grid ${accountsGridTemplate} items-center gap-4 px-3`}>
                       <SortableHeader
                         label="Account"
                         field="name"
@@ -703,7 +723,7 @@ export default function AccountsPage() {
                     key={a.id}
                     data-testid={`account-row-${a.id}`}
                     data-account-name={a.name}
-                    className={`flex flex-col gap-3 rounded-md px-3 py-2.5 transition-colors hover:bg-surface-raised md:grid md:grid-cols-[minmax(0,1fr)_8rem_8rem_auto] md:items-center md:gap-4 ${!a.is_active ? "opacity-40" : ""}`}
+                    className={`flex flex-col gap-3 rounded-md px-3 py-2.5 transition-colors hover:bg-surface-raised md:grid ${accountsGridTemplate} md:items-center md:gap-4 ${!a.is_active ? "opacity-40" : ""}`}
                   >
                     {/* Description column: name + meta. The "DEFAULT"
                         badge is a fixed-width inline pill (NOT trailing
@@ -762,49 +782,57 @@ export default function AccountsPage() {
                         </span>
                       ) : null}
                     </div>
-                    {/* Action column with fixed slots so links don't
-                        shift when an action is conditionally absent
-                        (e.g. "Set default" disappears once the row IS
-                        the default). Each conditional action renders an
-                        empty placeholder span when omitted, keeping
-                        every action's column position stable across
-                        rows. The "Adjust balance" slot is omitted from
-                        the template entirely when the user lacks the
-                        permission, so non-admin views aren't padded. */}
-                    <div
-                      data-testid={`account-row-actions-${a.id}`}
-                      className={`flex flex-wrap gap-3 md:grid md:items-center md:justify-end md:gap-3 ${
-                        canAdjustBalance
-                          ? "md:grid-cols-[3rem_7rem_5rem_5.5rem_4rem]"
-                          : "md:grid-cols-[3rem_5rem_5.5rem_4rem]"
-                      }`}
-                    >
-                      <button onClick={() => startEditAcct(a)} aria-label={`Edit ${a.name}`} className="min-h-[44px] text-left text-xs text-text-muted hover:text-accent md:min-h-0 md:text-center">Edit</button>
-                      {canAdjustBalance && (
-                        a.is_active ? (
-                          <button
-                            onClick={() => setAdjustingAccount(a)}
-                            aria-label={`Adjust balance of ${a.name}`}
-                            className="min-h-[44px] text-left text-xs text-text-muted hover:text-accent md:min-h-0 md:text-center"
-                          >
-                            Adjust balance
-                          </button>
-                        ) : (
-                          <span aria-hidden="true" className="hidden md:block" />
-                        )
-                      )}
-                      {!a.is_default && a.is_active ? (
-                        <button onClick={async () => { try { await apiFetch(`/api/v1/accounts/${a.id}`, { method: "PUT", body: JSON.stringify({ is_default: true }) }); await reload(); } catch (err) { setError(extractErrorMessage(err)); } }} aria-label={`Set ${a.name} as default`} className="min-h-[44px] text-left text-xs text-text-muted hover:text-accent md:min-h-0 md:text-center">
-                          Set default
-                        </button>
-                      ) : (
-                        <span aria-hidden="true" className="hidden md:block" />
-                      )}
-                      <button onClick={() => handleToggleActive(a)} aria-label={a.is_active ? `Deactivate ${a.name}` : `Activate ${a.name}`} className="min-h-[44px] text-left text-xs text-text-muted hover:text-text-secondary md:min-h-0 md:text-center">
-                        {a.is_active ? "Deactivate" : "Activate"}
-                      </button>
-                      <button onClick={() => setConfirmDeleteAcctId(a.id)} aria-label={`Delete ${a.name}`} className="min-h-[44px] text-left text-xs text-text-muted hover:text-danger md:min-h-0 md:text-center">Delete</button>
-                    </div>
+                    {/* Action column. Edit (and Adjust balance, when the
+                        admin permission is on AND the account is active)
+                        stay inline; the rarer actions move into a per-row
+                        "..." overflow menu so the action column can be a
+                        small fixed width and the Account name column gets
+                        the freed space. The fixed width is shared with the
+                        header via accountsGridTemplate so the columns stay
+                        aligned. */}
+                    {(() => {
+                      const overflowItems: OverflowMenuItem[] = [];
+                      if (!a.is_default && a.is_active) {
+                        overflowItems.push({
+                          label: "Set default",
+                          ariaLabel: `Set ${a.name} as default`,
+                          onSelect: () => { void handleSetDefault(a); },
+                        });
+                      }
+                      overflowItems.push({
+                        label: a.is_active ? "Deactivate" : "Activate",
+                        ariaLabel: a.is_active ? `Deactivate ${a.name}` : `Activate ${a.name}`,
+                        onSelect: () => { void handleToggleActive(a); },
+                      });
+                      overflowItems.push({
+                        label: "Delete",
+                        ariaLabel: `Delete ${a.name}`,
+                        danger: true,
+                        onSelect: () => setConfirmDeleteAcctId(a.id),
+                      });
+                      return (
+                        <div
+                          data-testid={`account-row-actions-${a.id}`}
+                          className="flex items-center justify-end gap-3"
+                        >
+                          <button onClick={() => startEditAcct(a)} aria-label={`Edit ${a.name}`} className="min-h-[44px] whitespace-nowrap text-xs text-text-muted hover:text-accent md:min-h-0">Edit</button>
+                          {canAdjustBalance && a.is_active && (
+                            <button
+                              onClick={() => setAdjustingAccount(a)}
+                              aria-label={`Adjust balance of ${a.name}`}
+                              className="min-h-[44px] whitespace-nowrap text-xs text-text-muted hover:text-accent md:min-h-0"
+                            >
+                              Adjust balance
+                            </button>
+                          )}
+                          <OverflowMenu
+                            items={overflowItems}
+                            label={`More actions for ${a.name}`}
+                            testId={`account-row-overflow-${a.id}`}
+                          />
+                        </div>
+                      );
+                    })()}
                   </article>
                 ))}
                 {accounts.length === 0 && (

--- a/frontend/components/ui/OverflowMenu.tsx
+++ b/frontend/components/ui/OverflowMenu.tsx
@@ -25,8 +25,10 @@ import { MoreHorizontal } from "lucide-react";
  *     the first item.
  *   - ArrowDown / ArrowUp cycle items.
  *   - Escape closes the menu and returns focus to the trigger.
- *   - Tab closes the menu and returns focus to the trigger (the menu is
- *     not a focus trap; focus then continues to the next page control).
+ *   - Tab closes the menu and returns focus to the trigger. Tab's default
+ *     traversal is prevented, so focus stays on the trigger rather than
+ *     advancing to the next control (the menu is not a focus trap).
+ *   - Selecting an item closes the menu and returns focus to the trigger.
  *   - Outside mousedown closes the menu.
  */
 
@@ -127,7 +129,13 @@ export default function OverflowMenu({
   }
 
   function selectItem(item: OverflowMenuItem) {
+    // Restore focus to the trigger BEFORE running the action. Selecting an
+    // item unmounts the focused menuitem; without this, focus falls to
+    // <body>, and an action that opens a modal (e.g. Delete -> ConfirmModal)
+    // would anchor its restore-focus to <body> instead of the trigger.
+    // setOpen is deferred, so the menu is still mounted at this point.
     setOpen(false);
+    triggerRef.current?.focus();
     item.onSelect();
   }
 
@@ -160,7 +168,7 @@ export default function OverflowMenu({
         >
           {items.map((item, i) => (
             <button
-              key={item.label}
+              key={item.testId ?? `${item.ariaLabel ?? item.label}-${i}`}
               ref={i === 0 ? firstItemRef : undefined}
               type="button"
               role="menuitem"

--- a/frontend/components/ui/OverflowMenu.tsx
+++ b/frontend/components/ui/OverflowMenu.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import {
+  KeyboardEvent as ReactKeyboardEvent,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+
+import { MoreHorizontal } from "lucide-react";
+
+/**
+ * Reusable per-row overflow ("...") menu.
+ *
+ * Mirrors the dropdown-menu pattern used by AppShellAddTransactionCta:
+ *   - Trigger button with the lucide MoreHorizontal icon and the full
+ *     aria-haspopup / aria-expanded / aria-controls contract.
+ *   - Popover with role="menu", absolutely positioned, right-aligned.
+ *   - Each item is a <button role="menuitem"> with an optional danger
+ *     variant.
+ *
+ * Keyboard contract (WAI-ARIA menu button, non-trapping):
+ *   - Enter / Space / click on the trigger opens the menu and focuses
+ *     the first item.
+ *   - ArrowDown / ArrowUp cycle items.
+ *   - Escape closes the menu and returns focus to the trigger.
+ *   - Tab closes the menu and returns focus to the trigger (the menu is
+ *     not a focus trap; focus then continues to the next page control).
+ *   - Outside mousedown closes the menu.
+ */
+
+export interface OverflowMenuItem {
+  label: string;
+  onSelect: () => void;
+  danger?: boolean;
+  /** Override the accessible name when it must differ from the visible label. */
+  ariaLabel?: string;
+  /** Optional data-testid for the individual menu item button. */
+  testId?: string;
+}
+
+export interface OverflowMenuProps {
+  items: OverflowMenuItem[];
+  /** aria-label for the trigger button. Default "More actions". */
+  label?: string;
+  /** Optional data-testid for the trigger button. */
+  testId?: string;
+}
+
+export default function OverflowMenu({
+  items,
+  label = "More actions",
+  testId,
+}: OverflowMenuProps) {
+  const [open, setOpen] = useState(false);
+
+  const menuId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const firstItemRef = useRef<HTMLButtonElement>(null);
+
+  // Close on outside mousedown / Escape (returning focus to the trigger).
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      const target = e.target as Node;
+      if (
+        menuRef.current?.contains(target) ||
+        triggerRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  // Focus the first item when the menu opens. setTimeout 0 lets the
+  // popover mount before focus moves.
+  useEffect(() => {
+    if (open) {
+      const id = window.setTimeout(() => {
+        firstItemRef.current?.focus();
+      }, 0);
+      return () => window.clearTimeout(id);
+    }
+  }, [open]);
+
+  function onMenuKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
+    if (e.key === "Tab") {
+      e.preventDefault();
+      setOpen(false);
+      triggerRef.current?.focus();
+      return;
+    }
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+    e.preventDefault();
+    const buttons = Array.from(
+      menuRef.current?.querySelectorAll<HTMLButtonElement>(
+        '[role="menuitem"]',
+      ) ?? [],
+    );
+    if (buttons.length === 0) return;
+    const active = document.activeElement as HTMLElement | null;
+    const currentIndex = active
+      ? buttons.indexOf(active as HTMLButtonElement)
+      : -1;
+    const delta = e.key === "ArrowDown" ? 1 : -1;
+    const nextIndex =
+      currentIndex === -1
+        ? 0
+        : (currentIndex + delta + buttons.length) % buttons.length;
+    buttons[nextIndex].focus();
+  }
+
+  function selectItem(item: OverflowMenuItem) {
+    setOpen(false);
+    item.onSelect();
+  }
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="relative inline-flex">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={label}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={menuId}
+        data-testid={testId}
+        className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-text-muted hover:bg-surface-raised hover:text-text-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 md:min-h-0 md:min-w-0 md:p-1.5"
+      >
+        <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          id={menuId}
+          role="menu"
+          aria-label={label}
+          onKeyDown={onMenuKeyDown}
+          className="absolute right-0 top-full z-50 mt-1 w-48 overflow-hidden rounded-md border border-border bg-surface shadow-lg"
+        >
+          {items.map((item, i) => (
+            <button
+              key={item.label}
+              ref={i === 0 ? firstItemRef : undefined}
+              type="button"
+              role="menuitem"
+              onClick={() => selectItem(item)}
+              aria-label={item.ariaLabel}
+              data-testid={item.testId}
+              className={`flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm hover:bg-surface-raised focus:bg-surface-raised focus:outline-none ${
+                item.danger
+                  ? "text-danger hover:text-danger"
+                  : "text-text-primary"
+              }`}
+            >
+              <span>{item.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/tests/app/accounts-adjust-balance-button.test.tsx
+++ b/frontend/tests/app/accounts-adjust-balance-button.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 
 import AccountsPage from "@/app/accounts/page";
 import { apiFetch } from "@/lib/api";
@@ -122,5 +122,26 @@ describe("AccountsPage — Adjust balance button gating (Track E)", () => {
         screen.getByRole("button", { name: /Adjust balance of Primary/i })
       ).toBeTruthy();
     });
+  });
+
+  it("keeps header/row grid templates aligned in the wider Adjust-balance (12rem) branch", async () => {
+    // When canAdjustBalance is true the action column widens to 12rem. The
+    // header <tr> and each row <article> must still carry the IDENTICAL
+    // md:grid-cols-* template, otherwise the columns drift (the misalignment
+    // bug this refactor fixes). The other (5rem) branch is covered in
+    // accounts-list-headers.test.tsx.
+    setUser("admin", true);
+    render(<AccountsPage />);
+    await waitFor(() => expect(screen.getByText("Primary")).toBeTruthy());
+
+    const gridCols = (el: HTMLElement) =>
+      Array.from(el.classList).find((c) => c.startsWith("md:grid-cols-"));
+    const headerRow = within(
+      screen.getByTestId("accounts-list-header"),
+    ).getByRole("row");
+    const row = screen.getByTestId("account-row-10");
+
+    expect(gridCols(headerRow)).toContain("12rem");
+    expect(gridCols(row)).toBe(gridCols(headerRow));
   });
 });

--- a/frontend/tests/app/accounts-list-headers.test.tsx
+++ b/frontend/tests/app/accounts-list-headers.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import AccountsPage from "@/app/accounts/page";
 import { apiFetch } from "@/lib/api";
@@ -151,41 +151,73 @@ describe("AccountsPage — list header row and fixed action column", () => {
     expect(screen.queryByTestId("accounts-list-header")).toBeNull();
   });
 
-  it("uses the same action-column grid template regardless of DEFAULT badge", async () => {
+  it("uses the same shared grid template on header and rows so columns align", async () => {
     render(<AccountsPage />);
     await waitFor(() => expect(screen.getByText(/Amex Primary/)).toBeInTheDocument());
 
-    const nonDefaultActions = screen.getByTestId("account-row-actions-10");
-    const defaultActions = screen.getByTestId("account-row-actions-20");
-
-    // The grid-cols-* utility (which encodes the fixed-slot widths)
-    // must be identical between the two rows. If "Set default" being
-    // omitted on the default row collapsed an action slot, this would
-    // diverge — exactly the bug we are guarding against.
+    // The header <tr> and each row <article> must carry the IDENTICAL
+    // md:grid-cols-* template so the Account / Type / Balance / Actions
+    // columns line up. A drift here is exactly the misalignment bug this
+    // refactor fixes.
     const gridCols = (el: HTMLElement) =>
       Array.from(el.classList).find((c) => c.startsWith("md:grid-cols-"));
-    expect(gridCols(nonDefaultActions)).toBeDefined();
-    expect(gridCols(nonDefaultActions)).toBe(gridCols(defaultActions));
 
-    // Same number of grid children rendered on each row, so each slot
-    // is occupied either by a button or an aria-hidden placeholder.
-    expect(nonDefaultActions.children.length).toBe(defaultActions.children.length);
+    const headerRow = within(
+      screen.getByTestId("accounts-list-header"),
+    ).getByRole("row");
+    const nonDefaultRow = screen.getByTestId("account-row-10");
+    const defaultRow = screen.getByTestId("account-row-20");
+
+    expect(gridCols(headerRow)).toBeDefined();
+    expect(gridCols(nonDefaultRow)).toBe(gridCols(headerRow));
+    expect(gridCols(defaultRow)).toBe(gridCols(headerRow));
   });
 
-  it("still renders Edit / Activate-Deactivate / Delete on the default row", async () => {
+  it("keeps the inline Edit button and exposes the rest via the overflow menu", async () => {
     render(<AccountsPage />);
     await waitFor(() => expect(screen.getByText(/ING Joint/)).toBeInTheDocument());
 
-    // The default row keeps its non-conditional actions; only "Set
-    // default" is replaced by a placeholder.
+    // Edit stays inline on every row.
     expect(screen.getByRole("button", { name: /^Edit ING Joint$/ })).toBeInTheDocument();
+
+    // Deactivate / Delete live behind the per-row "..." menu and are not
+    // in the DOM until it is opened.
     expect(
-      screen.getByRole("button", { name: /^Deactivate ING Joint$/ }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^Delete ING Joint$/ })).toBeInTheDocument();
-    // No "Set default" button on the default row.
-    expect(
-      screen.queryByRole("button", { name: /Set ING Joint as default/ }),
+      screen.queryByRole("menuitem", { name: /^Deactivate ING Joint$/ }),
     ).toBeNull();
+
+    const actions = screen.getByTestId("account-row-actions-20");
+    fireEvent.click(
+      within(actions).getByRole("button", { name: /More actions for ING Joint/ }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("menuitem", { name: /^Deactivate ING Joint$/ }),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("menuitem", { name: /^Delete ING Joint$/ }),
+    ).toBeInTheDocument();
+    // No "Set default" item on the default row.
+    expect(
+      screen.queryByRole("menuitem", { name: /Set ING Joint as default/ }),
+    ).toBeNull();
+  });
+
+  it("offers Set default in the overflow menu only on a non-default active row", async () => {
+    render(<AccountsPage />);
+    await waitFor(() => expect(screen.getByText(/Amex Primary/)).toBeInTheDocument());
+
+    const actions = screen.getByTestId("account-row-actions-10");
+    fireEvent.click(
+      within(actions).getByRole("button", { name: /More actions for Amex Primary/ }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("menuitem", { name: /^Set Amex Primary as default$/ }),
+      ).toBeInTheDocument(),
+    );
   });
 });

--- a/frontend/tests/app/accounts-side-by-side-layout.test.tsx
+++ b/frontend/tests/app/accounts-side-by-side-layout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import AccountsPage from "@/app/accounts/page";
 import { apiFetch } from "@/lib/api";
@@ -134,9 +134,15 @@ describe("AccountsPage — side-by-side layout (post-#199 follow-up)", () => {
     expect(screen.getByPlaceholderText(/New type name/)).toBeInTheDocument();
 
     // Accounts card actions survived (Add Account toggle + row actions).
+    // Edit stays inline; Delete now lives in the per-row "..." overflow menu.
     expect(screen.getByRole("button", { name: /\+ Add Account/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^Edit Amex Primary$/ })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^Delete Amex Primary$/ })).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: /More actions for Amex Primary/ }),
+    );
+    expect(
+      await screen.findByRole("menuitem", { name: /^Delete Amex Primary$/ }),
+    ).toBeInTheDocument();
 
     // Page-title HelpAnchor still present (link with `Help: Accounts`).
     expect(

--- a/frontend/tests/app/accounts-sort-pagination.test.tsx
+++ b/frontend/tests/app/accounts-sort-pagination.test.tsx
@@ -221,9 +221,15 @@ describe("AccountsPage — page clamping when row count shrinks", () => {
     }) as never);
 
     // Delete the first row visible on page 2 (Acct 025, id=125).
-    // The row's delete button has aria-label "Delete Acct 025".
-    const deleteBtn = screen.getByRole("button", { name: /Delete Acct 025/ });
-    fireEvent.click(deleteBtn);
+    // Delete now lives in the per-row "..." overflow menu, so open it
+    // first, then click the Delete menu item (aria-label "Delete Acct 025").
+    fireEvent.click(
+      screen.getByRole("button", { name: /More actions for Acct 025/ }),
+    );
+    const deleteItem = await screen.findByRole("menuitem", {
+      name: /Delete Acct 025/,
+    });
+    fireEvent.click(deleteItem);
 
     // ConfirmModal appears — click its Delete confirmation button (last "Delete").
     await screen.findByText(/Delete this account/);

--- a/frontend/tests/components/ui/overflow-menu.test.tsx
+++ b/frontend/tests/components/ui/overflow-menu.test.tsx
@@ -1,0 +1,156 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import OverflowMenu, {
+  type OverflowMenuItem,
+} from "@/components/ui/OverflowMenu";
+
+function items(onDelete = vi.fn(), onActivate = vi.fn()): OverflowMenuItem[] {
+  return [
+    { label: "Set default", onSelect: vi.fn() },
+    { label: "Deactivate", onSelect: onActivate },
+    { label: "Delete", onSelect: onDelete, danger: true },
+  ];
+}
+
+describe("OverflowMenu", () => {
+  it("renders a trigger with the menu-button aria contract", () => {
+    render(<OverflowMenu items={items()} testId="row-overflow" />);
+    const trigger = screen.getByTestId("row-overflow");
+    expect(trigger).toHaveAttribute("aria-haspopup", "menu");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveAttribute("aria-label", "More actions");
+  });
+
+  it("honours a custom trigger label", () => {
+    render(<OverflowMenu items={items()} label="More actions for Amex" />);
+    expect(
+      screen.getByRole("button", { name: "More actions for Amex" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when there are no items", () => {
+    const { container } = render(<OverflowMenu items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("opens on click and renders each item, including the danger variant", async () => {
+    render(<OverflowMenu items={items()} testId="row-overflow" />);
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("row-overflow"));
+
+    await waitFor(() => expect(screen.getByRole("menu")).toBeInTheDocument());
+    expect(screen.getByTestId("row-overflow")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(screen.getByRole("menuitem", { name: "Set default" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Deactivate" })).toBeInTheDocument();
+    const del = screen.getByRole("menuitem", { name: "Delete" });
+    expect(del).toBeInTheDocument();
+    expect(del.className).toContain("text-danger");
+  });
+
+  it("fires the item's onSelect and closes the menu when clicked", async () => {
+    const onDelete = vi.fn();
+    render(<OverflowMenu items={items(onDelete)} testId="row-overflow" />);
+    fireEvent.click(screen.getByTestId("row-overflow"));
+    await waitFor(() =>
+      expect(screen.getByRole("menuitem", { name: "Delete" })).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+  });
+
+  it("uses ariaLabel override for the accessible name when provided", async () => {
+    render(
+      <OverflowMenu
+        items={[
+          {
+            label: "Set default",
+            ariaLabel: "Set Amex as default",
+            onSelect: vi.fn(),
+          },
+        ]}
+        testId="row-overflow"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("row-overflow"));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("menuitem", { name: "Set Amex as default" }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("focuses the first item on open", async () => {
+    render(<OverflowMenu items={items()} testId="row-overflow" />);
+    fireEvent.click(screen.getByTestId("row-overflow"));
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("menuitem", { name: "Set default" }),
+      ),
+    );
+  });
+
+  it("ArrowDown / ArrowUp cycle focus between items", async () => {
+    render(<OverflowMenu items={items()} testId="row-overflow" />);
+    fireEvent.click(screen.getByTestId("row-overflow"));
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("menuitem", { name: "Set default" }),
+      ),
+    );
+
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowDown" });
+    expect(document.activeElement).toBe(
+      screen.getByRole("menuitem", { name: "Deactivate" }),
+    );
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowUp" });
+    expect(document.activeElement).toBe(
+      screen.getByRole("menuitem", { name: "Set default" }),
+    );
+  });
+
+  it("closes on Escape and returns focus to the trigger", async () => {
+    render(<OverflowMenu items={items()} testId="row-overflow" />);
+    fireEvent.click(screen.getByTestId("row-overflow"));
+    await waitFor(() => expect(screen.getByRole("menu")).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    expect(document.activeElement).toBe(screen.getByTestId("row-overflow"));
+  });
+
+  it("closes on Tab and returns focus to the trigger", async () => {
+    render(<OverflowMenu items={items()} testId="row-overflow" />);
+    fireEvent.click(screen.getByTestId("row-overflow"));
+    await waitFor(() => expect(screen.getByRole("menu")).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.keyDown(screen.getByRole("menu"), { key: "Tab" });
+    });
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    expect(document.activeElement).toBe(screen.getByTestId("row-overflow"));
+  });
+
+  it("closes on outside mousedown", async () => {
+    render(
+      <div>
+        <button type="button" data-testid="outside">
+          outside
+        </button>
+        <OverflowMenu items={items()} testId="row-overflow" />
+      </div>,
+    );
+    fireEvent.click(screen.getByTestId("row-overflow"));
+    await waitFor(() => expect(screen.getByRole("menu")).toBeInTheDocument());
+
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+  });
+});

--- a/frontend/tests/components/ui/overflow-menu.test.tsx
+++ b/frontend/tests/components/ui/overflow-menu.test.tsx
@@ -64,6 +64,22 @@ describe("OverflowMenu", () => {
     await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
   });
 
+  it("restores focus to the trigger when an item is selected", async () => {
+    // Selecting an item unmounts the focused menuitem. Focus must land back
+    // on the trigger (not <body>) so an action that opens a modal anchors
+    // its restore-focus to the trigger, and so keyboard users keep a stable
+    // anchor for non-modal actions.
+    render(<OverflowMenu items={items()} testId="row-overflow" />);
+    fireEvent.click(screen.getByTestId("row-overflow"));
+    await waitFor(() =>
+      expect(screen.getByRole("menuitem", { name: "Delete" })).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    expect(document.activeElement).toBe(screen.getByTestId("row-overflow"));
+  });
+
   it("uses ariaLabel override for the accessible name when provided", async () => {
     render(
       <OverflowMenu


### PR DESCRIPTION
## Problem

On the Accounts page the **Account** column collapsed so names truncated to "A…", "FJ…", and the Type/Balance headers floated far right of their data.

Two causes:
1. Each row reserved ~440px for five inline text actions (Edit / Adjust balance / Set default / Deactivate / Delete). Inside the 2/3-width Accounts card that left almost nothing for the name, so `minmax(0,1fr)` collapsed to ~0.
2. The header was a separate grid whose empty (sr-only) Actions cell made its `auto` last column ~0px, while the rows' `auto` column was ~440px. Same template string, different resolved widths, so the `1fr` account column differed between header and rows.

## Fix

- New reusable `OverflowMenu` (`components/ui/OverflowMenu.tsx`) following the existing `AppShellAddTransactionCta` dropdown pattern (role="menu", outside-click/Escape/Tab close, first-item focus, arrow-key cycling, full aria contract).
- Accounts rows now keep **Edit** and **Adjust balance** (when permitted and active) inline; **Set default**, **Activate/Deactivate**, and **Delete** move into a per-row "…" menu.
- The action column becomes a small fixed width (12rem with Adjust balance, 5rem without), and the **same** `accountsGridTemplate` is applied to both the header `<tr>` and each row `<article>` so columns can't drift. The account name column reclaims the freed space.
- Existing accessible names are preserved on the menu items (e.g. `Set {name} as default`, `Deactivate {name}`, `Delete {name}`).

Frontend-only. `tsc --noEmit` clean; 49 accounts + OverflowMenu tests pass (11 new for the component).