### PR TITLE
fix(dashboard): use shared Pagination for Recent Transactions

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { ChevronDown, ChevronUp, ChevronsUpDown } from "lucide-react";
 import AppShell from "@/components/AppShell";
 import HelpAnchor from "@/components/HelpAnchor";
 import HelpTooltip from "@/components/Tooltip";
+import Pagination from "@/components/ui/Pagination";
 import TourAnchor from "@/components/tour/TourAnchor";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -192,7 +193,7 @@ export default function DashboardPage() {
   const projectionRequestId = useRef(0);
   const [fetching, setFetching] = useState(true);
   const [page, setPage] = useState(0);
-  const [hasMore, setHasMore] = useState(false);
+  const [txTotal, setTxTotal] = useState(0);
   const [error, setError] = useState("");
   // Non-blocking error from a post-write refresh. The initial-load
   // banner above (`error`) keeps its hard-fail semantics: blank page +
@@ -286,7 +287,7 @@ export default function DashboardPage() {
       p === 0 ? apiFetch<ForecastPlan | null>(forecastUrl) : null,
     ]);
     const page_txs = pageData?.items ?? [];
-    setHasMore(page_txs.length > PAGE_SIZE);
+    setTxTotal(pageData?.total ?? 0);
     setTransactions(page_txs.slice(0, PAGE_SIZE));
     if (allData) setAllTransactions(allData.items);
     if (bds) setBudgets(bds);
@@ -1298,11 +1299,16 @@ export default function DashboardPage() {
                 </div>
               )}
             </div>
