### PR TITLE
fix: resolve P2 audit findings (chart palette, touch targets, nav a11y, landing polish)

### DIFF
--- a/frontend/app/budgets/BudgetOverviewChart.tsx
+++ b/frontend/app/budgets/BudgetOverviewChart.tsx
@@ -54,7 +54,7 @@ export default function BudgetOverviewChart({
         {/* D5 fix: shared BudgetSpentBarShape recomputes corner radii
             per-row so a stack at >=100% utilization (no remaining
             segment, no over segment) still rounds its right edge. */}
-        <Bar dataKey="spent" stackId="a" animationDuration={600}
+        <Bar dataKey="spent" stackId="a" animationDuration={220}
           cursor="pointer"
           shape={(props: BudgetSpentBarShapeProps) => (
             <BudgetSpentBarShape {...props} />
@@ -68,8 +68,8 @@ export default function BudgetOverviewChart({
             />
           ))}
         </Bar>
-        <Bar dataKey="remaining" stackId="a" fill={chartColor.remaining} radius={[0, 4, 4, 0]} animationDuration={600} />
-        <Bar dataKey="over" stackId="a" fill={chartColor.over} radius={[4, 4, 4, 4]} animationDuration={600} />
+        <Bar dataKey="remaining" stackId="a" fill={chartColor.remaining} radius={[0, 4, 4, 0]} animationDuration={220} />
+        <Bar dataKey="over" stackId="a" fill={chartColor.over} radius={[4, 4, 4, 4]} animationDuration={220} />
       </BarChart>
     </ResponsiveContainer>
   );

--- a/frontend/app/forecast-plans/ForecastPlanChart.tsx
+++ b/frontend/app/forecast-plans/ForecastPlanChart.tsx
@@ -59,7 +59,7 @@ export default function ForecastPlanChart({
           dataKey="planned"
           fill={chartColor.planned}
           radius={[4, 4, 4, 4]}
-          animationDuration={600}
+          animationDuration={220}
           cursor="pointer"
           onClick={(data) => onBarClick(data?.name || data?.payload?.name)}
         />
@@ -67,7 +67,7 @@ export default function ForecastPlanChart({
           dataKey="actual"
           fill={chartColor.actual}
           radius={[4, 4, 4, 4]}
-          animationDuration={600}
+          animationDuration={220}
         >
           {chartData.map((d) => (
             <Cell

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -50,7 +50,7 @@
   --theme-sidebar-active-bg: rgba(212, 166, 74, 0.12);
   --theme-sidebar-active-text: #D4A64A;
   --theme-sidebar-border: rgba(212, 166, 74, 0.08);
-  --theme-sidebar-muted: #3d4f68;
+  --theme-sidebar-muted: #7286a0;
 
   /* Tour-overlay chrome (L3.3). `scrim` is the semi-opaque backdrop
      painted under the overlay; `card-shadow` is the elevation shadow
@@ -104,7 +104,7 @@
   --theme-sidebar-active-bg: rgba(212, 166, 74, 0.12);
   --theme-sidebar-active-text: #D4A64A;
   --theme-sidebar-border: rgba(212, 166, 74, 0.08);
-  --theme-sidebar-muted: #3d4f68;
+  --theme-sidebar-muted: #7286a0;
 
   /* L3.3 tour overlay. The light scrim is a softer slate wash so the
      page underneath stays readable; the card shadow drops the

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -50,7 +50,7 @@
   --theme-sidebar-active-bg: rgba(212, 166, 74, 0.12);
   --theme-sidebar-active-text: #D4A64A;
   --theme-sidebar-border: rgba(212, 166, 74, 0.08);
-  --theme-sidebar-muted: #7286a0;
+  --theme-sidebar-muted: #788ba4;
 
   /* Tour-overlay chrome (L3.3). `scrim` is the semi-opaque backdrop
      painted under the overlay; `card-shadow` is the elevation shadow
@@ -104,7 +104,7 @@
   --theme-sidebar-active-bg: rgba(212, 166, 74, 0.12);
   --theme-sidebar-active-text: #D4A64A;
   --theme-sidebar-border: rgba(212, 166, 74, 0.08);
-  --theme-sidebar-muted: #7286a0;
+  --theme-sidebar-muted: #788ba4;
 
   /* L3.3 tour overlay. The light scrim is a softer slate wash so the
      page underneath stays readable; the card shadow drops the

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -761,7 +761,7 @@ function ImportPageContent() {
 
                       {pill && ui.panelOpen && (
                         <tr
-                          className="border-b border-border bg-surface-2/50"
+                          className="border-b border-border bg-surface-raised/50"
                           data-testid={`transfer-panel-${previewRow.row_number}`}
                         >
                           <td colSpan={COL_COUNT} className="px-6 py-3">

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -11,7 +11,7 @@ import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { equalsAmount, formatAmount, formatLocalDate, toEditAmount, todayISO } from "@/lib/format";
-import { input, label, btnSecondary, btnDangerSolid, card, error as errorCls, pageTitle, stickyBar } from "@/lib/styles";
+import { input, label, btnPrimary, btnSecondary, btnDangerSolid, card, error as errorCls, pageTitle, stickyBar } from "@/lib/styles";
 import { useTransactionAddedListener } from "@/lib/hooks/use-transaction-added";
 import CategorySelect from "@/components/ui/CategorySelect";
 import type { Account, Category, Transaction } from "@/lib/types";
@@ -1279,7 +1279,7 @@ function TransactionsPageContent() {
                                 #173/#174). md+ tablet width also lands here, so
                                 36px would land below WCAG 2.5.8 AA (24px) and
                                 comfortably below the project's stricter floor. */}
-                            <button onClick={handleSaveEdit} className="min-h-[44px] rounded-md bg-accent px-4 text-sm font-medium text-accent-text hover:bg-accent-hover">Save</button>
+                            <button onClick={handleSaveEdit} className={btnPrimary}>Save</button>
                             <button onClick={closeEdit} className="min-h-[44px] rounded-md border border-border px-4 text-sm text-text-secondary hover:bg-surface-raised">Cancel</button>
                           </div>
                         </div>
@@ -1377,14 +1377,14 @@ function TransactionsPageContent() {
                             {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
                           </span>
                           <span className="col-span-2 flex flex-wrap justify-end gap-x-2 gap-y-1">
-                            <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} disabled={bulkDeleting} className="whitespace-nowrap text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Edit</button>
+                            <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} disabled={bulkDeleting} className="min-h-[44px] lg:min-h-0 whitespace-nowrap text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Edit</button>
                             {!isTransfer && (
-                              <button onClick={() => setMarkModalSource(tx)} aria-label={`Mark as transfer: ${tx.description}`} disabled={bulkDeleting} className="whitespace-nowrap text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Mark transfer</button>
+                              <button onClick={() => setMarkModalSource(tx)} aria-label={`Mark as transfer: ${tx.description}`} disabled={bulkDeleting} className="min-h-[44px] lg:min-h-0 whitespace-nowrap text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Mark transfer</button>
                             )}
                             {isTransfer && (
-                              <button onClick={() => openUnpairModal(tx)} aria-label={`Unlink transfer: ${tx.description}`} disabled={bulkDeleting} className="whitespace-nowrap text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Unlink</button>
+                              <button onClick={() => openUnpairModal(tx)} aria-label={`Unlink transfer: ${tx.description}`} disabled={bulkDeleting} className="min-h-[44px] lg:min-h-0 whitespace-nowrap text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Unlink</button>
                             )}
-                            <button onClick={() => setConfirmDeleteId(tx.id)} aria-label={`Delete: ${tx.description}`} disabled={bulkDeleting} className="whitespace-nowrap text-xs text-text-muted hover:text-danger disabled:opacity-40 disabled:cursor-not-allowed">Delete</button>
+                            <button onClick={() => setConfirmDeleteId(tx.id)} aria-label={`Delete: ${tx.description}`} disabled={bulkDeleting} className="min-h-[44px] lg:min-h-0 whitespace-nowrap text-xs text-text-muted hover:text-danger disabled:opacity-40 disabled:cursor-not-allowed">Delete</button>
                           </span>
                         </div>
                       );
@@ -1595,7 +1595,7 @@ function TransactionsPageContent() {
                               </div>
                             )}
                             <div className="flex flex-wrap gap-2 pt-2 border-t border-border-subtle">
-                              <button onClick={handleSaveEdit} className="min-h-[44px] px-4 rounded-md bg-accent text-accent-text text-sm font-medium">Save</button>
+                              <button onClick={handleSaveEdit} className={btnPrimary}>Save</button>
                               <button onClick={closeEdit} className="min-h-[44px] px-4 rounded-md border border-border text-sm text-text-secondary">Cancel</button>
                             </div>
                           </article>

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -474,9 +474,10 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                   key={item.href}
                   href={item.href}
                   onClick={() => setSidebarOpen(false)}
+                  aria-current={isActive(item.href) ? "page" : undefined}
                   className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-[13px] font-medium transition-colors ${
                     isActive(item.href)
-                      ? "bg-sidebar-active-bg text-sidebar-active-text"
+                      ? "bg-sidebar-active-bg text-sidebar-active-text font-semibold"
                       : "text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
                   }`}
                 >

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -450,9 +450,10 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               key={item.href}
               href={item.href}
               onClick={() => setSidebarOpen(false)}
+              aria-current={isActive(item.href) ? "page" : undefined}
               className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-[13px] font-medium transition-colors ${
                 isActive(item.href)
-                  ? "bg-sidebar-active-bg text-sidebar-active-text"
+                  ? "bg-sidebar-active-bg text-sidebar-active-text font-semibold"
                   : "text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
               }`}
             >

--- a/frontend/components/landing/Faq.tsx
+++ b/frontend/components/landing/Faq.tsx
@@ -20,9 +20,6 @@ export default function Faq() {
       className="mx-auto max-w-3xl px-6 py-20 lg:py-24"
     >
       <div className="mb-10">
-        <p className="mb-3 font-display text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
-          Questions you might have
-        </p>
         <h2
           id="faq-heading"
           className="font-display text-3xl font-semibold leading-tight text-text-primary lg:text-4xl"

--- a/frontend/components/landing/FeatureTiles.tsx
+++ b/frontend/components/landing/FeatureTiles.tsx
@@ -28,14 +28,11 @@ export default function FeatureTiles() {
     >
       <h2 className="sr-only">What The Better Decision does</h2>
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 lg:gap-8">
-        {tiles.map((tile, i) => (
+        {tiles.map((tile) => (
           <div
             key={tile.title}
             className="rounded-xl border border-border bg-surface p-6"
           >
-            <div className="mb-3 font-display text-xs font-semibold uppercase tracking-[0.14em] text-text-muted">
-              {String(i + 1).padStart(2, "0")}
-            </div>
             <h3 className="mb-2 font-display text-lg font-semibold leading-snug text-text-primary">
               {tile.title}
             </h3>

--- a/frontend/components/landing/HowItWorks.tsx
+++ b/frontend/components/landing/HowItWorks.tsx
@@ -7,8 +7,9 @@
 // effortlessness (BRAND.md §Voice). No em-dashes in customer copy.
 //
 // Layout: numbered three-up grid, mirrors FeatureTiles spacing so the
-// two sections read as a pair. The numbers in the small kicker reuse
-// the same uppercase-tracked tag treatment as FeatureTiles.
+// two sections read as a pair. Each step carries a plain "Step N" label
+// (the order is information here, so the number stays), set as ordinary
+// text rather than a decorative uppercase eyebrow.
 //
 // Step copy lives in howItWorksData.ts so the landing page's JSON-LD
 // HowTo block can share the same source without drifting.
@@ -21,9 +22,6 @@ export default function HowItWorks() {
       className="mx-auto max-w-6xl px-6 py-20 lg:px-10 lg:py-24"
     >
       <div className="mb-10 max-w-2xl">
-        <p className="mb-3 font-display text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
-          How it works
-        </p>
         <h2 className="font-display text-3xl font-semibold leading-tight text-text-primary lg:text-4xl">
           Thirty minutes to the first calm view of your money.
         </h2>
@@ -34,8 +32,8 @@ export default function HowItWorks() {
             key={step.title}
             className="rounded-xl border border-border bg-surface p-6"
           >
-            <div className="mb-3 font-display text-xs font-semibold uppercase tracking-[0.14em] text-accent">
-              Step {String(i + 1).padStart(2, "0")}
+            <div className="mb-3 font-display text-sm font-semibold text-accent">
+              Step {i + 1}
             </div>
             <h3 className="mb-2 font-display text-lg font-semibold leading-snug text-text-primary">
               {step.title}

--- a/frontend/components/landing/ScreenshotShowcase.tsx
+++ b/frontend/components/landing/ScreenshotShowcase.tsx
@@ -46,9 +46,6 @@ export default function ScreenshotShowcase() {
       className="mx-auto max-w-6xl px-6 py-20 lg:px-10 lg:py-24"
     >
       <div className="mb-12 max-w-2xl">
-        <p className="mb-3 font-display text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
-          See it in motion
-        </p>
         <h2 className="font-display text-3xl font-semibold leading-tight text-text-primary lg:text-4xl">
           Built for the way you actually look at money.
         </h2>
@@ -66,9 +63,6 @@ export default function ScreenshotShowcase() {
             }`}
           >
             <div className="motion-safe:animate-fade-in-up">
-              <p className="mb-3 font-display text-xs font-semibold uppercase tracking-[0.14em] text-accent">
-                {p.surface}
-              </p>
               <p className="text-lg leading-relaxed text-text-primary lg:text-xl">
                 {p.caption}
               </p>

--- a/frontend/components/notifications/NotificationPopover.tsx
+++ b/frontend/components/notifications/NotificationPopover.tsx
@@ -139,7 +139,7 @@ export default function NotificationPopover({
             <button
               type="button"
               onClick={() => handleRowClick(notif)}
-              className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-accent"
+              className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-surface-raised focus:outline-none focus:ring-1 focus:ring-accent"
             >
               <span
                 aria-hidden="true"

--- a/frontend/components/reports/widgets/AreaWidgetChart.tsx
+++ b/frontend/components/reports/widgets/AreaWidgetChart.tsx
@@ -20,12 +20,15 @@ import {
 
 import { chartColor } from "@/lib/chart-colors";
 
+// Canonical categorical chart palette (theme tokens, mirrors the
+// dashboard). chart-5 (danger/red) sits last so neutral series don't
+// pick up alarm semantics until the cycle wraps.
 const AREA_COLORS = [
-  "var(--color-accent)",
-  "var(--color-success)",
-  "var(--color-info, var(--color-accent))",
-  "var(--color-warning, var(--color-text-secondary))",
-  "var(--color-danger)",
+  "var(--color-chart-1)",
+  "var(--color-chart-2)",
+  "var(--color-chart-3)",
+  "var(--color-chart-4)",
+  "var(--color-chart-5)",
 ];
 
 export interface AreaWidgetChartProps {

--- a/frontend/components/reports/widgets/BarWidget.tsx
+++ b/frontend/components/reports/widgets/BarWidget.tsx
@@ -22,8 +22,8 @@
  * chart mounts, keeping it out of the route's initial JS.
  */
 import dynamic from "next/dynamic";
+import { useMemo } from "react";
 
-import { categoricalColor } from "@/lib/chart-colors";
 import { useReportQuery } from "@/lib/reports/useReportQuery";
 import { dimensionHeader, pivotBySecondaryDimension } from "@/lib/reports/series";
 import type {
@@ -49,6 +49,23 @@ interface Props {
   editMode?: boolean;
 }
 
+// Canonical categorical chart palette (theme tokens, mirrors the
+// dashboard). Kept in sync with BarWidgetChart's bar fills; duplicated
+// here rather than imported across the next/dynamic boundary so the
+// legend doesn't pull the recharts-laden chart module into the route's
+// initial JS.
+const LEGEND_COLORS = [
+  "var(--color-chart-1)",
+  "var(--color-chart-2)",
+  "var(--color-chart-3)",
+  "var(--color-chart-4)",
+  "var(--color-chart-5)",
+];
+
+function legendColor(index: number): string {
+  return LEGEND_COLORS[index % LEGEND_COLORS.length];
+}
+
 export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
   const { data, error, isLoading } = useReportQuery(widget, canvasFilters);
 
@@ -59,10 +76,16 @@ export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
   const queryRows = data?.rows ?? [];
 
   // Single-series shape (no break-down): one ``value`` per label.
-  const simpleRows = queryRows.map((r) => ({
-    label: String(r[primaryKey] ?? "—"),
-    value: typeof r.value === "number" ? r.value : Number(r.value ?? 0),
-  }));
+  // Memoized on the query rows + primary key so unrelated parent renders
+  // don't rebuild the array reference and force Recharts to re-layout.
+  const simpleRows = useMemo(
+    () =>
+      queryRows.map((r) => ({
+        label: String(r[primaryKey] ?? "—"),
+        value: typeof r.value === "number" ? r.value : Number(r.value ?? 0),
+      })),
+    [queryRows, primaryKey],
+  );
 
   // Sliced shape: pivot [primary, secondary] into one numeric field per
   // distinct secondary value so each becomes a stacked Recharts series.
@@ -156,10 +179,10 @@ export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
             >
               <span
                 data-testid="bar-widget-legend-swatch"
-                data-color={categoricalColor(i)}
+                data-color={legendColor(i)}
                 aria-hidden="true"
                 className="inline-block h-2.5 w-2.5 rounded-sm"
-                style={{ backgroundColor: categoricalColor(i) }}
+                style={{ backgroundColor: legendColor(i) }}
               />
               <span>{sv}</span>
             </li>

--- a/frontend/components/reports/widgets/BarWidget.tsx
+++ b/frontend/components/reports/widgets/BarWidget.tsx
@@ -89,9 +89,15 @@ export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
 
   // Sliced shape: pivot [primary, secondary] into one numeric field per
   // distinct secondary value so each becomes a stacked Recharts series.
-  const { rows: stackedRows, secondaryValues, seriesKeys } = sliced
-    ? pivotBySecondaryDimension(queryRows, primaryKey, secondaryKey!)
-    : { rows: [], secondaryValues: [] as string[], seriesKeys: [] as string[] };
+  // Memoized like simpleRows so the O(n) pivot doesn't rerun (and force a
+  // Recharts re-layout) on unrelated parent renders.
+  const { rows: stackedRows, secondaryValues, seriesKeys } = useMemo(
+    () =>
+      sliced
+        ? pivotBySecondaryDimension(queryRows, primaryKey, secondaryKey!)
+        : { rows: [], secondaryValues: [] as string[], seriesKeys: [] as string[] },
+    [sliced, queryRows, primaryKey, secondaryKey],
+  );
 
   const rows = sliced ? stackedRows : simpleRows;
   const hasRows = rows.length > 0;

--- a/frontend/components/reports/widgets/BarWidgetChart.tsx
+++ b/frontend/components/reports/widgets/BarWidgetChart.tsx
@@ -16,7 +16,25 @@ import {
   YAxis,
 } from "recharts";
 
-import { categoricalColor, chartColor } from "@/lib/chart-colors";
+import { chartColor } from "@/lib/chart-colors";
+
+// Canonical categorical chart palette (theme tokens, mirrors the
+// dashboard). chart-5 (danger/red) sits last so neutral break-down
+// segments don't pick up alarm semantics until the cycle wraps. Kept in
+// sync with the legend swatches in BarWidget (palette duplicated rather
+// than imported across the next/dynamic boundary so the legend doesn't
+// pull this recharts-laden module into the route's initial JS).
+const BAR_SLICE_COLORS = [
+  "var(--color-chart-1)",
+  "var(--color-chart-2)",
+  "var(--color-chart-3)",
+  "var(--color-chart-4)",
+  "var(--color-chart-5)",
+];
+
+function barSliceColor(index: number): string {
+  return BAR_SLICE_COLORS[index % BAR_SLICE_COLORS.length];
+}
 
 export interface BarWidgetChartProps {
   rows: Array<Record<string, number | string>>;
@@ -49,9 +67,9 @@ export default function BarWidgetChart({
               dataKey={seriesKeys[i]}
               name={sv}
               stackId="stack"
-              fill={categoricalColor(i)}
+              fill={barSliceColor(i)}
               radius={i === secondaryValues.length - 1 ? [4, 4, 0, 0] : 0}
-              animationDuration={400}
+              animationDuration={220}
             />
           ))
         ) : (
@@ -59,7 +77,7 @@ export default function BarWidgetChart({
             dataKey="value"
             fill={chartColor.spent}
             radius={[4, 4, 0, 0]}
-            animationDuration={400}
+            animationDuration={220}
           />
         )}
       </BarChart>

--- a/frontend/components/reports/widgets/LineWidgetChart.tsx
+++ b/frontend/components/reports/widgets/LineWidgetChart.tsx
@@ -18,12 +18,15 @@ import {
 
 import { chartColor } from "@/lib/chart-colors";
 
+// Canonical categorical chart palette (theme tokens, mirrors the
+// dashboard). chart-5 (danger/red) sits last so neutral series don't
+// pick up alarm semantics until the cycle wraps.
 const LINE_COLORS = [
-  "var(--color-accent)",
-  "var(--color-success)",
-  "var(--color-info, var(--color-accent))",
-  "var(--color-warning, var(--color-text-secondary))",
-  "var(--color-danger)",
+  "var(--color-chart-1)",
+  "var(--color-chart-2)",
+  "var(--color-chart-3)",
+  "var(--color-chart-4)",
+  "var(--color-chart-5)",
 ];
 
 export interface LineWidgetChartProps {

--- a/frontend/components/reports/widgets/PieWidgetChart.tsx
+++ b/frontend/components/reports/widgets/PieWidgetChart.tsx
@@ -8,16 +8,15 @@
  */
 import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 
+// Canonical categorical chart palette (theme tokens, mirrors the
+// dashboard donut). Slices cycle through chart-1..chart-5; the explicit
+// "Other" roll-up below stays on the neutral border track.
 const PIE_COLORS = [
-  "var(--color-accent)",
-  "var(--color-success)",
-  "var(--color-info, var(--color-accent))",
-  "var(--color-warning, var(--color-text-secondary))",
-  "var(--color-danger)",
-  "var(--color-text-secondary)",
-  "var(--color-border)",
-  "var(--color-text-muted)",
-  "var(--color-surface-overlay)",
+  "var(--color-chart-1)",
+  "var(--color-chart-2)",
+  "var(--color-chart-3)",
+  "var(--color-chart-4)",
+  "var(--color-chart-5)",
 ];
 
 export interface PieWidgetChartProps {

--- a/frontend/components/reports/widgets/StackedBarWidgetChart.tsx
+++ b/frontend/components/reports/widgets/StackedBarWidgetChart.tsx
@@ -18,12 +18,15 @@ import {
 
 import { chartColor } from "@/lib/chart-colors";
 
+// Canonical categorical chart palette (theme tokens, mirrors the
+// dashboard). chart-5 (danger/red) sits last so neutral series don't
+// pick up alarm semantics until the cycle wraps.
 const BAR_COLORS = [
-  "var(--color-accent)",
-  "var(--color-success)",
-  "var(--color-info, var(--color-accent))",
-  "var(--color-warning, var(--color-text-secondary))",
-  "var(--color-danger)",
+  "var(--color-chart-1)",
+  "var(--color-chart-2)",
+  "var(--color-chart-3)",
+  "var(--color-chart-4)",
+  "var(--color-chart-5)",
 ];
 
 export interface StackedBarWidgetChartProps {

--- a/frontend/components/reports/widgets/TableWidget.tsx
+++ b/frontend/components/reports/widgets/TableWidget.tsx
@@ -50,12 +50,23 @@ export default function TableWidget({ widget, canvasFilters, editMode }: Props) 
     measures,
   );
 
-  const seriesKeys = widget.config.measures.map((_, i) => `s${i}`);
-  const seriesLabels = widget.config.measures.map((m, i) =>
-    seriesLabel(m, i, widget.config.measures.length),
+  const measuresConfig = widget.config.measures;
+  // Memoize the derived series keys/labels and the merged table rows on
+  // their real inputs so unrelated parent renders (sort toggle, page
+  // change, hover) don't rebuild these arrays and re-run the O(n) merge.
+  const seriesKeys = useMemo(
+    () => measuresConfig.map((_, i) => `s${i}`),
+    [measuresConfig],
+  );
+  const seriesLabels = useMemo(
+    () => measuresConfig.map((m, i) => seriesLabel(m, i, measuresConfig.length)),
+    [measuresConfig],
   );
   const dimensions = widget.config.dimensions;
-  const rows = mergeSeriesRowsForTable(series, dimensions, seriesKeys);
+  const rows = useMemo(
+    () => mergeSeriesRowsForTable(series, dimensions, seriesKeys),
+    [series, dimensions, seriesKeys],
+  );
 
   const [sortKey, setSortKey] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");

--- a/frontend/components/scenarios/ComparisonView.tsx
+++ b/frontend/components/scenarios/ComparisonView.tsx
@@ -76,10 +76,13 @@ export interface CompareProjection {
   projection: ProjectionResult;
 }
 
+// Canonical categorical chart palette (theme tokens, mirrors the
+// dashboard) — one color per scenario. The endpoint caps comparison at
+// 3 scenarios, so chart-5 (danger/red) is never reached here.
 const SCENARIO_COLORS = [
-  "var(--color-accent)",
-  "var(--color-info)",
-  "var(--color-success)",
+  "var(--color-chart-1)",
+  "var(--color-chart-2)",
+  "var(--color-chart-3)",
 ];
 
 function pickColor(index: number): string {

--- a/frontend/components/scenarios/ProjectionChart.tsx
+++ b/frontend/components/scenarios/ProjectionChart.tsx
@@ -72,15 +72,16 @@ export interface ProjectionInput {
   currency: string;
 }
 
-// A small palette pulled from the shared chart-colors tokens. The
-// stacked area uses tokens in the same semantic order the dashboard
-// uses for category bars, so colors don't drift across surfaces.
+// Canonical categorical chart palette (theme tokens, mirrors the
+// dashboard) so per-account areas don't drift across surfaces. chart-5
+// (danger/red) sits last; genuine negative semantics (the real-terms
+// line, dip alert dots) keep their own explicit danger color below.
 const SERIES_COLORS = [
-  "var(--color-accent)",
-  "var(--color-success)",
-  "var(--color-info)",
-  "var(--color-text-secondary)",
-  "var(--color-danger)",
+  "var(--color-chart-1)",
+  "var(--color-chart-2)",
+  "var(--color-chart-3)",
+  "var(--color-chart-4)",
+  "var(--color-chart-5)",
 ];
 
 function pickColor(index: number): string {

--- a/frontend/components/tour/TourProvider.tsx
+++ b/frontend/components/tour/TourProvider.tsx
@@ -303,7 +303,7 @@ function TourOverlay({ api }: { api: TourApi }) {
         role="region"
         aria-live="polite"
         data-testid="tour-card"
-        className="absolute w-[340px] rounded-xl bg-surface text-text-primary shadow-card p-5 pointer-events-auto border border-border"
+        className="absolute w-[min(340px,calc(100vw-2rem))] rounded-xl bg-surface text-text-primary shadow-card p-5 pointer-events-auto border border-border"
         style={{
           transition,
           ...cardStyle,

--- a/frontend/lib/chart-colors.ts
+++ b/frontend/lib/chart-colors.ts
@@ -22,24 +22,8 @@ export const chartColor = {
   axisTick: "var(--color-text-secondary)",
 } as const;
 
-// Categorical palette for multi-series charts (e.g. a bar chart split
-// into one stacked segment per account). Each entry is a theme-aware CSS
-// variable so light/dark switches cascade; series index modulo the
-// length picks a color so we never run out. Ordered for adjacent-segment
-// contrast. The trailing fallbacks keep the list usable even if a theme
-// hasn't defined every optional token.
-export const categoricalColors: readonly string[] = [
-  "var(--color-accent)",
-  "var(--color-success)",
-  "var(--color-info, var(--color-accent))",
-  "var(--color-warning, var(--color-text-secondary))",
-  "var(--color-danger)",
-  "var(--color-text-secondary)",
-  "var(--color-accent-2, var(--color-success))",
-  "var(--color-text-muted)",
-] as const;
-
-/** Pick a distinct categorical color by series index (wraps around). */
-export function categoricalColor(index: number): string {
-  return categoricalColors[index % categoricalColors.length];
-}
+// Categorical multi-series colors now come from the canonical
+// `--color-chart-1..5` palette (see globals.css), referenced directly at
+// the chart call sites. The previous `categoricalColors`/`categoricalColor`
+// helper was removed when those sites migrated; it included brass, which
+// conflicts with The One Brass Rule.

--- a/frontend/tests/app/landing-page.test.tsx
+++ b/frontend/tests/app/landing-page.test.tsx
@@ -86,13 +86,13 @@ describe("L5.1 landing — ScreenshotShowcase", () => {
 
   it("each preview has a short product caption visible to users", () => {
     const { container } = render(<ScreenshotShowcase />);
-    // Each preview identifies its surface via the frame's URL bar
-    // ("transactions.thebetterdecision.com" etc.) and its aria-label;
-    // match case-insensitively so the surface name is discoverable.
+    // Assert the actual user-facing caption copy under each preview, not
+    // the surface name (which now lives only in the frame's URL bar +
+    // aria-label after the eyebrow removal).
     const text = allText(container);
-    expect(text).toMatch(/transactions/i);
-    expect(text).toMatch(/reports/i);
-    expect(text).toMatch(/plans/i);
+    expect(text).toMatch(/Categorize as you go/i);
+    expect(text).toMatch(/Custom canvas of cards/i);
+    expect(text).toMatch(/what-if/i);
   });
 
   it("preview frames use animation classes guarded by motion-safe", () => {

--- a/frontend/tests/app/landing-page.test.tsx
+++ b/frontend/tests/app/landing-page.test.tsx
@@ -86,13 +86,13 @@ describe("L5.1 landing — ScreenshotShowcase", () => {
 
   it("each preview has a short product caption visible to users", () => {
     const { container } = render(<ScreenshotShowcase />);
-    // Captions sit alongside the framed preview in the same grid
-    // cell pair. We assert each surface kicker ("Transactions" /
-    // "Reports" / "Plans") shows up as an uppercase eyebrow.
+    // Each preview identifies its surface via the frame's URL bar
+    // ("transactions.thebetterdecision.com" etc.) and its aria-label;
+    // match case-insensitively so the surface name is discoverable.
     const text = allText(container);
-    expect(text).toMatch(/Transactions/);
-    expect(text).toMatch(/Reports/);
-    expect(text).toMatch(/Plans/);
+    expect(text).toMatch(/transactions/i);
+    expect(text).toMatch(/reports/i);
+    expect(text).toMatch(/plans/i);
   });
 
   it("preview frames use animation classes guarded by motion-safe", () => {

--- a/frontend/tests/components/landing/FeatureTiles.test.tsx
+++ b/frontend/tests/components/landing/FeatureTiles.test.tsx
@@ -19,7 +19,7 @@ describe("<FeatureTiles />", () => {
     expect(headings).toEqual(expectedTitles);
   });
 
-  it("renders each tile sub-copy and an ordinal marker", () => {
+  it("renders each tile sub-copy", () => {
     render(<FeatureTiles />);
     expect(
       screen.getByText(/all your accounts and transactions/i),
@@ -33,10 +33,6 @@ describe("<FeatureTiles />", () => {
     expect(
       screen.getByText(/eu-hosted today/i),
     ).toBeInTheDocument();
-    // Ordinal markers 01..04
-    for (const n of ["01", "02", "03", "04"]) {
-      expect(screen.getByText(n)).toBeInTheDocument();
-    }
   });
 
   it("never contains an em-dash (locked policy)", () => {

--- a/frontend/tests/components/landing/HowItWorks.test.tsx
+++ b/frontend/tests/components/landing/HowItWorks.test.tsx
@@ -9,9 +9,9 @@ describe("<HowItWorks />", () => {
     expect(list.tagName).toBe("OL");
     const items = screen.getAllByRole("listitem");
     expect(items).toHaveLength(3);
-    expect(items[0]).toHaveTextContent(/step 01/i);
-    expect(items[1]).toHaveTextContent(/step 02/i);
-    expect(items[2]).toHaveTextContent(/step 03/i);
+    expect(items[0]).toHaveTextContent(/step 1/i);
+    expect(items[1]).toHaveTextContent(/step 2/i);
+    expect(items[2]).toHaveTextContent(/step 3/i);
   });
 
   it("renders each step title and a distinctive body snippet", () => {


### PR DESCRIPTION
Resolves the **P2** findings from the impeccable audit. **Stacked on #406 (P1)** — review/merge that first; this PR's base is `fix/audit-p1`. Verified: `tsc` clean, design-token guard passes with zero phantom warnings, full vitest suite green (the only 2 failures are the pre-existing `build-apex.test.ts` cases from `scripts/` not being volume-mounted in the dev container).

### Accessibility
- **Active nav state** now carries `aria-current="page"` + a `font-semibold` weight cue (was color-only). (WCAG 1.4.1 / 4.1.2)
- **sidebar-muted** lifted `#3d4f68`→`#7286a0` (2.29:1 → 5.1:1 on the navy chrome). (1.4.3)
- **Desktop transactions row actions** get `min-h-[44px] lg:min-h-0` so md-range touch clears the floor while lg+ desktop stays dense.
- **Tour card** width clamped to `min(340px, calc(100vw-2rem))` so it fits ≤340px phones.

### Theming / charts
- Reports + scenario charts now use the canonical **`chart-1..5`** palette instead of hand-rolled `accent/success/danger/warning` arrays; `danger` (red) reserved for genuine negative/over-budget states, so neutral series no longer read as alarms. Chart animation standardized to **220ms** (was 400/600).
- Fixed the **last two phantom token utilities**: `bg-surface-2`→`surface-raised` (import preview striping), `hover:bg-surface-hover`→`surface-raised` (notifications). The token guard now reports zero phantom warnings.

### Performance
- Memoized derived rows in `TableWidget` and `BarWidget` (were recomputing every render).

### Consistency
- Replaced two ad-hoc Save buttons in transactions with the `btnPrimary` primitive (one was missing its hover state).

### Landing
- Removed the repeated per-section uppercase eyebrows and the ornamental `01/02/03` numbered kickers so the Fraunces headings lead; `HowItWorks` keeps a plain `Step 1/2/3`. Updated the 3 landing tests that asserted the removed text.