### PR TITLE
fix: resolve P3 audit findings (CI token gate, focus rings, minor polish)

### DIFF
--- a/frontend/app/import/[import_id]/reconcile/ReconcileClient.tsx
+++ b/frontend/app/import/[import_id]/reconcile/ReconcileClient.tsx
@@ -297,7 +297,7 @@ export default function ReconcileClient({
                   aria-label="Reconciliation progress"
                 >
                   <div
-                    className="h-full bg-accent transition-all"
+                    className="h-full bg-accent transition-[width]"
                     style={{
                       width:
                         progress.total === 0

--- a/frontend/app/recurring/page.tsx
+++ b/frontend/app/recurring/page.tsx
@@ -251,21 +251,21 @@ function RecurringTable({
                     {paused ? (
                       <button
                         onClick={() => onResume?.(r)}
-                        className="min-h-[44px] text-xs text-text-muted hover:text-accent"
+                        className="min-h-[44px] md:min-h-0 text-xs text-text-muted hover:text-accent"
                       >
                         Resume
                       </button>
                     ) : (
                       <button
                         onClick={() => onStop?.(r)}
-                        className="min-h-[44px] text-xs text-text-muted hover:text-accent"
+                        className="min-h-[44px] md:min-h-0 text-xs text-text-muted hover:text-accent"
                       >
                         Stop
                       </button>
                     )}
                     <button
                       onClick={() => onDelete(r.id)}
-                      className="min-h-[44px] text-xs text-text-muted hover:text-danger"
+                      className="min-h-[44px] md:min-h-0 text-xs text-text-muted hover:text-danger"
                     >
                       Delete
                     </button>

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -212,7 +212,7 @@ export default function SettingsProfilePage() {
         )}
         <div className={`${card} p-6`}>
           <div className="flex items-center gap-4">
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-accent-dim font-display text-lg text-accent">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-accent-dim text-lg font-semibold text-accent">
               {initials}
             </div>
             <div>

--- a/frontend/components/notifications/NotificationBell.tsx
+++ b/frontend/components/notifications/NotificationBell.tsx
@@ -165,7 +165,7 @@ export default function NotificationBell() {
         }
         aria-haspopup="dialog"
         aria-expanded={open}
-        className="relative rounded-md p-2 text-text-muted transition-colors hover:text-text-primary focus:outline-none focus:ring-1 focus:ring-accent"
+        className="relative rounded-md p-2 text-text-muted transition-colors hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
         data-testid="notification-bell"
       >
         {unseen > 0 ? (

--- a/frontend/components/notifications/NotificationPopover.tsx
+++ b/frontend/components/notifications/NotificationPopover.tsx
@@ -139,7 +139,7 @@ export default function NotificationPopover({
             <button
               type="button"
               onClick={() => handleRowClick(notif)}
-              className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-surface-raised focus:outline-none focus:ring-1 focus:ring-accent"
+              className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-surface-raised focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
             >
               <span
                 aria-hidden="true"

--- a/frontend/scripts/check-design-tokens.sh
+++ b/frontend/scripts/check-design-tokens.sh
@@ -8,15 +8,12 @@
 #     excluded — they cannot rely on Tailwind theme tokens at runtime).
 #   - Hard-coded hex literals in .ts/.tsx.
 #
-# This script is EXPECTED TO FAIL today (Phase A): the foundation PR adds
-# the missing primitives but does not migrate call sites. Phase B will
-# replace the offending utilities at the call sites and, once green, this
-# check will be wired into CI. Until then, do not gate CI on it.
-#
-# Tracked Phase B fix targets (non-exhaustive):
-#   - app/transactions/page.tsx (sticky bar + amber/red utilities)
-#   - components/categories/BatchActionBar.tsx (sticky bar)
-#   - any component still using bg-amber-* / bg-red-* / text-white / text-black
+# This check is wired into CI (.github/workflows/test.yml) and is expected to
+# PASS: the call sites have been migrated to theme tokens. Both the raw-palette
+# / hex checks and the phantom-token check (a className referencing a --color-*
+# name that does not exist, which silently emits no CSS) are fatal. Keep it
+# green: use a theme token from app/globals.css or a primitive from
+# lib/styles.ts instead of a raw color or an undefined token.
 #
 # Usage:
 #   bash frontend/scripts/check-design-tokens.sh
@@ -148,15 +145,13 @@ if [ -n "${candidates}" ]; then
   done <<< "${candidates}"
 
   if [ -n "${phantom_hits}" ]; then
-    # Phantom-token findings are reported as WARNINGS in this commit
-    # (do not flip ``fail`` to 1). There is one pre-existing offender
-    # in ``app/import/page.tsx`` that predates this check; gating CI
-    # on it would expand scope. Each follow-up PR that touches a
-    # phantom site should drop it from the list. Once the list is
-    # empty, promote this block to ``fail=1`` so the check gates CI
-    # on its own.
+    # Phantom-token findings are FATAL. All known offenders were migrated
+    # to real tokens (audit P1/P2), so any new className referencing a
+    # --color-* name that does not exist (it silently emits no CSS, e.g.
+    # invisible text or a dead hover) must fail the check.
+    fail=1
     echo "── Phantom theme-token utilities (no --color-* match) ─────"
-    echo "WARNING (not currently fatal). Fix at first opportunity."
+    echo "FAIL: className references a token with no --color-* definition."
     printf '%s' "${phantom_hits}"
     echo
   fi


### PR DESCRIPTION
Resolves the **P3** findings from the impeccable audit. **Stacked on #407 (P2)**, which is stacked on #406 (P1) — merge order is #406 → #407 → this. Verified: `tsc` clean, design-token guard passes (now with phantom tokens fatal), full vitest suite green (only the 2 pre-existing `build-apex.test.ts` env failures from `scripts/` not being volume-mounted).

- **CI token gate**: promoted the phantom-token block in `check-design-tokens.sh` to **fatal** (all offenders were cleared in P1/P2) and refreshed the stale 'Phase A — do not gate CI' header. The script already runs in CI (`test.yml`); it now also fails on any future phantom (undefined `--color-*`) utility.
- **Focus rings**: notification bell + popover rows now use the app-standard `focus-visible:ring-2 focus-visible:ring-accent/30` (were the weaker `focus:ring-1`).
- **Reconcile progress bar**: animates `transition-[width]` instead of `transition-all` (compositor-friendlier).
- **Settings avatar monogram**: sans stack (`font-semibold`) instead of Fraunces — data-derived glyphs are sans per the Number-Voice rule.
- **Recurring row actions**: added `md:min-h-0` to match the dense-table touch-target convention used on transactions/accounts.

### Admin tables on mobile (documented, no change)
The audit's remaining P3 — admin tables using `overflow-x-auto` with no mobile card stack — is intentionally left as-is: those are desktop-admin surfaces and horizontal scroll is acceptable for that audience.