-            {!chartFilter && (page > 0 || hasMore) && (
-              <div className="flex items-center justify-between border-t border-border px-5 py-2.5">
-                <button onClick={() => setPage(Math.max(0, page - 1))} disabled={page === 0} className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-border px-3 text-xs text-text-secondary hover:bg-surface-raised disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30">Prev</button>
-                <span className="text-xs text-text-muted">Page {page + 1}</span>
-                <button onClick={() => setPage(page + 1)} disabled={!hasMore} className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-border px-3 text-xs text-text-secondary hover:bg-surface-raised disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30">Next</button>
+            {!chartFilter && (txTotal > PAGE_SIZE || page > 0) && (
+              <div className="border-t border-border px-5">
+                <Pagination
+                  page={page + 1}
+                  pageSize={PAGE_SIZE}
+                  total={txTotal}
+                  onPageChange={(n) => setPage(n - 1)}
+                  onPageSizeChange={() => {}}
+                  showPageSizeSelector={false}
+                />
               </div>
             )}
           </div>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -281,14 +281,14 @@ export default function DashboardPage() {
     const forecastUrl = realPeriodStart ? `/api/v1/forecast-plans/current?period_start=${realPeriodStart}` : "/api/v1/forecast-plans/current";
     const dateFilter = `date_from=${monthFrom}${monthTo ? `&date_to=${monthTo}` : ""}`;
     const [pageData, allData, bds, fc] = await Promise.all([
-      apiFetch<{ items: Transaction[]; total: number }>(`/api/v1/transactions?limit=${PAGE_SIZE + 1}&offset=${p * PAGE_SIZE}&${dateFilter}`),
+      apiFetch<{ items: Transaction[]; total: number }>(`/api/v1/transactions?limit=${PAGE_SIZE}&offset=${p * PAGE_SIZE}&${dateFilter}`),
       p === 0 ? apiFetch<{ items: Transaction[]; total: number }>(`/api/v1/transactions?limit=200&${dateFilter}`) : null,
       p === 0 ? apiFetch<Budget[]>(budgetUrl) : null,
       p === 0 ? apiFetch<ForecastPlan | null>(forecastUrl) : null,
     ]);
     const page_txs = pageData?.items ?? [];
     setTxTotal(pageData?.total ?? 0);
-    setTransactions(page_txs.slice(0, PAGE_SIZE));
+    setTransactions(page_txs);
     if (allData) setAllTransactions(allData.items);
     if (bds) setBudgets(bds);
     // null is a valid response (no plan yet) — set state so empty-state UI renders.

--- a/frontend/components/ui/Pagination.tsx
+++ b/frontend/components/ui/Pagination.tsx
@@ -20,6 +20,10 @@ export interface PaginationProps {
   onPageChange: (n: number) => void;
   onPageSizeChange: (n: number) => void;
   pageSizeOptions?: number[];
+  // When false, the per-page selector is omitted. An empty <div /> is still
+  // rendered as the first flex child so justify-between keeps the status +
+  // navigation group right-aligned (dropping the child would left-align them).
+  showPageSizeSelector?: boolean;
 }
 
 export default function Pagination({
@@ -29,6 +33,7 @@ export default function Pagination({
   onPageChange,
   onPageSizeChange,
   pageSizeOptions = [...PAGE_SIZE_OPTIONS],
+  showPageSizeSelector = true,
 }: PaginationProps) {
   const uid = useId();
   const selectId = `pagination-page-size-${uid}`;
@@ -38,27 +43,32 @@ export default function Pagination({
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 py-2 text-sm text-text-secondary">
-      {/* Per-page selector */}
-      <div className="flex items-center gap-2">
-        <label
-          htmlFor={selectId}
-          className="whitespace-nowrap text-xs"
-        >
-          Per page
-        </label>
-        <select
-          id={selectId}
-          value={pageSize}
-          onChange={(e) => onPageSizeChange(Number(e.target.value))}
-          className="rounded border border-border bg-surface px-2 py-1 text-xs text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
-        >
-          {pageSizeOptions.map((n) => (
-            <option key={n} value={n}>
-              {n}
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* Per-page selector. When hidden, render an empty <div /> so the
+          justify-between layout keeps the status + nav group right-aligned. */}
+      {showPageSizeSelector ? (
+        <div className="flex items-center gap-2">
+          <label
+            htmlFor={selectId}
+            className="whitespace-nowrap text-xs"
+          >
+            Per page
+          </label>
+          <select
+            id={selectId}
+            value={pageSize}
+            onChange={(e) => onPageSizeChange(Number(e.target.value))}
+            className="rounded border border-border bg-surface px-2 py-1 text-xs text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+          >
+            {pageSizeOptions.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : (
+        <div />
+      )}
 
       {/* Status + navigation */}
       <div className="flex items-center gap-3">

--- a/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
+++ b/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
@@ -137,14 +137,15 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
     render(<DashboardPage />);
 
     // Wait for the initial page-0 render. The Next button is enabled
-    // (hasMore=true because PAGE_0_ROWS.length = 11 > PAGE_SIZE).
+    // (txTotal = 11 > PAGE_SIZE, so the shared Pagination renders and Next
+    // is not on the last page). The shared component labels it "Next page".
     await waitFor(
-      () => expect(screen.getByRole("button", { name: /^Next$/ })).not.toBeDisabled(),
+      () => expect(screen.getByRole("button", { name: /Next page/ })).not.toBeDisabled(),
       { timeout: 3000 },
     );
 
     // Navigate to page 1 (page index 1 = "page > 0", the regression case).
-    fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Next page/ }));
 
     // Wait for page-1 render. SETTLED_TX (Coffee) is now visible; its
     // status-toggle button has the destination-aware aria-label set in

--- a/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
+++ b/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
@@ -85,9 +85,10 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
     let pendingCalls = 0;
     let toggleCallSeen = false;
 
-    // Page 0: 11 rows so hasMore is true and the Next button is enabled.
-    // Each row has a unique id so React keys are stable.
-    const PAGE_0_ROWS = Array.from({ length: 11 }, (_, i) => ({
+    // Page 0: a full page of PAGE_SIZE (10) rows. The grand total (11) is
+    // what enables the Next button — the visible-page fetch carries `total`,
+    // not an extra probe row. Each row has a unique id so React keys are stable.
+    const PAGE_0_ROWS = Array.from({ length: 10 }, (_, i) => ({
       ...SETTLED_TX,
       id: 200 + i,
       description: `Row ${i}`,
@@ -96,6 +97,7 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
     // below targets exactly this row, so the toggle test is unambiguous
     // about which page it's on.
     const PAGE_1_ROWS = [SETTLED_TX];
+    const GRAND_TOTAL = PAGE_0_ROWS.length + PAGE_1_ROWS.length;
 
     vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
       if (url === "/api/v1/accounts") return Promise.resolve([]);
@@ -122,15 +124,16 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
         return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
       }
       // limit=200 is the period-scoped "all" fetch (donut, charts, etc.).
-      // limit=11 is the paginated visible-page fetch (PAGE_SIZE+1).
+      // limit=10 is the paginated visible-page fetch (PAGE_SIZE). Every page
+      // response carries the grand total so the Pagination control can render.
       if (url.startsWith("/api/v1/transactions?limit=200")) {
         const items = [...PAGE_0_ROWS, ...PAGE_1_ROWS];
         return Promise.resolve({ items, total: items.length, limit: 200, offset: 0 });
       }
-      if (url.startsWith("/api/v1/transactions?limit=11&offset=0"))
-        return Promise.resolve({ items: PAGE_0_ROWS, total: PAGE_0_ROWS.length, limit: 11, offset: 0 });
-      if (url.startsWith("/api/v1/transactions?limit=11&offset=10"))
-        return Promise.resolve({ items: PAGE_1_ROWS, total: PAGE_1_ROWS.length, limit: 11, offset: 10 });
+      if (url.startsWith("/api/v1/transactions?limit=10&offset=0"))
+        return Promise.resolve({ items: PAGE_0_ROWS, total: GRAND_TOTAL, limit: 10, offset: 0 });
+      if (url.startsWith("/api/v1/transactions?limit=10&offset=10"))
+        return Promise.resolve({ items: PAGE_1_ROWS, total: GRAND_TOTAL, limit: 10, offset: 10 });
       return Promise.resolve({});
     }) as never);
 
@@ -188,8 +191,8 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
       if (url.startsWith("/api/v1/forecast?period_start=")) return Promise.resolve(null);
       if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
       if (url.startsWith("/api/v1/transactions?limit=200")) return Promise.resolve({ items: [SETTLED_TX], total: 1, limit: 200, offset: 0 });
-      if (url.startsWith("/api/v1/transactions?limit=11&offset=0"))
-        return Promise.resolve({ items: [SETTLED_TX], total: 1, limit: 11, offset: 0 });
+      if (url.startsWith("/api/v1/transactions?limit=10&offset=0"))
+        return Promise.resolve({ items: [SETTLED_TX], total: 1, limit: 10, offset: 0 });
       return Promise.resolve({});
     }) as never);
 
@@ -233,8 +236,8 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
       if (url.startsWith("/api/v1/forecast?period_start=")) return Promise.resolve(null);
       if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [], total: 0, limit: 200, offset: 0 });
       if (url.startsWith("/api/v1/transactions?limit=200")) return Promise.resolve({ items: [CC_TX], total: 1, limit: 200, offset: 0 });
-      if (url.startsWith("/api/v1/transactions?limit=11&offset=0"))
-        return Promise.resolve({ items: [CC_TX], total: 1, limit: 11, offset: 0 });
+      if (url.startsWith("/api/v1/transactions?limit=10&offset=0"))
+        return Promise.resolve({ items: [CC_TX], total: 1, limit: 10, offset: 0 });
       return Promise.resolve({});
     }) as never);
 

--- a/frontend/tests/components/ui/pagination.test.tsx
+++ b/frontend/tests/components/ui/pagination.test.tsx
@@ -138,6 +138,33 @@ describe("Pagination", () => {
     expect(screen.getByText(/Page 1 of 2/)).toBeInTheDocument();
   });
 
+  describe("showPageSizeSelector={false}", () => {
+    it("does not render the per-page select", () => {
+      render(<Pagination {...defaults} showPageSizeSelector={false} />);
+      expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/per page/i)).not.toBeInTheDocument();
+    });
+
+    it("still renders the status line and navigation buttons", () => {
+      render(
+        <Pagination
+          {...defaults}
+          page={1}
+          total={100}
+          pageSize={25}
+          showPageSizeSelector={false}
+        />,
+      );
+      expect(screen.getByText(/Page 1 of 4/)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /next page/i }),
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /previous page/i }),
+      ).toBeDisabled();
+    });
+  });
+
   describe("unique ids when multiple instances are rendered", () => {
     it("two Pagination instances have distinct select ids", () => {
       const { container } = render(


### PR DESCRIPTION
## What

Replaces the Dashboard "Recent Transactions" custom Prev/Page/Next bar with the shared `Pagination` component, with the page-size selector hidden so it matches `/transactions` while keeping the dashboard list at a fixed 10 rows.

## Changes
- `components/ui/Pagination.tsx` — new `showPageSizeSelector?: boolean` prop (default `true`). When `false`, the per-page `<select>` is omitted but an empty `<div />` is still rendered so `justify-between` keeps the status + nav group right-aligned.
- `app/dashboard/page.tsx` — track `txTotal` from the existing `{ items, total }` response (drops the old `hasMore` flag) and render `<Pagination … showPageSizeSelector={false} />`. Supersedes the old custom bar (and its low-contrast "Page {n}" label nit).
- Updated `dashboard-pending-toggle-refresh.test.tsx` selectors for the shared component's `"Next page"` accessible name.

Verified: `tsc --noEmit` clean, design-token check passes, 126 dashboard/pagination tests green.