### PR TITLE
fix: resolve P1 audit findings (a11y contrast, dialog semantics, phantom tokens, chart code-split)

### DIFF
--- a/frontend/app/budgets/BudgetOverviewChart.tsx
+++ b/frontend/app/budgets/BudgetOverviewChart.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * Colocated recharts subtree for the Budgets page "Budget Overview" bar
+ * chart. Extracted so the page can dynamic-import it (ssr:false) and keep
+ * recharts out of the budgets route's initial JS. Data + the bar-click
+ * navigation are passed in as props; this only renders the chart.
+ */
+import {
+  Bar,
+  BarChart,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { formatAmount } from "@/lib/format";
+import { chartColor } from "@/lib/chart-colors";
+import { BudgetSpentBarShape, type BudgetSpentBarShapeProps } from "@/lib/chart-shapes";
+
+export interface BudgetOverviewDatum {
+  name: string;
+  spent: number;
+  remaining: number;
+  over: number;
+}
+
+export default function BudgetOverviewChart({
+  budgetChartData,
+  cellMeta,
+  onBarClick,
+}: {
+  budgetChartData: BudgetOverviewDatum[];
+  // Index-aligned per-row color driver (percent_used) + a stable key.
+  cellMeta: Array<{ category_id: number; percent_used: number }>;
+  onBarClick: (name: string | undefined) => void;
+}) {
+  return (
+    <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 1, height: 1 }}>
+      <BarChart data={budgetChartData} layout="vertical" margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
+        <XAxis type="number" hide />
+        <YAxis type="category" dataKey="name" width={100} tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
+        <Tooltip
+          formatter={(v, name) => [
+            formatAmount(Number(v)),
+            name === "spent" ? <span style={{ color: chartColor.spent }}>Spent</span>
+              : name === "over" ? <span style={{ color: chartColor.over }}>Over budget</span>
+              : <span style={{ color: chartColor.remaining }}>Remaining</span>,
+          ]}
+          contentStyle={{ fontSize: "11px" }}
+        />
+        {/* D5 fix: shared BudgetSpentBarShape recomputes corner radii
+            per-row so a stack at >=100% utilization (no remaining
+            segment, no over segment) still rounds its right edge. */}
+        <Bar dataKey="spent" stackId="a" animationDuration={600}
+          cursor="pointer"
+          shape={(props: BudgetSpentBarShapeProps) => (
+            <BudgetSpentBarShape {...props} />
+          )}
+          onClick={(data) => onBarClick(data?.name || data?.payload?.name)}
+        >
+          {cellMeta.map((b) => (
+            <Cell
+              key={b.category_id}
+              fill={b.percent_used > 100 ? chartColor.over : b.percent_used > 80 ? chartColor.watch : chartColor.spent}
+            />
+          ))}
+        </Bar>
+        <Bar dataKey="remaining" stackId="a" fill={chartColor.remaining} radius={[0, 4, 4, 0]} animationDuration={600} />
+        <Bar dataKey="over" stackId="a" fill={chartColor.over} radius={[4, 4, 4, 4]} animationDuration={600} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -11,12 +11,24 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { formatAmount, todayISO } from "@/lib/format";
 import { input, label, btnPrimary, card, cardHeader, cardTitle, error as errorCls, pageTitle, badgeError } from "@/lib/styles";
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts";
+import dynamic from "next/dynamic";
 import type { BillingPeriod, Budget, Category } from "@/lib/types";
 import ConfirmModal from "@/components/ui/ConfirmModal";
+// chartColor (theme tokens) stays for the static DOM legend swatches
+// below the chart; the recharts subtree itself is code-split into
+// BudgetOverviewChart and loaded via next/dynamic (ssr:false).
 import { chartColor } from "@/lib/chart-colors";
-import { BudgetSpentBarShape, type BudgetSpentBarShapeProps } from "@/lib/chart-shapes";
 import { useTransactionAddedListener } from "@/lib/hooks/use-transaction-added";
+
+const BudgetOverviewChart = dynamic(() => import("./BudgetOverviewChart"), {
+  ssr: false,
+  loading: () => (
+    <div
+      aria-hidden="true"
+      className="h-full w-full animate-pulse rounded bg-surface-raised"
+    />
+  ),
+});
 import { useAiStatus } from "@/lib/hooks/use-ai-status";
 import { SetUpAiCta } from "@/components/ai/SetUpAiCta";
 import BudgetRebalanceModal from "@/components/budgets/BudgetRebalanceModal";
@@ -379,47 +391,13 @@ export default function BudgetsPage() {
                 </span>
               </div>
               <div className="w-full min-w-0 p-4" style={{ height: Math.max(budgets.length * 36, 100) }}>
-                <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 1, height: 1 }}>
-                  <BarChart data={budgetChartData} layout="vertical" margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
-                    <XAxis type="number" hide />
-                    <YAxis type="category" dataKey="name" width={100} tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
-                    <Tooltip
-                      formatter={(v, name) => [
-                        formatAmount(Number(v)),
-                        name === "spent" ? <span style={{ color: chartColor.spent }}>Spent</span>
-                          : name === "over" ? <span style={{ color: chartColor.over }}>Over budget</span>
-                          : <span style={{ color: chartColor.remaining }}>Remaining</span>,
-                      ]}
-                      contentStyle={{ fontSize: "11px" }}
-                    />
-                    {/* D5 fix: shared BudgetSpentBarShape recomputes
-                        corner radii per-row so a stack at >=100%
-                        utilization (no remaining segment, no over
-                        segment) still rounds its right edge. Static
-                        radius={[4,0,0,4]} on the Bar wouldn't, because
-                        the trailing remaining bar would normally own
-                        the right rounding. */}
-                    <Bar dataKey="spent" stackId="a" animationDuration={600}
-                      cursor="pointer"
-                      shape={(props: BudgetSpentBarShapeProps) => (
-                        <BudgetSpentBarShape {...props} />
-                      )}
-                      onClick={(data) => {
-                        const name = data?.name || data?.payload?.name;
-                        if (name) router.push(`/transactions?category=${encodeURIComponent(name)}`);
-                      }}
-                    >
-                      {budgets.map((b) => (
-                        <Cell
-                          key={b.category_id}
-                          fill={b.percent_used > 100 ? chartColor.over : b.percent_used > 80 ? chartColor.watch : chartColor.spent}
-                        />
-                      ))}
-                    </Bar>
-                    <Bar dataKey="remaining" stackId="a" fill={chartColor.remaining} radius={[0, 4, 4, 0]} animationDuration={600} />
-                    <Bar dataKey="over" stackId="a" fill={chartColor.over} radius={[4, 4, 4, 4]} animationDuration={600} />
-                  </BarChart>
-                </ResponsiveContainer>
+                <BudgetOverviewChart
+                  budgetChartData={budgetChartData}
+                  cellMeta={budgets}
+                  onBarClick={(name) => {
+                    if (name) router.push(`/transactions?category=${encodeURIComponent(name)}`);
+                  }}
+                />
               </div>
               <div className="mt-3 flex gap-4 px-4 pb-2 text-[10px] text-text-muted">
                 <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.spent }} /> Spent</span>

--- a/frontend/app/forecast-plans/ForecastPlanChart.tsx
+++ b/frontend/app/forecast-plans/ForecastPlanChart.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+/**
+ * Colocated recharts subtree for the Forecast Plans "Planned vs Actual"
+ * bar chart. Extracted so the client page can dynamic-import it
+ * (ssr:false) and keep recharts out of the route's initial JS. Data + the
+ * bar-click navigation are passed in as props; this only renders the
+ * chart.
+ */
+import {
+  Bar,
+  BarChart,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { formatAmount } from "@/lib/format";
+import { chartColor } from "@/lib/chart-colors";
+
+export interface ForecastPlanChartDatum {
+  categoryId: number;
+  name: string;
+  planned: number;
+  actual: number;
+}
+
+export default function ForecastPlanChart({
+  chartData,
+  onBarClick,
+}: {
+  chartData: ForecastPlanChartDatum[];
+  onBarClick: (name: string | undefined) => void;
+}) {
+  return (
+    <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 1, height: 1 }}>
+      <BarChart
+        data={chartData}
+        layout="vertical"
+        margin={{ left: 0, right: 20, top: 0, bottom: 0 }}
+      >
+        <XAxis type="number" hide />
+        <YAxis
+          type="category"
+          dataKey="name"
+          width={100}
+          tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+        />
+        <Tooltip
+          formatter={(v, name) => [
+            formatAmount(Number(v)),
+            name === "planned" ? <span style={{ color: chartColor.planned }}>Planned</span> : <span style={{ color: chartColor.actual }}>Actual</span>,
+          ]}
+          contentStyle={{ fontSize: "11px" }}
+        />
+        <Bar
+          dataKey="planned"
+          fill={chartColor.planned}
+          radius={[4, 4, 4, 4]}
+          animationDuration={600}
+          cursor="pointer"
+          onClick={(data) => onBarClick(data?.name || data?.payload?.name)}
+        />
+        <Bar
+          dataKey="actual"
+          fill={chartColor.actual}
+          radius={[4, 4, 4, 4]}
+          animationDuration={600}
+        >
+          {chartData.map((d) => (
+            <Cell
+              key={d.categoryId}
+              fill={d.actual > d.planned ? chartColor.over : chartColor.actual}
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/app/forecast-plans/ForecastPlansClient.tsx
+++ b/frontend/app/forecast-plans/ForecastPlansClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import AppShell from "@/components/AppShell";
@@ -25,19 +26,24 @@ import {
   btnLink,
   btnDanger,
 } from "@/lib/styles";
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  Cell,
-
-} from "recharts";
 import type { BillingPeriod, Category, ForecastPlan, ForecastPlanItem } from "@/lib/types";
+// chartColor (theme tokens) stays for the static DOM legend swatches
+// below the chart; the recharts subtree is code-split (see below).
 import { chartColor } from "@/lib/chart-colors";
 import { useTransactionAddedListener } from "@/lib/hooks/use-transaction-added";
+
+// The recharts subtree (Planned vs Actual) is code-split into
+// ForecastPlanChart and loaded via next/dynamic (ssr:false) so recharts
+// stays out of the route's initial JS.
+const ForecastPlanChart = dynamic(() => import("./ForecastPlanChart"), {
+  ssr: false,
+  loading: () => (
+    <div
+      aria-hidden="true"
+      className="h-full w-full animate-pulse rounded bg-surface-raised"
+    />
+  ),
+});
 
 // "Auto" is the honest label for source=history (PR #146 #1). populate
 // surfaces both 3-month-average rows AND current-period-only rows under
@@ -1184,52 +1190,12 @@ export default function ForecastPlansClient({
                 Planned vs Actual (Expenses)
               </h2>
               <div className="w-full min-w-0" style={{ height: Math.max(chartData.length * 40, 100) }}>
-                <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 1, height: 1 }}>
-                  <BarChart
-                    data={chartData}
-                    layout="vertical"
-                    margin={{ left: 0, right: 20, top: 0, bottom: 0 }}
-                  >
-                    <XAxis type="number" hide />
-                    <YAxis
-                      type="category"
-                      dataKey="name"
-                      width={100}
-                      tick={{ fill: chartColor.axisTick, fontSize: 11 }}
-                    />
-                    <Tooltip
-                      formatter={(v, name) => [
-                        formatAmount(Number(v)),
-                        name === "planned" ? <span style={{ color: chartColor.planned }}>Planned</span> : <span style={{ color: chartColor.actual }}>Actual</span>,
-                      ]}
-                      contentStyle={{ fontSize: "11px" }}
-                    />
-                    <Bar
-                      dataKey="planned"
-                      fill={chartColor.planned}
-                      radius={[4, 4, 4, 4]}
-                      animationDuration={600}
-                      cursor="pointer"
-                      onClick={(data) => {
-                        const name = data?.name || data?.payload?.name;
-                        if (name) router.push(`/transactions?category=${encodeURIComponent(name)}`);
-                      }}
-                    />
-                    <Bar
-                      dataKey="actual"
-                      fill={chartColor.actual}
-                      radius={[4, 4, 4, 4]}
-                      animationDuration={600}
-                    >
-                      {chartData.map((d) => (
-                        <Cell
-                          key={d.categoryId}
-                          fill={d.actual > d.planned ? chartColor.over : chartColor.actual}
-                        />
-                      ))}
-                    </Bar>
-                  </BarChart>
-                </ResponsiveContainer>
+                <ForecastPlanChart
+                  chartData={chartData}
+                  onBarClick={(name) => {
+                    if (name) router.push(`/transactions?category=${encodeURIComponent(name)}`);
+                  }}
+                />
               </div>
               <div className="mt-3 flex gap-4 px-4 pb-2 text-[10px] text-text-muted">
                 <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.planned }} /> Planned</span>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -20,7 +20,10 @@
 
   --theme-text-primary: #E6EAF0;
   --theme-text-secondary: #9ba8bd;
-  --theme-text-muted: #5a6a82;
+  /* Lifted from #5a6a82 (3.0:1 on surface) to clear WCAG 1.4.3 (>=4.5:1) on
+     every dark surface up to surface-overlay; muted stays below text-secondary
+     so the hierarchy holds. */
+  --theme-text-muted: #8f9db2;
 
   --theme-accent: #D4A64A;
   --theme-accent-hover: #B88A2E;
@@ -69,10 +72,15 @@
 
   --theme-text-primary: #0B1F3A;
   --theme-text-secondary: #3d5070;
-  --theme-text-muted: #8895a8;
+  /* Darkened from #8895a8 (3.0:1 on white) to clear WCAG 1.4.3 on the light
+     surfaces. */
+  --theme-text-muted: #5d6a7e;
 
-  --theme-accent: #B88A2E;
-  --theme-accent-hover: #9a7425;
+  /* Darkened from #B88A2E (white-on-brass was 3.13:1) so primary buttons and
+     text-accent links clear 4.5:1 in the light theme. Sidebar brass is a
+     separate always-dark token and is unaffected. */
+  --theme-accent: #8a6a1f;
+  --theme-accent-hover: #75591a;
   --theme-accent-dim: rgba(184, 138, 46, 0.08);
   --theme-accent-text: #ffffff;
 

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -417,8 +417,9 @@ function ImportPageContent() {
           </div>
           <div className="space-y-4 p-6">
             <div>
-              <label className={label}>Target Account</label>
+              <label htmlFor="import-target-account" className={label}>Target Account</label>
               <select
+                id="import-target-account"
                 value={accountId}
                 onChange={(e) => setAccountId(e.target.value === "" ? "" : Number(e.target.value))}
                 className={input}
@@ -432,8 +433,9 @@ function ImportPageContent() {
               </select>
             </div>
             <div>
-              <label className={label}>CSV File</label>
+              <label htmlFor="import-csv-file" className={label}>CSV File</label>
               <input
+                id="import-csv-file"
                 type="file"
                 accept=".csv"
                 onChange={(e) => setFile(e.target.files?.[0] ?? null)}
@@ -515,10 +517,11 @@ function ImportPageContent() {
           {/* Default category */}
           <div className={card}>
             <div className="p-6">
-              <label className={label}>
+              <label htmlFor="import-default-category" className={label}>
                 Default Category (applied to rows without a specific category)
               </label>
               <select
+                id="import-default-category"
                 value={defaultCategoryId}
                 onChange={(e) => setDefaultCategoryId(e.target.value === "" ? "" : Number(e.target.value))}
                 className={input + " max-w-sm"}

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -615,7 +615,7 @@ export default function ReportEditorPage({ params }: PageProps) {
             <button
               type="button"
               onClick={() => setPickerOpen(true)}
-              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-surface-raised"
               data-testid="report-editor-add-widget"
             >
               Add widget
@@ -626,7 +626,7 @@ export default function ReportEditorPage({ params }: PageProps) {
               type="button"
               onClick={handleSave}
               disabled={saving || !dirty}
-              className="rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-text transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
               data-testid="report-editor-save"
             >
               {saving ? "Saving..." : "Save"}
@@ -636,7 +636,7 @@ export default function ReportEditorPage({ params }: PageProps) {
             <button
               type="button"
               onClick={handleCancelEdit}
-              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-surface-raised"
               data-testid="report-editor-cancel"
             >
               Cancel
@@ -650,7 +650,7 @@ export default function ReportEditorPage({ params }: PageProps) {
               type="button"
               onClick={handleToggleVisibility}
               disabled={togglingVisibility}
-              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-surface-raised disabled:cursor-not-allowed disabled:opacity-60"
               data-testid="report-editor-visibility-toggle"
               aria-label="Toggle report sharing"
             >
@@ -671,7 +671,7 @@ export default function ReportEditorPage({ params }: PageProps) {
             type="button"
             onClick={handleDuplicate}
             disabled={duplicating}
-            className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-60"
+            className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-surface-raised disabled:cursor-not-allowed disabled:opacity-60"
             data-testid="report-editor-duplicate"
           >
             {duplicating ? "Duplicating..." : "Duplicate"}
@@ -680,7 +680,7 @@ export default function ReportEditorPage({ params }: PageProps) {
           <button
             type="button"
             onClick={() => setHistoryOpen(true)}
-            className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+            className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-surface-raised"
             data-testid="report-editor-history"
           >
             History
@@ -705,7 +705,7 @@ export default function ReportEditorPage({ params }: PageProps) {
             <button
               type="button"
               onClick={() => setEditMode((v) => !v)}
-              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-surface-raised"
               data-testid="report-editor-toggle-edit"
             >
               {editMode ? "Done" : "Edit"}
@@ -764,7 +764,7 @@ export default function ReportEditorPage({ params }: PageProps) {
                   <button
                     type="button"
                     onClick={() => setPickerOpen(true)}
-                    className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover"
+                    className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-text transition hover:bg-accent-hover"
                     data-testid="report-editor-empty-add-widget"
                   >
                     Add widget
@@ -772,7 +772,7 @@ export default function ReportEditorPage({ params }: PageProps) {
                 )}
                 <Link
                   href="/reports"
-                  className="rounded-md border border-border px-4 py-2 text-sm text-text-primary hover:bg-bg-elevated"
+                  className="rounded-md border border-border px-4 py-2 text-sm text-text-primary hover:bg-surface-raised"
                   data-testid="report-editor-empty-templates"
                 >
                   Start from a template

--- a/frontend/app/reports/new/page.tsx
+++ b/frontend/app/reports/new/page.tsx
@@ -225,7 +225,7 @@ export default function ReportDraftPage() {
             <button
               type="button"
               onClick={() => setPickerOpen(true)}
-              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-surface-raised"
               data-testid="report-draft-add-widget"
             >
               Add widget
@@ -234,7 +234,7 @@ export default function ReportDraftPage() {
               type="button"
               onClick={handleSave}
               disabled={saving}
-              className="rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-text transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
               data-testid="report-draft-save"
             >
               {saving ? "Saving..." : "Save"}
@@ -242,7 +242,7 @@ export default function ReportDraftPage() {
             <button
               type="button"
               onClick={handleCancel}
-              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-surface-raised"
               data-testid="report-draft-cancel"
             >
               Cancel
@@ -281,7 +281,7 @@ export default function ReportDraftPage() {
                   <button
                     type="button"
                     onClick={() => setPickerOpen(true)}
-                    className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover"
+                    className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-text transition hover:bg-accent-hover"
                     data-testid="report-draft-empty-add-widget"
                   >
                     Add widget

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -144,7 +144,7 @@ export default function ReportsListPage() {
         <button
           type="button"
           onClick={handleNewReport}
-          className="inline-flex items-center gap-2 rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover"
+          className="inline-flex items-center gap-2 rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-text transition hover:bg-accent-hover"
         >
           New report
         </button>
@@ -178,7 +178,7 @@ export default function ReportsListPage() {
                 <button
                   type="button"
                   onClick={() => handleUseTemplate(t)}
-                  className="mt-3 inline-flex items-center justify-center gap-2 self-start rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover"
+                  className="mt-3 inline-flex items-center justify-center gap-2 self-start rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-text transition hover:bg-accent-hover"
                 >
                   Use template
                 </button>
@@ -207,7 +207,7 @@ export default function ReportsListPage() {
       ) : (
         <ul className="divide-y divide-border rounded-md border border-border bg-surface">
           {(reports ?? []).map((r) => (
-            <li key={r.id} className="flex items-center hover:bg-bg-elevated">
+            <li key={r.id} className="flex items-center hover:bg-surface-raised">
               <Link
                 href={`/reports/${r.id}`}
                 className="flex flex-1 items-center justify-between px-4 py-3"
@@ -229,7 +229,7 @@ export default function ReportsListPage() {
                 type="button"
                 onClick={() => handleDuplicate(r)}
                 disabled={duplicatingId === r.id}
-                className="mr-2 rounded-md border border-border px-2.5 py-1 text-xs text-text-primary hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-60"
+                className="mr-2 rounded-md border border-border px-2.5 py-1 text-xs text-text-primary hover:bg-surface-raised disabled:cursor-not-allowed disabled:opacity-60"
                 data-testid={`report-duplicate-${r.id}`}
               >
                 {duplicatingId === r.id ? "Duplicating..." : "Duplicate"}

--- a/frontend/app/settings/organization/page.tsx
+++ b/frontend/app/settings/organization/page.tsx
@@ -673,12 +673,12 @@ export default function OrganizationSettingsPage() {
           <div className="p-6 space-y-4">
             <form onSubmit={handleAdd} className="flex flex-col gap-3 sm:flex-row sm:items-end sm:gap-3">
               <div className="flex-1">
-                <label className={label}>Key</label>
-                <input value={key} onChange={(e) => setKey(e.target.value)} className={`${input} w-full`} placeholder="key" />
+                <label htmlFor="org-setting-key" className={label}>Key</label>
+                <input id="org-setting-key" value={key} onChange={(e) => setKey(e.target.value)} className={`${input} w-full`} placeholder="key" />
               </div>
               <div className="flex-1">
-                <label className={label}>Value</label>
-                <input value={value} onChange={(e) => setValue(e.target.value)} className={`${input} w-full`} placeholder="value" />
+                <label htmlFor="org-setting-value" className={label}>Value</label>
+                <input id="org-setting-value" value={value} onChange={(e) => setValue(e.target.value)} className={`${input} w-full`} placeholder="value" />
               </div>
               <button type="submit" className={`${btnPrimary} w-full sm:w-auto sm:min-h-0`}>Add</button>
             </form>

--- a/frontend/app/system/announcements/page.tsx
+++ b/frontend/app/system/announcements/page.tsx
@@ -228,8 +228,9 @@ export default function SystemAnnouncementsPage() {
           </div>
           <form onSubmit={handleSubmit} className="p-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="sm:col-span-2">
-              <label className={label}>Title</label>
+              <label htmlFor="announcement-title" className={label}>Title</label>
               <input
+                id="announcement-title"
                 value={formTitle}
                 onChange={(e) => setFormTitle(e.target.value)}
                 className={input}
@@ -239,8 +240,9 @@ export default function SystemAnnouncementsPage() {
               />
             </div>
             <div className="sm:col-span-2">
-              <label className={label}>Body</label>
+              <label htmlFor="announcement-body" className={label}>Body</label>
               <textarea
+                id="announcement-body"
                 value={formBody}
                 onChange={(e) => setFormBody(e.target.value)}
                 className={`${input} min-h-[120px]`}
@@ -253,8 +255,9 @@ export default function SystemAnnouncementsPage() {
               </p>
             </div>
             <div>
-              <label className={label}>Severity</label>
+              <label htmlFor="announcement-severity" className={label}>Severity</label>
               <select
+                id="announcement-severity"
                 value={formSeverity}
                 onChange={(e) => setFormSeverity(e.target.value as Severity)}
                 className={input}
@@ -278,8 +281,9 @@ export default function SystemAnnouncementsPage() {
               </label>
             </div>
             <div>
-              <label className={label}>Start (UTC, optional)</label>
+              <label htmlFor="announcement-start" className={label}>Start (UTC, optional)</label>
               <input
+                id="announcement-start"
                 type="datetime-local"
                 value={formStartAt}
                 onChange={(e) => setFormStartAt(e.target.value)}
@@ -288,8 +292,9 @@ export default function SystemAnnouncementsPage() {
               />
             </div>
             <div>
-              <label className={label}>End (UTC, optional)</label>
+              <label htmlFor="announcement-end" className={label}>End (UTC, optional)</label>
               <input
+                id="announcement-end"
                 type="datetime-local"
                 value={formEndAt}
                 onChange={(e) => setFormEndAt(e.target.value)}

--- a/frontend/app/system/plans/page.tsx
+++ b/frontend/app/system/plans/page.tsx
@@ -210,12 +210,13 @@ export default function SystemPlansPage() {
           </div>
           <form onSubmit={handleSubmit} className="p-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div>
-              <label className={label}>Name</label>
-              <input value={formName} onChange={(e) => setFormName(e.target.value)} className={input} required />
+              <label htmlFor="plan-name" className={label}>Name</label>
+              <input id="plan-name" value={formName} onChange={(e) => setFormName(e.target.value)} className={input} required />
             </div>
             <div>
-              <label className={label}>Slug</label>
+              <label htmlFor="plan-slug" className={label}>Slug</label>
               <input
+                id="plan-slug"
                 value={formSlug}
                 onChange={(e) => setFormSlug(e.target.value)}
                 className={input}
@@ -225,28 +226,28 @@ export default function SystemPlansPage() {
               />
             </div>
             <div className="sm:col-span-2">
-              <label className={label}>Description</label>
-              <input value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />
+              <label htmlFor="plan-description" className={label}>Description</label>
+              <input id="plan-description" value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />
             </div>
             <div>
-              <label className={label}>Price Monthly (€)</label>
-              <input type="number" step="0.01" min="0" value={formPriceMonthly} onChange={(e) => setFormPriceMonthly(e.target.value)} className={input} />
+              <label htmlFor="plan-price-monthly" className={label}>Price Monthly (€)</label>
+              <input id="plan-price-monthly" type="number" step="0.01" min="0" value={formPriceMonthly} onChange={(e) => setFormPriceMonthly(e.target.value)} className={input} />
             </div>
             <div>
-              <label className={label}>Price Yearly (€)</label>
-              <input type="number" step="0.01" min="0" value={formPriceYearly} onChange={(e) => setFormPriceYearly(e.target.value)} className={input} />
+              <label htmlFor="plan-price-yearly" className={label}>Price Yearly (€)</label>
+              <input id="plan-price-yearly" type="number" step="0.01" min="0" value={formPriceYearly} onChange={(e) => setFormPriceYearly(e.target.value)} className={input} />
             </div>
             <div>
-              <label className={label}>Max Users (blank = unlimited)</label>
-              <input type="number" min="1" value={formMaxUsers} onChange={(e) => setFormMaxUsers(e.target.value)} className={input} />
+              <label htmlFor="plan-max-users" className={label}>Max Users (blank = unlimited)</label>
+              <input id="plan-max-users" type="number" min="1" value={formMaxUsers} onChange={(e) => setFormMaxUsers(e.target.value)} className={input} />
             </div>
             <div>
-              <label className={label}>Retention Days (blank = unlimited)</label>
-              <input type="number" min="1" value={formRetentionDays} onChange={(e) => setFormRetentionDays(e.target.value)} className={input} />
+              <label htmlFor="plan-retention-days" className={label}>Retention Days (blank = unlimited)</label>
+              <input id="plan-retention-days" type="number" min="1" value={formRetentionDays} onChange={(e) => setFormRetentionDays(e.target.value)} className={input} />
             </div>
             <div>
-              <label className={label}>Sort Order</label>
-              <input type="number" value={formSortOrder} onChange={(e) => setFormSortOrder(e.target.value)} className={input} />
+              <label htmlFor="plan-sort-order" className={label}>Sort Order</label>
+              <input id="plan-sort-order" type="number" value={formSortOrder} onChange={(e) => setFormSortOrder(e.target.value)} className={input} />
             </div>
             <div className="flex items-center gap-2 pt-6">
               <input type="checkbox" id="is_custom" checked={formIsCustom} onChange={(e) => setFormIsCustom(e.target.checked)} />

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1413,16 +1413,17 @@ function TransactionsPageContent() {
                             )}
                             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                               <div>
-                                <label className={label}>Date</label>
-                                <input aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm ${input}`} />
+                                <label htmlFor={`edit-date-mobile-${tx.id}`} className={label}>Date</label>
+                                <input id={`edit-date-mobile-${tx.id}`} aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm ${input}`} />
                               </div>
                               <div>
-                                <label className={label}>Description</label>
-                                <input aria-label="Description" type="text" required value={editDesc} onChange={(e) => setEditDesc(e.target.value)} className={`text-sm ${input}`} />
+                                <label htmlFor={`edit-desc-mobile-${tx.id}`} className={label}>Description</label>
+                                <input id={`edit-desc-mobile-${tx.id}`} aria-label="Description" type="text" required value={editDesc} onChange={(e) => setEditDesc(e.target.value)} className={`text-sm ${input}`} />
                               </div>
                               <div>
-                                <label className={label}>Account</label>
+                                <label htmlFor={`edit-account-mobile-${tx.id}`} className={label}>Account</label>
                                 <select
+                                  id={`edit-account-mobile-${tx.id}`}
                                   aria-label="Account"
                                   value={editAccountId}
                                   onChange={(e) => setEditAccountId(e.target.value === "" ? "" : Number(e.target.value))}
@@ -1439,7 +1440,7 @@ function TransactionsPageContent() {
                                 </select>
                               </div>
                               <div>
-                                <label className={label}>Category</label>
+                                <label htmlFor={`edit-cat-mobile-${tx.id}`} className={label}>Category</label>
                                 <CategorySelect aria-label="Category" id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={isTransfer ? undefined : editType} typeFilter={isTransfer ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
                                 {categorizeAi?.entitled && !editPartner ? (
                                   <div className="mt-1">
@@ -1462,14 +1463,14 @@ function TransactionsPageContent() {
                                 ) : null}
                               </div>
                               <div>
-                                <label className={label}>Status</label>
-                                <select aria-label="Status" value={editStatus} onChange={(e) => setEditStatus(e.target.value as "settled" | "pending")} className={`text-sm ${input}`}>
+                                <label htmlFor={`edit-status-mobile-${tx.id}`} className={label}>Status</label>
+                                <select id={`edit-status-mobile-${tx.id}`} aria-label="Status" value={editStatus} onChange={(e) => setEditStatus(e.target.value as "settled" | "pending")} className={`text-sm ${input}`}>
                                   <option value="settled">Settled</option>
                                   <option value="pending">Pending</option>
                                 </select>
                               </div>
                               <div>
-                                <label className={label}>Type</label>
+                                <label htmlFor={editPartner ? undefined : `edit-type-mobile-${tx.id}`} className={label}>Type</label>
                                 {editPartner ? (
                                   <span
                                     aria-label="Type"
@@ -1479,15 +1480,15 @@ function TransactionsPageContent() {
                                     {editType === "expense" ? "Expense" : "Income"}
                                   </span>
                                 ) : (
-                                  <select aria-label="Type" value={editType} onChange={(e) => { setEditType(e.target.value as "income" | "expense"); setEditCategoryId(""); }} className={`text-sm ${input}`}>
+                                  <select id={`edit-type-mobile-${tx.id}`} aria-label="Type" value={editType} onChange={(e) => { setEditType(e.target.value as "income" | "expense"); setEditCategoryId(""); }} className={`text-sm ${input}`}>
                                     <option value="expense">Expense</option>
                                     <option value="income">Income</option>
                                   </select>
                                 )}
                               </div>
                               <div className="sm:col-span-2">
-                                <label className={label}>Amount</label>
-                                <input aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm ${input}`} />
+                                <label htmlFor={`edit-amount-mobile-${tx.id}`} className={label}>Amount</label>
+                                <input id={`edit-amount-mobile-${tx.id}`} aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm ${input}`} />
                               </div>
                               <div className="sm:col-span-2">
                                 <label htmlFor={`edit-tags-mobile-${tx.id}`} className={label}>Tags</label>
@@ -1500,8 +1501,9 @@ function TransactionsPageContent() {
                               </div>
                               {editStatus === "pending" && (
                                 <div className="sm:col-span-2" data-testid={`edit-settled-date-cell-mobile-${tx.id}`}>
-                                  <label className={label}>Expected settlement date</label>
+                                  <label htmlFor={`edit-settled-mobile-${tx.id}`} className={label}>Expected settlement date</label>
                                   <input
+                                    id={`edit-settled-mobile-${tx.id}`}
                                     aria-label="Expected settlement date"
                                     type="date"
                                     min={editDate}
@@ -1548,8 +1550,9 @@ function TransactionsPageContent() {
                                     {editPromoteRecurring && (
                                       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                                         <div>
-                                          <label className={label}>Frequency</label>
+                                          <label htmlFor={`edit-rec-frequency-mobile-${tx.id}`} className={label}>Frequency</label>
                                           <select
+                                            id={`edit-rec-frequency-mobile-${tx.id}`}
                                             aria-label="Frequency"
                                             value={editRecFrequency}
                                             onChange={(e) =>
@@ -1567,8 +1570,9 @@ function TransactionsPageContent() {
                                           </select>
                                         </div>
                                         <div>
-                                          <label className={label}>Next due date</label>
+                                          <label htmlFor={`edit-rec-nextdue-mobile-${tx.id}`} className={label}>Next due date</label>
                                           <input
+                                            id={`edit-rec-nextdue-mobile-${tx.id}`}
                                             aria-label="Next due date"
                                             type="date"
                                             min={todayISO()}

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1158,10 +1158,13 @@ function TransactionsPageContent() {
                               </select>
                             </div>
                             <div>
-                              <label htmlFor={`edit-type-${tx.id}`} className={label}>Type</label>
+                              {editPartner ? (
+                                <span className={label}>Type</span>
+                              ) : (
+                                <label htmlFor={`edit-type-${tx.id}`} className={label}>Type</label>
+                              )}
                               {editPartner ? (
                                 <span
-                                  id={`edit-type-${tx.id}`}
                                   aria-label="Type"
                                   title="Type is fixed for transfer legs."
                                   className="text-sm flex items-center px-3 rounded border border-border bg-surface text-text-muted h-10"
@@ -1470,7 +1473,11 @@ function TransactionsPageContent() {
                                 </select>
                               </div>
                               <div>
-                                <label htmlFor={editPartner ? undefined : `edit-type-mobile-${tx.id}`} className={label}>Type</label>
+                                {editPartner ? (
+                                  <span className={label}>Type</span>
+                                ) : (
+                                  <label htmlFor={`edit-type-mobile-${tx.id}`} className={label}>Type</label>
+                                )}
                                 {editPartner ? (
                                   <span
                                     aria-label="Type"

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -407,6 +407,15 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex h-screen overflow-hidden">
+      {/* Skip link (WCAG 2.4.1 Bypass Blocks). Visually hidden until focused,
+          then surfaces top-left as a brass chip; jumps past the sidebar nav
+          straight to <main>. */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-accent focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-accent-text focus:shadow-lg"
+      >
+        Skip to main content
+      </a>
       {/* Mobile overlay backdrop — real <button> so keyboard users can dismiss */}
       {sidebarOpen && (
         <button
@@ -584,7 +593,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           </div>
         </header>
         <AnnouncementBar />
-        <main className="flex-1 overflow-auto p-4 sm:p-8"><div className="mx-auto max-w-screen-xl">{children}</div></main>
+        <main id="main-content" tabIndex={-1} className="flex-1 overflow-auto p-4 sm:p-8"><div className="mx-auto max-w-screen-xl">{children}</div></main>
         <AppShellFooter />
       </div>
     </div>

--- a/frontend/components/admin/ChangePlanModal.tsx
+++ b/frontend/components/admin/ChangePlanModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { btnPrimary, btnSecondary, card, error as errorCls, input, label } from "@/lib/styles";
@@ -19,6 +19,9 @@ export default function ChangePlanModal({ orgId, currentPlanSlug, onClose, onCha
   const [errorMsg, setErrorMsg] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
+  const dialogRef = useRef<HTMLFormElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
   useEffect(() => {
     apiFetch<Plan[]>("/api/v1/plans/all").then((all) => {
       setPlans(all);
@@ -26,6 +29,44 @@ export default function ChangePlanModal({ orgId, currentPlanSlug, onClose, onCha
       if (current) setPlanId(current.id);
     });
   }, [currentPlanSlug]);
+
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    const focusable = dialogRef.current?.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    focusable?.focus();
+    return () => {
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.stopPropagation(); onClose(); return; }
+      if (e.key === "Tab") {
+        const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault(); last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault(); first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -48,12 +89,24 @@ export default function ChangePlanModal({ orgId, currentPlanSlug, onClose, onCha
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4">
-      <form onSubmit={handleSubmit} className={`${card} w-full max-w-[min(28rem,calc(100vw-2rem))] p-6`}>
-        <h2 className="mb-4 text-lg font-semibold">Change plan</h2>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
+      onClick={onClose}
+    >
+      <form
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="change-plan-modal-title"
+        onSubmit={handleSubmit}
+        onClick={(e) => e.stopPropagation()}
+        className={`${card} w-full max-w-[min(28rem,calc(100vw-2rem))] p-6`}
+      >
+        <h2 id="change-plan-modal-title" className="mb-4 text-lg font-semibold">Change plan</h2>
         {errorMsg && <div className={`${errorCls} mb-3`}>{errorMsg}</div>}
-        <label className={label}>Plan</label>
+        <label htmlFor="change-plan-select" className={label}>Plan</label>
         <select
+          id="change-plan-select"
           value={planId}
           onChange={(e) => setPlanId(e.target.value === "" ? "" : Number(e.target.value))}
           className={input}

--- a/frontend/components/admin/ChangePlanModal.tsx
+++ b/frontend/components/admin/ChangePlanModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { useFocusTrap } from "@/lib/hooks/use-focus-trap";
 import { btnPrimary, btnSecondary, card, error as errorCls, input, label } from "@/lib/styles";
 import type { Plan } from "@/lib/types";
 
@@ -20,7 +21,8 @@ export default function ChangePlanModal({ orgId, currentPlanSlug, onClose, onCha
   const [submitting, setSubmitting] = useState(false);
 
   const dialogRef = useRef<HTMLFormElement>(null);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useFocusTrap({ active: true, containerRef: dialogRef });
 
   useEffect(() => {
     apiFetch<Plan[]>("/api/v1/plans/all").then((all) => {
@@ -31,33 +33,8 @@ export default function ChangePlanModal({ orgId, currentPlanSlug, onClose, onCha
   }, [currentPlanSlug]);
 
   useEffect(() => {
-    previousFocusRef.current = document.activeElement as HTMLElement;
-    const focusable = dialogRef.current?.querySelector<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    );
-    focusable?.focus();
-    return () => {
-      previousFocusRef.current?.focus();
-      previousFocusRef.current = null;
-    };
-  }, []);
-
-  useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { e.stopPropagation(); onClose(); return; }
-      if (e.key === "Tab") {
-        const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        );
-        if (!focusable || focusable.length === 0) return;
-        const first = focusable[0];
-        const last = focusable[focusable.length - 1];
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault(); last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault(); first.focus();
-        }
-      }
+      if (e.key === "Escape") { e.stopPropagation(); onClose(); }
     };
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);

--- a/frontend/components/admin/FeatureOverridesCard.tsx
+++ b/frontend/components/admin/FeatureOverridesCard.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { useFocusTrap } from "@/lib/hooks/use-focus-trap";
 import { FEATURE_LABELS } from "@/lib/feature-catalog";
 import { btnPrimary, btnSecondary, card, cardHeader, cardTitle, error as errorCls, input, label } from "@/lib/styles";
 import type { FeatureKey, FeatureStateResponse, FeatureStateRow } from "@/lib/types";
@@ -110,36 +111,12 @@ function FeatureOverrideEditModal({
   const [errorMsg, setErrorMsg] = useState("");
 
   const dialogRef = useRef<HTMLFormElement>(null);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
 
-  useEffect(() => {
-    previousFocusRef.current = document.activeElement as HTMLElement;
-    const focusable = dialogRef.current?.querySelector<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    );
-    focusable?.focus();
-    return () => {
-      previousFocusRef.current?.focus();
-      previousFocusRef.current = null;
-    };
-  }, []);
+  useFocusTrap({ active: true, containerRef: dialogRef });
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { e.stopPropagation(); onClose(); return; }
-      if (e.key === "Tab") {
-        const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        );
-        if (!focusable || focusable.length === 0) return;
-        const first = focusable[0];
-        const last = focusable[focusable.length - 1];
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault(); last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault(); first.focus();
-        }
-      }
+      if (e.key === "Escape") { e.stopPropagation(); onClose(); }
     };
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);

--- a/frontend/components/admin/FeatureOverridesCard.tsx
+++ b/frontend/components/admin/FeatureOverridesCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { FEATURE_LABELS } from "@/lib/feature-catalog";
@@ -109,6 +109,47 @@ function FeatureOverrideEditModal({
   const [submitting, setSubmitting] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
 
+  const dialogRef = useRef<HTMLFormElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    const focusable = dialogRef.current?.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    focusable?.focus();
+    return () => {
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.stopPropagation(); onClose(); return; }
+      if (e.key === "Tab") {
+        const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault(); last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault(); first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, []);
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setSubmitting(true);
@@ -130,13 +171,25 @@ function FeatureOverrideEditModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4">
-      <form onSubmit={handleSubmit} className={`${card} w-full max-w-md p-6`}>
-        <h2 className="mb-4 text-lg font-semibold">{FEATURE_LABELS[row.key].label}</h2>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
+      onClick={onClose}
+    >
+      <form
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`feature-override-modal-title-${row.key}`}
+        onSubmit={handleSubmit}
+        onClick={(e) => e.stopPropagation()}
+        className={`${card} w-full max-w-md p-6`}
+      >
+        <h2 id={`feature-override-modal-title-${row.key}`} className="mb-4 text-lg font-semibold">{FEATURE_LABELS[row.key].label}</h2>
         {errorMsg && <div className={`${errorCls} mb-3`}>{errorMsg}</div>}
         <div className="mb-3">
-          <label className={label}>Value</label>
+          <label htmlFor={`feature-override-value-${row.key}`} className={label}>Value</label>
           <select
+            id={`feature-override-value-${row.key}`}
             value={String(value)}
             onChange={(e) => setValue(e.target.value === "true")}
             className={input}
@@ -146,8 +199,9 @@ function FeatureOverrideEditModal({
           </select>
         </div>
         <div className="mb-3">
-          <label className={label}>Expires at (your local time, stored as UTC)</label>
+          <label htmlFor={`feature-override-expires-${row.key}`} className={label}>Expires at (your local time, stored as UTC)</label>
           <input
+            id={`feature-override-expires-${row.key}`}
             type="datetime-local"
             value={expiresAtLocal}
             onChange={(e) => setExpiresAtLocal(e.target.value)}
@@ -155,8 +209,9 @@ function FeatureOverrideEditModal({
           />
         </div>
         <div className="mb-4">
-          <label className={label}>Note (max 500 chars)</label>
+          <label htmlFor={`feature-override-note-${row.key}`} className={label}>Note (max 500 chars)</label>
           <textarea
+            id={`feature-override-note-${row.key}`}
             value={note}
             onChange={(e) => setNote(e.target.value)}
             maxLength={500}

--- a/frontend/components/dashboard/AIForecastRefinePanel.tsx
+++ b/frontend/components/dashboard/AIForecastRefinePanel.tsx
@@ -137,7 +137,7 @@ export function AIForecastRefinePanel({
               id="ai-refine-timeframe"
               value={timeframe}
               onChange={(e) => setTimeframe(Number(e.target.value))}
-              className="rounded border border-border bg-bg-secondary px-2 py-1 text-xs text-text-primary focus:border-accent focus:outline-none"
+              className="rounded border border-border bg-surface px-2 py-1 text-xs text-text-primary focus:border-accent focus:outline-none"
             >
               {TIMEFRAMES.map((m) => (
                 <option key={m} value={m}>
@@ -157,7 +157,7 @@ export function AIForecastRefinePanel({
               id="ai-refine-scope"
               value={scope}
               onChange={(e) => setScope(e.target.value)}
-              className="rounded border border-border bg-bg-secondary px-2 py-1 text-xs text-text-primary focus:border-accent focus:outline-none"
+              className="rounded border border-border bg-surface px-2 py-1 text-xs text-text-primary focus:border-accent focus:outline-none"
             >
               {SCOPES.map((s) => (
                 <option key={s.value} value={s.value}>
@@ -199,7 +199,7 @@ export function AIForecastRefinePanel({
             type="button"
             onClick={handleConfirm}
             disabled={!canProceed || estimating || running}
-            className="rounded border border-border bg-bg-secondary px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-bg-tertiary disabled:opacity-50"
+            className="rounded border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-surface-overlay disabled:opacity-50"
           >
             {running ? (
               <span className="inline-flex items-center gap-1">

--- a/frontend/components/dashboard/AIForecastRefineToggle.tsx
+++ b/frontend/components/dashboard/AIForecastRefineToggle.tsx
@@ -113,7 +113,7 @@ export default function AIForecastRefineToggle({
     return (
       <SetUpAiCta
         role={role}
-        className="rounded border border-border bg-bg-secondary px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-bg-tertiary disabled:opacity-50"
+        className="rounded border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-surface-overlay disabled:opacity-50"
       />
     );
   }
@@ -155,7 +155,7 @@ export default function AIForecastRefineToggle({
           type="button"
           onClick={() => setPanelOpen(true)}
           data-testid="ai-forecast-refine-toggle"
-          className="rounded border border-border bg-bg-secondary px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-bg-tertiary disabled:opacity-50"
+          className="rounded border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-surface-overlay disabled:opacity-50"
         >
           Refine forecast with AI
         </button>
@@ -177,7 +177,7 @@ export default function AIForecastRefineToggle({
         {aiApplied ? (
           <span
             data-testid="ai-refined-badge"
-            className="inline-flex items-center gap-1 rounded-full bg-bg-tertiary px-2 py-0.5 text-xs font-medium text-text-primary"
+            className="inline-flex items-center gap-1 rounded-full bg-surface-raised px-2 py-0.5 text-xs font-medium text-text-primary"
           >
             <Sparkles className="h-3 w-3" aria-hidden="true" />
             AI-refined
@@ -185,7 +185,7 @@ export default function AIForecastRefineToggle({
         ) : (
           <span
             data-testid="ai-fallback-badge"
-            className="inline-flex items-center gap-1 rounded-full bg-bg-tertiary px-2 py-0.5 text-xs font-medium text-text-muted"
+            className="inline-flex items-center gap-1 rounded-full bg-surface-raised px-2 py-0.5 text-xs font-medium text-text-muted"
           >
             <AlertTriangle className="h-3 w-3" aria-hidden="true" />
             Baseline (AI unavailable)

--- a/frontend/components/reports/WidgetPicker.tsx
+++ b/frontend/components/reports/WidgetPicker.tsx
@@ -151,7 +151,7 @@ export default function WidgetPicker({ open, onClose, onPick }: Props) {
                       type="button"
                       onClick={() => onPick(type)}
                       data-testid={`widget-picker-option-${type}`}
-                      className="flex w-full items-start gap-3 rounded-md border border-border bg-bg p-3 text-left transition hover:border-accent hover:bg-bg-elevated"
+                      className="flex w-full items-start gap-3 rounded-md border border-border bg-bg p-3 text-left transition hover:border-accent hover:bg-surface-raised"
                     >
                       <Icon
                         aria-hidden="true"

--- a/frontend/components/reports/filters/AccountFilter.tsx
+++ b/frontend/components/reports/filters/AccountFilter.tsx
@@ -88,8 +88,8 @@ export default function AccountFilter({
                 onClick={() => toggle(a.id)}
                 className={`rounded-full border px-2.5 py-0.5 text-xs transition ${
                   active
-                    ? "border-accent bg-accent text-accent-foreground"
-                    : "border-border text-text-secondary hover:bg-bg-elevated"
+                    ? "border-accent bg-accent text-accent-text"
+                    : "border-border text-text-secondary hover:bg-surface-raised"
                 }`}
               >
                 {a.name}

--- a/frontend/components/reports/filters/DatePresetChips.tsx
+++ b/frontend/components/reports/filters/DatePresetChips.tsx
@@ -91,8 +91,8 @@ export default function DatePresetChips({
               onClick={() => pick(p.key)}
               className={`rounded-full border px-3 py-1 text-xs transition ${
                 isActive
-                  ? "border-accent bg-accent text-accent-foreground"
-                  : "border-border text-text-secondary hover:bg-bg-elevated"
+                  ? "border-accent bg-accent text-accent-text"
+                  : "border-border text-text-secondary hover:bg-surface-raised"
               }`}
             >
               {p.label}

--- a/frontend/components/reports/filters/TagFilter.tsx
+++ b/frontend/components/reports/filters/TagFilter.tsx
@@ -104,8 +104,8 @@ export default function TagFilter({
                 onClick={() => toggle(t.name)}
                 className={`rounded-full border px-2.5 py-0.5 text-xs transition ${
                   active
-                    ? "border-accent bg-accent text-accent-foreground"
-                    : "border-border text-text-secondary hover:bg-bg-elevated"
+                    ? "border-accent bg-accent text-accent-text"
+                    : "border-border text-text-secondary hover:bg-surface-raised"
                 }`}
               >
                 {t.name}

--- a/frontend/components/reports/widgets/AreaWidget.tsx
+++ b/frontend/components/reports/widgets/AreaWidget.tsx
@@ -5,19 +5,16 @@
  * multiple series are configured AND ``stacked`` is true, the areas
  * stack (each series sums on top of the prior). When ``stacked`` is
  * false, overlapping areas render with transparency.
+ *
+ * The recharts-rendering subtree is code-split: it lives in
+ * ``AreaWidgetChart`` and is loaded via ``next/dynamic`` (ssr:false) so
+ * the ~100KB recharts bundle is fetched only when a chart actually
+ * mounts, not in the route's initial JS. The fallback matches the
+ * existing loading placeholder (the global prefers-reduced-motion block
+ * neutralizes the pulse).
  */
-import {
-  Area,
-  AreaChart,
-  CartesianGrid,
-  Legend,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import dynamic from "next/dynamic";
 
-import { chartColor } from "@/lib/chart-colors";
 import { useSeriesQueries } from "@/lib/reports/useReportQuery";
 import { mergeSeriesRows, seriesLabel } from "@/lib/reports/series";
 import type {
@@ -27,19 +24,21 @@ import type {
 import WidgetCsvButton from "./WidgetCsvButton";
 import { buildSeriesCsvDataset } from "./seriesCsv";
 
+const AreaWidgetChart = dynamic(() => import("./AreaWidgetChart"), {
+  ssr: false,
+  loading: () => (
+    <div
+      data-testid="area-widget-chart-loading"
+      className="h-full w-full animate-pulse rounded bg-border/40"
+    />
+  ),
+});
+
 interface Props {
   widget: AreaWidgetType;
   canvasFilters?: CanvasFilters;
   editMode?: boolean;
 }
-
-const AREA_COLORS = [
-  "var(--color-accent)",
-  "var(--color-success)",
-  "var(--color-info, var(--color-accent))",
-  "var(--color-warning, var(--color-text-secondary))",
-  "var(--color-danger)",
-];
 
 export default function AreaWidget({ widget, canvasFilters, editMode }: Props) {
   const measures = widget.config.measures.map((m) => m.measure);
@@ -104,35 +103,12 @@ export default function AreaWidget({ widget, canvasFilters, editMode }: Props) {
             No data
           </div>
         ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={rows} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
-              <XAxis
-                dataKey="label"
-                tick={{ fill: chartColor.axisTick, fontSize: 11 }}
-                interval={0}
-              />
-              <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
-              <Tooltip cursor={{ stroke: "var(--color-border)" }} />
-              {seriesKeys.length > 1 && (
-                <Legend wrapperStyle={{ fontSize: 11 }} />
-              )}
-              {seriesKeys.map((key, i) => (
-                <Area
-                  key={key}
-                  type="monotone"
-                  dataKey={key}
-                  name={labels[i]}
-                  stackId={stackId}
-                  stroke={AREA_COLORS[i % AREA_COLORS.length]}
-                  fill={AREA_COLORS[i % AREA_COLORS.length]}
-                  fillOpacity={seriesKeys.length > 1 ? 0.35 : 0.55}
-                  strokeWidth={2}
-                  isAnimationActive={false}
-                />
-              ))}
-            </AreaChart>
-          </ResponsiveContainer>
+          <AreaWidgetChart
+            rows={rows}
+            seriesKeys={seriesKeys}
+            labels={labels}
+            stackId={stackId}
+          />
         )}
       </div>
     </div>

--- a/frontend/components/reports/widgets/AreaWidgetChart.tsx
+++ b/frontend/components/reports/widgets/AreaWidgetChart.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * Recharts-rendering inner for AreaWidget. Split out so the heavy
+ * recharts bundle is dynamically imported (ssr:false) only when an area
+ * chart actually mounts — keeping recharts out of the route's initial
+ * JS. The public AreaWidget keeps all data wiring; this renders the
+ * already-merged rows.
+ */
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { chartColor } from "@/lib/chart-colors";
+
+const AREA_COLORS = [
+  "var(--color-accent)",
+  "var(--color-success)",
+  "var(--color-info, var(--color-accent))",
+  "var(--color-warning, var(--color-text-secondary))",
+  "var(--color-danger)",
+];
+
+export interface AreaWidgetChartProps {
+  rows: Array<{ label: string } & Record<string, number | string>>;
+  seriesKeys: string[];
+  labels: string[];
+  stackId?: string;
+}
+
+export default function AreaWidgetChart({
+  rows,
+  seriesKeys,
+  labels,
+  stackId,
+}: AreaWidgetChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <AreaChart data={rows} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+        <XAxis
+          dataKey="label"
+          tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+          interval={0}
+        />
+        <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
+        <Tooltip cursor={{ stroke: "var(--color-border)" }} />
+        {seriesKeys.length > 1 && <Legend wrapperStyle={{ fontSize: 11 }} />}
+        {seriesKeys.map((key, i) => (
+          <Area
+            key={key}
+            type="monotone"
+            dataKey={key}
+            name={labels[i]}
+            stackId={stackId}
+            stroke={AREA_COLORS[i % AREA_COLORS.length]}
+            fill={AREA_COLORS[i % AREA_COLORS.length]}
+            fillOpacity={seriesKeys.length > 1 ? 0.35 : 0.55}
+            strokeWidth={2}
+            isAnimationActive={false}
+          />
+        ))}
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/components/reports/widgets/BarWidget.tsx
+++ b/frontend/components/reports/widgets/BarWidget.tsx
@@ -17,19 +17,13 @@
  *
  * Recharts is the canvas chart engine across the app (Dashboard,
  * Budgets, Forecast Plans); reusing it here keeps visual register
- * consistent.
+ * consistent. The recharts subtree is code-split via ``next/dynamic``
+ * (ssr:false) into ``BarWidgetChart`` so recharts loads only when a
+ * chart mounts, keeping it out of the route's initial JS.
  */
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import dynamic from "next/dynamic";
 
-import { categoricalColor, chartColor } from "@/lib/chart-colors";
+import { categoricalColor } from "@/lib/chart-colors";
 import { useReportQuery } from "@/lib/reports/useReportQuery";
 import { dimensionHeader, pivotBySecondaryDimension } from "@/lib/reports/series";
 import type {
@@ -38,6 +32,16 @@ import type {
 } from "@/lib/reports/types";
 import WidgetCsvButton from "./WidgetCsvButton";
 import type { CsvCell } from "@/lib/reports/csv";
+
+const BarWidgetChart = dynamic(() => import("./BarWidgetChart"), {
+  ssr: false,
+  loading: () => (
+    <div
+      data-testid="bar-widget-chart-loading"
+      className="h-full w-full animate-pulse rounded bg-border/40"
+    />
+  ),
+});
 
 interface Props {
   widget: BarWidgetType;
@@ -126,40 +130,12 @@ export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
             No data
           </div>
         ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={rows} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
-              <XAxis
-                dataKey="label"
-                tick={{ fill: chartColor.axisTick, fontSize: 11 }}
-                interval={0}
-              />
-              <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
-              <Tooltip cursor={{ fill: "var(--color-border)", opacity: 0.3 }} />
-              {sliced ? (
-                secondaryValues.map((sv, i) => (
-                  <Bar
-                    key={seriesKeys[i]}
-                    dataKey={seriesKeys[i]}
-                    name={sv}
-                    stackId="stack"
-                    fill={categoricalColor(i)}
-                    radius={
-                      i === secondaryValues.length - 1 ? [4, 4, 0, 0] : 0
-                    }
-                    animationDuration={400}
-                  />
-                ))
-              ) : (
-                <Bar
-                  dataKey="value"
-                  fill={chartColor.spent}
-                  radius={[4, 4, 0, 0]}
-                  animationDuration={400}
-                />
-              )}
-            </BarChart>
-          </ResponsiveContainer>
+          <BarWidgetChart
+            rows={rows}
+            sliced={sliced}
+            secondaryValues={secondaryValues}
+            seriesKeys={seriesKeys}
+          />
         )}
       </div>
 

--- a/frontend/components/reports/widgets/BarWidgetChart.tsx
+++ b/frontend/components/reports/widgets/BarWidgetChart.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+/**
+ * Recharts-rendering inner for BarWidget. Split out so recharts is
+ * dynamically imported (ssr:false) only when a chart mounts. The public
+ * BarWidget keeps all data wiring (simple vs sliced pivot, CSV, legend);
+ * this renders the already-prepared rows.
+ */
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { categoricalColor, chartColor } from "@/lib/chart-colors";
+
+export interface BarWidgetChartProps {
+  rows: Array<Record<string, number | string>>;
+  sliced: boolean;
+  secondaryValues: string[];
+  seriesKeys: string[];
+}
+
+export default function BarWidgetChart({
+  rows,
+  sliced,
+  secondaryValues,
+  seriesKeys,
+}: BarWidgetChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={rows} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+        <XAxis
+          dataKey="label"
+          tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+          interval={0}
+        />
+        <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
+        <Tooltip cursor={{ fill: "var(--color-border)", opacity: 0.3 }} />
+        {sliced ? (
+          secondaryValues.map((sv, i) => (
+            <Bar
+              key={seriesKeys[i]}
+              dataKey={seriesKeys[i]}
+              name={sv}
+              stackId="stack"
+              fill={categoricalColor(i)}
+              radius={i === secondaryValues.length - 1 ? [4, 4, 0, 0] : 0}
+              animationDuration={400}
+            />
+          ))
+        ) : (
+          <Bar
+            dataKey="value"
+            fill={chartColor.spent}
+            radius={[4, 4, 0, 0]}
+            animationDuration={400}
+          />
+        )}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/components/reports/widgets/LineWidget.tsx
+++ b/frontend/components/reports/widgets/LineWidget.tsx
@@ -8,20 +8,12 @@
  *
  * Recharts is the canvas chart engine across the app (Dashboard,
  * Budgets, Forecast Plans); reusing it here keeps visual register
- * consistent.
+ * consistent. The recharts subtree is code-split via ``next/dynamic``
+ * (ssr:false) into ``LineWidgetChart`` so it loads only when a chart
+ * mounts, keeping recharts out of the route's initial JS.
  */
-import {
-  CartesianGrid,
-  Line,
-  LineChart,
-  Legend,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import dynamic from "next/dynamic";
 
-import { chartColor } from "@/lib/chart-colors";
 import { useSeriesQueries } from "@/lib/reports/useReportQuery";
 import { mergeSeriesRows, seriesLabel } from "@/lib/reports/series";
 import type {
@@ -31,19 +23,21 @@ import type {
 import WidgetCsvButton from "./WidgetCsvButton";
 import { buildSeriesCsvDataset } from "./seriesCsv";
 
+const LineWidgetChart = dynamic(() => import("./LineWidgetChart"), {
+  ssr: false,
+  loading: () => (
+    <div
+      data-testid="line-widget-chart-loading"
+      className="h-full w-full animate-pulse rounded bg-border/40"
+    />
+  ),
+});
+
 interface Props {
   widget: LineWidgetType;
   canvasFilters?: CanvasFilters;
   editMode?: boolean;
 }
-
-const LINE_COLORS = [
-  "var(--color-accent)",
-  "var(--color-success)",
-  "var(--color-info, var(--color-accent))",
-  "var(--color-warning, var(--color-text-secondary))",
-  "var(--color-danger)",
-];
 
 export default function LineWidget({ widget, canvasFilters, editMode }: Props) {
   const measures = widget.config.measures.map((m) => m.measure);
@@ -107,33 +101,12 @@ export default function LineWidget({ widget, canvasFilters, editMode }: Props) {
             No data
           </div>
         ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={rows} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
-              <XAxis
-                dataKey="label"
-                tick={{ fill: chartColor.axisTick, fontSize: 11 }}
-                interval={0}
-              />
-              <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
-              <Tooltip cursor={{ stroke: "var(--color-border)" }} />
-              {seriesKeys.length > 1 && (
-                <Legend wrapperStyle={{ fontSize: 11 }} />
-              )}
-              {seriesKeys.map((key, i) => (
-                <Line
-                  key={key}
-                  type={widget.config.smooth === false ? "linear" : "monotone"}
-                  dataKey={key}
-                  name={labels[i]}
-                  stroke={LINE_COLORS[i % LINE_COLORS.length]}
-                  strokeWidth={2}
-                  dot={false}
-                  isAnimationActive={false}
-                />
-              ))}
-            </LineChart>
-          </ResponsiveContainer>
+          <LineWidgetChart
+            rows={rows}
+            seriesKeys={seriesKeys}
+            labels={labels}
+            smooth={widget.config.smooth}
+          />
         )}
       </div>
     </div>

--- a/frontend/components/reports/widgets/LineWidgetChart.tsx
+++ b/frontend/components/reports/widgets/LineWidgetChart.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+/**
+ * Recharts-rendering inner for LineWidget. Split out so recharts is
+ * dynamically imported (ssr:false) only when a line chart mounts. The
+ * public LineWidget keeps all data wiring; this renders merged rows.
+ */
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { chartColor } from "@/lib/chart-colors";
+
+const LINE_COLORS = [
+  "var(--color-accent)",
+  "var(--color-success)",
+  "var(--color-info, var(--color-accent))",
+  "var(--color-warning, var(--color-text-secondary))",
+  "var(--color-danger)",
+];
+
+export interface LineWidgetChartProps {
+  rows: Array<{ label: string } & Record<string, number | string>>;
+  seriesKeys: string[];
+  labels: string[];
+  smooth?: boolean;
+}
+
+export default function LineWidgetChart({
+  rows,
+  seriesKeys,
+  labels,
+  smooth,
+}: LineWidgetChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={rows} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+        <XAxis
+          dataKey="label"
+          tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+          interval={0}
+        />
+        <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
+        <Tooltip cursor={{ stroke: "var(--color-border)" }} />
+        {seriesKeys.length > 1 && <Legend wrapperStyle={{ fontSize: 11 }} />}
+        {seriesKeys.map((key, i) => (
+          <Line
+            key={key}
+            type={smooth === false ? "linear" : "monotone"}
+            dataKey={key}
+            name={labels[i]}
+            stroke={LINE_COLORS[i % LINE_COLORS.length]}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/components/reports/widgets/PieWidget.tsx
+++ b/frontend/components/reports/widgets/PieWidget.tsx
@@ -7,15 +7,12 @@
  *
  * Single dimension, single aggregation — the config rail locks both
  * to length 1 when the widget type is ``pie``.
+ *
+ * The recharts subtree is code-split via ``next/dynamic`` (ssr:false)
+ * into ``PieWidgetChart`` so recharts loads only when a chart mounts,
+ * keeping it out of the route's initial JS.
  */
-import {
-  Cell,
-  Legend,
-  Pie,
-  PieChart,
-  ResponsiveContainer,
-  Tooltip,
-} from "recharts";
+import dynamic from "next/dynamic";
 
 import { useReportQuery } from "@/lib/reports/useReportQuery";
 import { dimensionHeader, topNWithOther } from "@/lib/reports/series";
@@ -26,23 +23,21 @@ import type {
 import WidgetCsvButton from "./WidgetCsvButton";
 import type { CsvCell } from "@/lib/reports/csv";
 
+const PieWidgetChart = dynamic(() => import("./PieWidgetChart"), {
+  ssr: false,
+  loading: () => (
+    <div
+      data-testid="pie-widget-chart-loading"
+      className="h-full w-full animate-pulse rounded bg-border/40"
+    />
+  ),
+});
+
 interface Props {
   widget: PieWidgetType;
   canvasFilters?: CanvasFilters;
   editMode?: boolean;
 }
-
-const PIE_COLORS = [
-  "var(--color-accent)",
-  "var(--color-success)",
-  "var(--color-info, var(--color-accent))",
-  "var(--color-warning, var(--color-text-secondary))",
-  "var(--color-danger)",
-  "var(--color-text-secondary)",
-  "var(--color-border)",
-  "var(--color-text-muted)",
-  "var(--color-bg-elevated, var(--color-border))",
-];
 
 export default function PieWidget({ widget, canvasFilters, editMode }: Props) {
   const { data, error, isLoading } = useReportQuery(widget, canvasFilters);
@@ -104,36 +99,7 @@ export default function PieWidget({ widget, canvasFilters, editMode }: Props) {
             No data
           </div>
         ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={rows}
-                dataKey="value"
-                nameKey="label"
-                innerRadius="40%"
-                outerRadius="75%"
-                stroke="var(--color-surface)"
-                isAnimationActive={false}
-              >
-                {rows.map((row, i) => (
-                  <Cell
-                    key={row.label}
-                    fill={
-                      row.label === "Other"
-                        ? "var(--color-border)"
-                        : PIE_COLORS[i % PIE_COLORS.length]
-                    }
-                  />
-                ))}
-              </Pie>
-              <Tooltip />
-              <Legend
-                verticalAlign="bottom"
-                wrapperStyle={{ fontSize: 11 }}
-                iconSize={8}
-              />
-            </PieChart>
-          </ResponsiveContainer>
+          <PieWidgetChart rows={rows} />
         )}
       </div>
     </div>

--- a/frontend/components/reports/widgets/PieWidgetChart.tsx
+++ b/frontend/components/reports/widgets/PieWidgetChart.tsx
@@ -17,7 +17,7 @@ const PIE_COLORS = [
   "var(--color-text-secondary)",
   "var(--color-border)",
   "var(--color-text-muted)",
-  "var(--color-bg-elevated, var(--color-border))",
+  "var(--color-surface-overlay)",
 ];
 
 export interface PieWidgetChartProps {

--- a/frontend/components/reports/widgets/PieWidgetChart.tsx
+++ b/frontend/components/reports/widgets/PieWidgetChart.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+/**
+ * Recharts-rendering inner for PieWidget. Split out so recharts is
+ * dynamically imported (ssr:false) only when a chart mounts. The public
+ * PieWidget keeps all data wiring (top-N roll-up, CSV); this renders the
+ * already-prepared rows.
+ */
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+
+const PIE_COLORS = [
+  "var(--color-accent)",
+  "var(--color-success)",
+  "var(--color-info, var(--color-accent))",
+  "var(--color-warning, var(--color-text-secondary))",
+  "var(--color-danger)",
+  "var(--color-text-secondary)",
+  "var(--color-border)",
+  "var(--color-text-muted)",
+  "var(--color-bg-elevated, var(--color-border))",
+];
+
+export interface PieWidgetChartProps {
+  rows: Array<{ label: string; value: number }>;
+}
+
+export default function PieWidgetChart({ rows }: PieWidgetChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <PieChart>
+        <Pie
+          data={rows}
+          dataKey="value"
+          nameKey="label"
+          innerRadius="40%"
+          outerRadius="75%"
+          stroke="var(--color-surface)"
+          isAnimationActive={false}
+        >
+          {rows.map((row, i) => (
+            <Cell
+              key={row.label}
+              fill={
+                row.label === "Other"
+                  ? "var(--color-border)"
+                  : PIE_COLORS[i % PIE_COLORS.length]
+              }
+            />
+          ))}
+        </Pie>
+        <Tooltip />
+        <Legend
+          verticalAlign="bottom"
+          wrapperStyle={{ fontSize: 11 }}
+          iconSize={8}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/components/reports/widgets/SparklineWidget.tsx
+++ b/frontend/components/reports/widgets/SparklineWidget.tsx
@@ -9,13 +9,12 @@
  *
  * Single dimension, single aggregation — the config rail locks both
  * when the widget type is ``sparkline``.
+ *
+ * The recharts subtree is code-split via ``next/dynamic`` (ssr:false)
+ * into ``SparklineWidgetChart`` so recharts loads only when a sparkline
+ * mounts, keeping it out of the route's initial JS.
  */
-import {
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-} from "recharts";
+import dynamic from "next/dynamic";
 
 import { useReportQuery } from "@/lib/reports/useReportQuery";
 import { dimensionHeader } from "@/lib/reports/series";
@@ -25,6 +24,19 @@ import type {
 } from "@/lib/reports/types";
 import WidgetCsvButton from "./WidgetCsvButton";
 import type { CsvCell } from "@/lib/reports/csv";
+
+const SparklineWidgetChart = dynamic(
+  () => import("./SparklineWidgetChart"),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        data-testid="sparkline-widget-chart-loading"
+        className="h-full w-full animate-pulse rounded bg-border/40"
+      />
+    ),
+  },
+);
 
 interface Props {
   widget: SparklineWidgetType;
@@ -98,19 +110,7 @@ export default function SparklineWidget({
             {formatValue(lastValue ?? 0, format)}
           </div>
           <div className="-mx-1 h-10">
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={rows} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
-                <Tooltip cursor={false} />
-                <Line
-                  type="monotone"
-                  dataKey="value"
-                  stroke="var(--color-accent)"
-                  strokeWidth={2}
-                  dot={false}
-                  isAnimationActive={false}
-                />
-              </LineChart>
-            </ResponsiveContainer>
+            <SparklineWidgetChart rows={rows} />
           </div>
         </>
       )}

--- a/frontend/components/reports/widgets/SparklineWidgetChart.tsx
+++ b/frontend/components/reports/widgets/SparklineWidgetChart.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+/**
+ * Recharts-rendering inner for SparklineWidget. Split out so recharts is
+ * dynamically imported (ssr:false) only when a sparkline mounts. The
+ * public SparklineWidget keeps all data wiring; this renders the trend
+ * line for the already-prepared rows.
+ */
+import { Line, LineChart, ResponsiveContainer, Tooltip } from "recharts";
+
+export interface SparklineWidgetChartProps {
+  rows: Array<{ label: string; value: number }>;
+}
+
+export default function SparklineWidgetChart({
+  rows,
+}: SparklineWidgetChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={rows} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
+        <Tooltip cursor={false} />
+        <Line
+          type="monotone"
+          dataKey="value"
+          stroke="var(--color-accent)"
+          strokeWidth={2}
+          dot={false}
+          isAnimationActive={false}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/components/reports/widgets/StackedBarWidget.tsx
+++ b/frontend/components/reports/widgets/StackedBarWidget.tsx
@@ -9,19 +9,13 @@
  *
  * With a single measure this falls back to a plain bar visual; the
  * config rail still lets the user add additional series.
+ *
+ * The recharts subtree is code-split via ``next/dynamic`` (ssr:false)
+ * into ``StackedBarWidgetChart`` so recharts loads only when a chart
+ * mounts, keeping it out of the route's initial JS.
  */
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Legend,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import dynamic from "next/dynamic";
 
-import { chartColor } from "@/lib/chart-colors";
 import { useSeriesQueries } from "@/lib/reports/useReportQuery";
 import { mergeSeriesRows, seriesLabel } from "@/lib/reports/series";
 import type {
@@ -31,19 +25,24 @@ import type {
 import WidgetCsvButton from "./WidgetCsvButton";
 import { buildSeriesCsvDataset } from "./seriesCsv";
 
+const StackedBarWidgetChart = dynamic(
+  () => import("./StackedBarWidgetChart"),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        data-testid="stacked-bar-widget-chart-loading"
+        className="h-full w-full animate-pulse rounded bg-border/40"
+      />
+    ),
+  },
+);
+
 interface Props {
   widget: StackedBarWidgetType;
   canvasFilters?: CanvasFilters;
   editMode?: boolean;
 }
-
-const BAR_COLORS = [
-  "var(--color-accent)",
-  "var(--color-success)",
-  "var(--color-info, var(--color-accent))",
-  "var(--color-warning, var(--color-text-secondary))",
-  "var(--color-danger)",
-];
 
 export default function StackedBarWidget({
   widget,
@@ -116,38 +115,12 @@ export default function StackedBarWidget({
             No data
           </div>
         ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={rows} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
-              <XAxis
-                dataKey="label"
-                tick={{ fill: chartColor.axisTick, fontSize: 11 }}
-                interval={0}
-              />
-              <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
-              <Tooltip cursor={{ fill: "var(--color-border)", opacity: 0.3 }} />
-              {seriesKeys.length > 1 && (
-                <Legend wrapperStyle={{ fontSize: 11 }} />
-              )}
-              {seriesKeys.map((key, i) => (
-                <Bar
-                  key={key}
-                  dataKey={key}
-                  name={labels[i]}
-                  stackId={stackId}
-                  fill={BAR_COLORS[i % BAR_COLORS.length]}
-                  radius={
-                    stackId && i === seriesKeys.length - 1
-                      ? [4, 4, 0, 0]
-                      : stackId
-                        ? 0
-                        : [4, 4, 0, 0]
-                  }
-                  isAnimationActive={false}
-                />
-              ))}
-            </BarChart>
-          </ResponsiveContainer>
+          <StackedBarWidgetChart
+            rows={rows}
+            seriesKeys={seriesKeys}
+            labels={labels}
+            stackId={stackId}
+          />
         )}
       </div>
     </div>

--- a/frontend/components/reports/widgets/StackedBarWidgetChart.tsx
+++ b/frontend/components/reports/widgets/StackedBarWidgetChart.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+/**
+ * Recharts-rendering inner for StackedBarWidget. Split out so recharts is
+ * dynamically imported (ssr:false) only when a chart mounts. The public
+ * StackedBarWidget keeps all data wiring; this renders merged rows.
+ */
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { chartColor } from "@/lib/chart-colors";
+
+const BAR_COLORS = [
+  "var(--color-accent)",
+  "var(--color-success)",
+  "var(--color-info, var(--color-accent))",
+  "var(--color-warning, var(--color-text-secondary))",
+  "var(--color-danger)",
+];
+
+export interface StackedBarWidgetChartProps {
+  rows: Array<{ label: string } & Record<string, number | string>>;
+  seriesKeys: string[];
+  labels: string[];
+  stackId?: string;
+}
+
+export default function StackedBarWidgetChart({
+  rows,
+  seriesKeys,
+  labels,
+  stackId,
+}: StackedBarWidgetChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={rows} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+        <XAxis
+          dataKey="label"
+          tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+          interval={0}
+        />
+        <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
+        <Tooltip cursor={{ fill: "var(--color-border)", opacity: 0.3 }} />
+        {seriesKeys.length > 1 && <Legend wrapperStyle={{ fontSize: 11 }} />}
+        {seriesKeys.map((key, i) => (
+          <Bar
+            key={key}
+            dataKey={key}
+            name={labels[i]}
+            stackId={stackId}
+            fill={BAR_COLORS[i % BAR_COLORS.length]}
+            radius={
+              stackId && i === seriesKeys.length - 1
+                ? [4, 4, 0, 0]
+                : stackId
+                  ? 0
+                  : [4, 4, 0, 0]
+            }
+            isAnimationActive={false}
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/components/reports/widgets/WidgetCsvButton.tsx
+++ b/frontend/components/reports/widgets/WidgetCsvButton.tsx
@@ -56,7 +56,7 @@ export default function WidgetCsvButton({ title, dataset, editMode }: Props) {
       disabled={!hasRows}
       title="Export CSV"
       aria-label={`Export ${title || "widget"} as CSV`}
-      className="rounded p-1 text-text-muted transition hover:bg-bg-elevated hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+      className="rounded p-1 text-text-muted transition hover:bg-surface-raised hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
     >
       <Download aria-hidden="true" className="h-3.5 w-3.5" />
     </button>

--- a/frontend/components/system/DuplicatePlanModal.tsx
+++ b/frontend/components/system/DuplicatePlanModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { useFocusTrap } from "@/lib/hooks/use-focus-trap";
 import { btnPrimary, btnSecondary, card, error as errorCls, input, label } from "@/lib/styles";
 import type { Plan } from "@/lib/types";
 
@@ -28,36 +29,12 @@ export default function DuplicatePlanModal({ source, onClose, onDuplicated }: Pr
   const [submitting, setSubmitting] = useState(false);
 
   const dialogRef = useRef<HTMLFormElement>(null);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
 
-  useEffect(() => {
-    previousFocusRef.current = document.activeElement as HTMLElement;
-    const focusable = dialogRef.current?.querySelector<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    );
-    focusable?.focus();
-    return () => {
-      previousFocusRef.current?.focus();
-      previousFocusRef.current = null;
-    };
-  }, []);
+  useFocusTrap({ active: true, containerRef: dialogRef });
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { e.stopPropagation(); onClose(); return; }
-      if (e.key === "Tab") {
-        const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        );
-        if (!focusable || focusable.length === 0) return;
-        const first = focusable[0];
-        const last = focusable[focusable.length - 1];
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault(); last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault(); first.focus();
-        }
-      }
+      if (e.key === "Escape") { e.stopPropagation(); onClose(); }
     };
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);

--- a/frontend/components/system/DuplicatePlanModal.tsx
+++ b/frontend/components/system/DuplicatePlanModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { btnPrimary, btnSecondary, card, error as errorCls, input, label } from "@/lib/styles";
@@ -27,6 +27,47 @@ export default function DuplicatePlanModal({ source, onClose, onDuplicated }: Pr
   const [errorMsg, setErrorMsg] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
+  const dialogRef = useRef<HTMLFormElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    const focusable = dialogRef.current?.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    focusable?.focus();
+    return () => {
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.stopPropagation(); onClose(); return; }
+      if (e.key === "Tab") {
+        const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault(); last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault(); first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, []);
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setErrorMsg("");
@@ -46,13 +87,25 @@ export default function DuplicatePlanModal({ source, onClose, onDuplicated }: Pr
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4">
-      <form onSubmit={handleSubmit} className={`${card} w-full max-w-md p-6`}>
-        <h2 className="mb-4 text-lg font-semibold">Duplicate plan</h2>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
+      onClick={onClose}
+    >
+      <form
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="duplicate-plan-modal-title"
+        onSubmit={handleSubmit}
+        onClick={(e) => e.stopPropagation()}
+        className={`${card} w-full max-w-md p-6`}
+      >
+        <h2 id="duplicate-plan-modal-title" className="mb-4 text-lg font-semibold">Duplicate plan</h2>
         {errorMsg && <div className={`${errorCls} mb-3`}>{errorMsg}</div>}
         <div className="mb-3">
-          <label className={label}>Name</label>
+          <label htmlFor="duplicate-plan-name" className={label}>Name</label>
           <input
+            id="duplicate-plan-name"
             type="text"
             value={name}
             onChange={(e) => {
@@ -64,8 +117,9 @@ export default function DuplicatePlanModal({ source, onClose, onDuplicated }: Pr
           />
         </div>
         <div className="mb-4">
-          <label className={label}>Slug</label>
+          <label htmlFor="duplicate-plan-slug" className={label}>Slug</label>
           <input
+            id="duplicate-plan-slug"
             type="text"
             value={slug}
             onChange={(e) => setSlug(e.target.value)}


### PR DESCRIPTION
Resolves the **P1** findings from the full-system impeccable audit. Verified: `tsc` clean, design-token guard passes, full vitest suite green (the only 2 failures are the pre-existing `build-apex.test.ts` cases that fail because `scripts/` isn't volume-mounted in the dev container, unrelated to this PR).

### Accessibility (WCAG 2.2 AA)
- **Contrast**: lifted `text-muted` in both themes (dark `#5a6a82`→`#8f9db2`, light `#8895a8`→`#5d6a7e`) so muted body text, the shared `label` token and placeholders clear 4.5:1 on every surface; darkened the light-theme accent (`#B88A2E`→`#8a6a1f`, hover →`#75591a`) so white-on-brass buttons and `text-accent` links clear 4.5:1. (1.4.3)
- **Skip link** in AppShell jumping to `<main id="main-content">`. (2.4.1)
- **Dialog contract** (role/aria-modal/aria-labelledby, focus trap, Escape, focus restore, backdrop close) added to `ChangePlanModal`, `DuplicatePlanModal`, and the FeatureOverrides edit modal, matching the existing `ConfirmModal`. (4.1.2 / 2.1.2 / 2.4.3)
- **Label associations** (`htmlFor`/`id`) wired across admin, system, settings, import and transactions forms. (1.3.1 / 3.3.2)

### Theming
- Renamed **phantom token utilities** (referenced `--color-*` names that don't exist, so emitted no CSS) to real tokens across the reports surface + AI forecast panels: `accent-foreground`→`accent-text` (invisible brass text), `bg-elevated`→`surface-raised` (dead hovers), `bg-secondary`/`bg-tertiary`→`surface`/`surface-raised`/`surface-overlay` (unstyled inputs).

### Performance
- Code-split **recharts** via `next/dynamic` (ssr:false) with sized skeletons for the reports widgets, budgets and forecast-plans charts, so the charting lib loads after first paint.

### Deferred from P1 (follow-up)
- **SWR reference-data migration** and the **dashboard recharts split**: implemented but reverted from this PR. SWR's module-level cache doesn't resolve under the current test harness (no per-test cache provider), breaking ~27 transactions/dashboard/accounts tests. It needs test-infra changes (a fresh SWRConfig cache per test) and should land as its own PR. Tracked for a dedicated follow-up.

Merge order: this PR first, then the P2 PR (stacked on it), then P3.