### PR TITLE
test(backend): sweep deprecation warnings (cookies, utcnow, httpx, sqlite3)

### DIFF
--- a/backend/tests/auth/test_legacy_cookie_cleanup.py
+++ b/backend/tests/auth/test_legacy_cookie_cleanup.py
@@ -39,7 +39,7 @@ from app.models.user import Organization, Role, User
 from app.rate_limit import limiter
 from app.routers.auth import LEGACY_REFRESH_COOKIE_PATH, router as auth_router
 from app.security import create_refresh_token, hash_password
-from tests.conftest import issue_test_refresh_token
+from tests.conftest import issue_test_refresh_token, set_refresh_cookie
 
 
 def _mint_refresh_at(user_id: int, iat: datetime) -> str:
@@ -333,9 +333,9 @@ async def test_refresh_rotation_emits_legacy_cleanup(session_factory):
 
     app = make_app(session_factory)
     with TestClient(app) as client:
+        set_refresh_cookie(client, refresh)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/refresh"
         )
 
     assert res.status_code == 200
@@ -364,9 +364,9 @@ async def test_refresh_session_expired_emits_legacy_cleanup(session_factory):
 
     app = make_app(session_factory)
     with TestClient(app) as client:
+        set_refresh_cookie(client, refresh)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/refresh"
         )
 
     assert res.status_code == 401

--- a/backend/tests/auth/test_session_grace_lua.py
+++ b/backend/tests/auth/test_session_grace_lua.py
@@ -60,6 +60,8 @@ from app.routers.auth import (
 )
 from app.security import decode_refresh_jti_sid, hash_password
 
+from tests.conftest import set_refresh_cookie
+
 
 PASSWORD = "starting-password-1"
 
@@ -213,7 +215,8 @@ async def test_replay_after_grace_window_returns_401(session_factory, fake_redis
         old_jti, _sid = decode_refresh_jti_sid(token)
 
         # First refresh rotates.
-        first = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        set_refresh_cookie(client, token)
+        first = client.post("/api/v1/auth/refresh")
         assert first.status_code == 200
         # Grace key should exist now.
         assert f"auth:session:grace:{old_jti}" in fake_redis._kv
@@ -222,9 +225,8 @@ async def test_replay_after_grace_window_returns_401(session_factory, fake_redis
         del fake_redis._kv[f"auth:session:grace:{old_jti}"]
 
         # Replay the old cookie.
-        second = client.post(
-            "/api/v1/auth/refresh", cookies={"refresh_token": token}
-        )
+        set_refresh_cookie(client, token)
+        second = client.post("/api/v1/auth/refresh")
     assert second.status_code == 401
     assert second.json()["detail"] == "Session has been invalidated"
 
@@ -268,10 +270,10 @@ async def test_concurrent_refresh_one_winner_one_grace(session_factory, fake_red
     fake_redis.eval_barrier_target = 2
 
     async with _httpx_app_client(app) as ac:
+        set_refresh_cookie(ac, token)
+
         async def _do_refresh():
-            return await ac.post(
-                "/api/v1/auth/refresh", cookies={"refresh_token": token}
-            )
+            return await ac.post("/api/v1/auth/refresh")
 
         task_a = asyncio.create_task(_do_refresh())
         task_b = asyncio.create_task(_do_refresh())
@@ -341,10 +343,10 @@ async def test_concurrent_refresh_emits_one_rotated_and_one_grace_accept(
     fake_redis.eval_barrier_target = 2
 
     async with _httpx_app_client(app) as ac:
+        set_refresh_cookie(ac, token)
+
         async def _do_refresh():
-            return await ac.post(
-                "/api/v1/auth/refresh", cookies={"refresh_token": token}
-            )
+            return await ac.post("/api/v1/auth/refresh")
 
         task_a = asyncio.create_task(_do_refresh())
         task_b = asyncio.create_task(_do_refresh())
@@ -377,12 +379,14 @@ async def test_verify_accepts_grace_ticket_when_family_alive(
         old_jti, sid = decode_refresh_jti_sid(token)
 
         # Rotate once to land the grace key.
-        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        set_refresh_cookie(client, token)
+        r1 = client.post("/api/v1/auth/refresh")
         assert r1.status_code == 200
         assert f"auth:session:grace:{old_jti}" in fake_redis._kv
 
         # /verify with the OLD cookie — primary gone, grace alive, family alive.
-        res = client.post("/api/v1/auth/verify", cookies={"refresh_token": token})
+        set_refresh_cookie(client, token)
+        res = client.post("/api/v1/auth/verify")
     assert res.status_code == 200, res.text
     # Invariant: no Set-Cookie from /verify.
     assert _canonical_refresh_cookie(res.headers) is None
@@ -404,13 +408,15 @@ async def test_verify_rejects_grace_ticket_when_family_deleted(
         token = _login(client)
         old_jti, sid = decode_refresh_jti_sid(token)
 
-        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        set_refresh_cookie(client, token)
+        r1 = client.post("/api/v1/auth/refresh")
         assert r1.status_code == 200
 
         # Simulate concurrent logout: wipe the family set.
         del fake_redis._sets[f"auth:session:by_sid:{sid}"]
 
-        res = client.post("/api/v1/auth/verify", cookies={"refresh_token": token})
+        set_refresh_cookie(client, token)
+        res = client.post("/api/v1/auth/verify")
     assert res.status_code == 401
 
 
@@ -430,16 +436,16 @@ async def test_refresh_grace_branch_rejects_when_family_deleted(
         old_jti, sid = decode_refresh_jti_sid(token)
 
         # Rotate so old_jti has only a grace key.
-        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        set_refresh_cookie(client, token)
+        r1 = client.post("/api/v1/auth/refresh")
         assert r1.status_code == 200
         assert f"auth:session:grace:{old_jti}" in fake_redis._kv
 
         # Concurrent logout: wipe the family set.
         del fake_redis._sets[f"auth:session:by_sid:{sid}"]
 
-        res = client.post(
-            "/api/v1/auth/refresh", cookies={"refresh_token": token}
-        )
+        set_refresh_cookie(client, token)
+        res = client.post("/api/v1/auth/refresh")
     assert res.status_code == 401, res.text
     assert res.json()["detail"] == "Session has been invalidated"
 
@@ -459,16 +465,16 @@ async def test_refresh_grace_branch_rejects_on_sid_mismatch(
         token = _login(client)
         old_jti, sid = decode_refresh_jti_sid(token)
 
-        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        set_refresh_cookie(client, token)
+        r1 = client.post("/api/v1/auth/refresh")
         assert r1.status_code == 200
         # Corrupt the grace row so its sid mismatches the JWT's sid.
         fake_redis._kv[f"auth:session:grace:{old_jti}"] = json.dumps(
             {"user_id": 1, "sid": "deadbeef-not-the-real-sid", "successor_jti": "x"}
         )
 
-        res = client.post(
-            "/api/v1/auth/refresh", cookies={"refresh_token": token}
-        )
+        set_refresh_cookie(client, token)
+        res = client.post("/api/v1/auth/refresh")
     assert res.status_code == 401
 
 
@@ -517,9 +523,8 @@ async def test_jti_collision_retries_and_succeeds(
     )
 
     with TestClient(app) as client:
-        res = client.post(
-            "/api/v1/auth/refresh", cookies={"refresh_token": token}
-        )
+        set_refresh_cookie(client, token)
+        res = client.post("/api/v1/auth/refresh")
     assert res.status_code == 200, res.text
     assert _canonical_refresh_cookie(res.headers) is not None
 
@@ -555,9 +560,8 @@ async def test_jti_collision_double_failure_returns_503(
     )
 
     with TestClient(app) as client:
-        res = client.post(
-            "/api/v1/auth/refresh", cookies={"refresh_token": token}
-        )
+        set_refresh_cookie(client, token)
+        res = client.post("/api/v1/auth/refresh")
     assert res.status_code == 503, res.text
     assert _canonical_refresh_cookie(res.headers) is None
 
@@ -592,7 +596,8 @@ async def test_refresh_direct_grace_path_emits_catchup_cookie_and_audit(
         token = _login(client)
         old_jti, sid = decode_refresh_jti_sid(token)
 
-        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        set_refresh_cookie(client, token)
+        r1 = client.post("/api/v1/auth/refresh")
         assert r1.status_code == 200
         # Capture the winner's successor jti from r1's Set-Cookie.
         winner_raw = _canonical_refresh_cookie(r1.headers)
@@ -602,9 +607,8 @@ async def test_refresh_direct_grace_path_emits_catchup_cookie_and_audit(
 
         # At this point primary {old_jti} is gone, grace alive, family alive.
         # Tab B replays the old cookie.
-        res = client.post(
-            "/api/v1/auth/refresh", cookies={"refresh_token": token}
-        )
+        set_refresh_cookie(client, token)
+        res = client.post("/api/v1/auth/refresh")
 
     assert res.status_code == 200, res.text
     catchup_raw = _canonical_refresh_cookie(res.headers)

--- a/backend/tests/auth/test_session_jti_sid.py
+++ b/backend/tests/auth/test_session_jti_sid.py
@@ -61,6 +61,8 @@ from app.services.mfa_service import (
     hash_recovery_code,
 )
 
+from tests.conftest import set_refresh_cookie
+
 
 PASSWORD = "starting-password-1"
 
@@ -299,9 +301,9 @@ async def test_refresh_rotation_preserves_sid(session_factory, fake_redis) -> No
         login_token = _refresh_token_from_set_cookie(login_raw)
         original_jti, original_sid = decode_refresh_jti_sid(login_token)
 
+        set_refresh_cookie(client, login_token)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": login_token},
+            "/api/v1/auth/refresh"
         )
 
     assert res.status_code == 200, res.json()
@@ -340,9 +342,9 @@ async def test_sid_preserved_across_five_rotations(
 
         seen_jtis = [original_jti]
         for _ in range(5):
+            set_refresh_cookie(client, token)
             res = client.post(
-                "/api/v1/auth/refresh",
-                cookies={"refresh_token": token},
+                "/api/v1/auth/refresh"
             )
             assert res.status_code == 200, res.json()
             raw = _canonical_refresh_cookie(res.headers)
@@ -501,9 +503,9 @@ async def test_legacy_no_jti_no_sid_token_rejected(
 
     app = _make_app(session_factory)
     with TestClient(app) as client:
+        set_refresh_cookie(client, legacy_token)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": legacy_token},
+            "/api/v1/auth/refresh"
         )
 
     assert res.status_code == 401, res.json()
@@ -529,9 +531,9 @@ async def test_manual_redis_del_invalidates_session(
         # Operator yanks the row out of Redis.
         del fake_redis._kv[f"auth:session:{jti}"]
 
+        set_refresh_cookie(client, token)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": token},
+            "/api/v1/auth/refresh"
         )
 
     assert res.status_code == 401, res.json()
@@ -557,9 +559,9 @@ async def test_family_set_membership_matches_rotation_chain(
         issued = [first_jti]
 
         for _ in range(3):
+            set_refresh_cookie(client, token)
             res = client.post(
-                "/api/v1/auth/refresh",
-                cookies={"refresh_token": token},
+                "/api/v1/auth/refresh"
             )
             assert res.status_code == 200
             token = _refresh_token_from_set_cookie(_canonical_refresh_cookie(res.headers))
@@ -609,9 +611,9 @@ async def test_refresh_503_when_redis_unreachable(
     # Now make redis disappear and try to rotate.
     monkeypatch.setattr(redis_client, "get_client", lambda: None)
     with TestClient(app) as client:
+        set_refresh_cookie(client, token)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": token},
+            "/api/v1/auth/refresh"
         )
     assert res.status_code == 503, res.json()
     assert _canonical_refresh_cookie(res.headers) is None
@@ -807,9 +809,9 @@ async def test_verify_accepts_session_with_redis_row(
         )
         token = _refresh_token_from_set_cookie(_canonical_refresh_cookie(login.headers))
 
+        set_refresh_cookie(client, token)
         res = client.post(
-            "/api/v1/auth/verify",
-            cookies={"refresh_token": token},
+            "/api/v1/auth/verify"
         )
     assert res.status_code == 200, res.json()
     # /verify must NEVER emit Set-Cookie (RSC contract).
@@ -832,9 +834,9 @@ async def test_verify_rejects_token_with_missing_redis_row(
         jti, _sid = decode_refresh_jti_sid(token)
         del fake_redis._kv[f"auth:session:{jti}"]
 
+        set_refresh_cookie(client, token)
         res = client.post(
-            "/api/v1/auth/verify",
-            cookies={"refresh_token": token},
+            "/api/v1/auth/verify"
         )
     assert res.status_code == 401, res.json()
 
@@ -1036,9 +1038,9 @@ async def test_refresh_rejects_jti_with_mismatched_user_id_in_redis(
             {"user_id": 999999, "sid": sid}
         )
 
+        set_refresh_cookie(client, token)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": token},
+            "/api/v1/auth/refresh"
         )
     assert res.status_code == 401, res.json()
     assert "invalidated" in res.json()["detail"].lower()
@@ -1072,8 +1074,8 @@ async def test_refresh_rejects_jti_with_mismatched_sid_in_redis(
             {"user_id": row["user_id"], "sid": "deadbeef-not-the-real-sid"}
         )
 
+        set_refresh_cookie(client, token)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": token},
+            "/api/v1/auth/refresh"
         )
     assert res.status_code == 401, res.json()

--- a/backend/tests/auth/test_session_logout_revoke.py
+++ b/backend/tests/auth/test_session_logout_revoke.py
@@ -62,6 +62,8 @@ from app.security import (
     hash_password,
 )
 
+from tests.conftest import set_refresh_cookie
+
 
 PASSWORD = "starting-password-1"
 
@@ -225,7 +227,8 @@ async def test_logout_after_rotation_revokes_entire_family(
         old_jti, sid = decode_refresh_jti_sid(token)
 
         # Rotate so old_jti only has a grace key, new_jti is the primary.
-        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        set_refresh_cookie(client, token)
+        r1 = client.post("/api/v1/auth/refresh" )
         assert r1.status_code == 200
         new_raw = _canonical_refresh_cookie(r1.headers)
         assert new_raw is not None
@@ -246,10 +249,10 @@ async def test_logout_after_rotation_revokes_entire_family(
             seed["org_id"],
             Role.OWNER.value,
         )
+        set_refresh_cookie(client, new_token)
         logout = client.post(
             "/api/v1/auth/logout",
-            cookies={"refresh_token": new_token},
-            headers={"Authorization": f"Bearer {access}"},
+            headers={"Authorization": f"Bearer {access}"}
         )
         assert logout.status_code == 200, logout.text
 
@@ -262,8 +265,9 @@ async def test_logout_after_rotation_revokes_entire_family(
 
         # Replay the PRE-rotation cookie. Grace key is gone AND family
         # is gone, so /refresh must 401.
+        set_refresh_cookie(client, token)
         replay = client.post(
-            "/api/v1/auth/refresh", cookies={"refresh_token": token}
+            "/api/v1/auth/refresh"
         )
     assert replay.status_code == 401
     assert replay.json()["detail"] == "Session has been invalidated"
@@ -313,15 +317,16 @@ async def test_concurrent_logout_vs_rotation_returns_session_revoked(
 
     async with _httpx_app_client(app) as ac:
         async def _do_refresh():
+            set_refresh_cookie(ac, token)
             return await ac.post(
-                "/api/v1/auth/refresh", cookies={"refresh_token": token}
+                "/api/v1/auth/refresh"
             )
 
         async def _do_logout():
+            set_refresh_cookie(ac, token)
             res = await ac.post(
                 "/api/v1/auth/logout",
-                cookies={"refresh_token": token},
-                headers={"Authorization": f"Bearer {access}"},
+                headers={"Authorization": f"Bearer {access}"}
             )
             logout_done.set()
             return res
@@ -362,7 +367,8 @@ async def test_verify_rejects_grace_ticket_after_logout(
         old_jti, sid = decode_refresh_jti_sid(token)
 
         # Rotate so the grace key exists for old_jti.
-        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        set_refresh_cookie(client, token)
+        r1 = client.post("/api/v1/auth/refresh" )
         assert r1.status_code == 200
         new_token = _refresh_token_from_set_cookie(
             _canonical_refresh_cookie(r1.headers)
@@ -372,18 +378,19 @@ async def test_verify_rejects_grace_ticket_after_logout(
         access = create_access_token(
             seed["user_id"], seed["org_id"], Role.OWNER.value
         )
+        set_refresh_cookie(client, new_token)
         logout = client.post(
             "/api/v1/auth/logout",
-            cookies={"refresh_token": new_token},
-            headers={"Authorization": f"Bearer {access}"},
+            headers={"Authorization": f"Bearer {access}"}
         )
         assert logout.status_code == 200
 
         # /verify with the PRE-rotation cookie. Grace key was deleted
         # by Round B, but even if some grace-only edge case lingered,
         # the family-set check in the grace branch rejects.
+        set_refresh_cookie(client, token)
         verify = client.post(
-            "/api/v1/auth/verify", cookies={"refresh_token": token}
+            "/api/v1/auth/verify"
         )
     assert verify.status_code == 401
 
@@ -480,9 +487,9 @@ async def test_corrupt_refresh_cookie_logout_still_clears(session_factory, fake_
     await _seed_user(session_factory)
     app = _make_app(session_factory)
     with TestClient(app) as client:
+        set_refresh_cookie(client, "this-is-not-a-jwt")
         res = client.post(
-            "/api/v1/auth/logout",
-            cookies={"refresh_token": "this-is-not-a-jwt"},
+            "/api/v1/auth/logout"
         )
     assert res.status_code == 200
     deletes = _delete_cookie_headers(res.headers)
@@ -524,10 +531,10 @@ async def test_logout_does_not_write_sessions_invalidated_at(
             user_before = row.scalar_one()
             cutoff_before = user_before.sessions_invalidated_at
 
+        set_refresh_cookie(client, token)
         res = client.post(
             "/api/v1/auth/logout",
-            cookies={"refresh_token": token},
-            headers={"Authorization": f"Bearer {access}"},
+            headers={"Authorization": f"Bearer {access}"}
         )
     assert res.status_code == 200
 
@@ -561,10 +568,10 @@ async def test_logout_audit_binds_to_actor_when_bearer_present(
         access = create_access_token(
             seed["user_id"], seed["org_id"], Role.OWNER.value
         )
+        set_refresh_cookie(client, token)
         res = client.post(
             "/api/v1/auth/logout",
-            cookies={"refresh_token": token},
-            headers={"Authorization": f"Bearer {access}"},
+            headers={"Authorization": f"Bearer {access}"}
         )
     assert res.status_code == 200
 
@@ -592,10 +599,10 @@ async def test_logout_clears_canonical_and_legacy_cookie_paths(
         access = create_access_token(
             seed["user_id"], seed["org_id"], Role.OWNER.value
         )
+        set_refresh_cookie(client, token)
         res = client.post(
             "/api/v1/auth/logout",
-            cookies={"refresh_token": token},
-            headers={"Authorization": f"Bearer {access}"},
+            headers={"Authorization": f"Bearer {access}"}
         )
     assert res.status_code == 200
     deletes = _delete_cookie_headers(res.headers)
@@ -637,10 +644,10 @@ async def test_logout_one_device_leaves_other_device_authenticated(
         seed["user_id"], seed["org_id"], Role.OWNER.value
     )
     with TestClient(app_a) as client_a:
+        set_refresh_cookie(client_a, token_a)
         logout = client_a.post(
             "/api/v1/auth/logout",
-            cookies={"refresh_token": token_a},
-            headers={"Authorization": f"Bearer {access_a}"},
+            headers={"Authorization": f"Bearer {access_a}"}
         )
     assert logout.status_code == 200
 
@@ -651,8 +658,9 @@ async def test_logout_one_device_leaves_other_device_authenticated(
 
     # Device B can still rotate.
     with TestClient(app_b) as client_b:
+        set_refresh_cookie(client_b, token_b)
         rotate = client_b.post(
-            "/api/v1/auth/refresh", cookies={"refresh_token": token_b}
+            "/api/v1/auth/refresh"
         )
     assert rotate.status_code == 200
     new_raw = _canonical_refresh_cookie(rotate.headers)
@@ -691,8 +699,9 @@ async def test_verify_rejects_primary_when_family_set_missing(
         # Primary + grace keys deliberately remain — that's the bug class.
         del fake_redis._sets[f"auth:session:by_sid:{sid}"]
 
+        set_refresh_cookie(client, token)
         verify = client.post(
-            "/api/v1/auth/verify", cookies={"refresh_token": token}
+            "/api/v1/auth/verify"
         )
     assert verify.status_code == 401, verify.json()
     assert "invalidated" in verify.json()["detail"].lower()
@@ -714,8 +723,9 @@ async def test_refresh_rejects_primary_when_family_set_missing(
         # Round A simulation.
         del fake_redis._sets[f"auth:session:by_sid:{sid}"]
 
+        set_refresh_cookie(client, token)
         refresh = client.post(
-            "/api/v1/auth/refresh", cookies={"refresh_token": token}
+            "/api/v1/auth/refresh"
         )
     assert refresh.status_code == 401, refresh.json()
     # No Set-Cookie on a rejected refresh.
@@ -763,10 +773,10 @@ async def test_logout_round_a_succeeds_round_b_fails_revocation_still_holds(
         # the cookie is still cleared, and the response is 200. The
         # orphan primary remains in Redis — exactly the half-revoked
         # state we want to test against.
+        set_refresh_cookie(client, token)
         logout = client.post(
             "/api/v1/auth/logout",
-            cookies={"refresh_token": token},
-            headers={"Authorization": f"Bearer {access}"},
+            headers={"Authorization": f"Bearer {access}"}
         )
         assert logout.status_code == 200
 
@@ -787,13 +797,15 @@ async def test_logout_round_a_succeeds_round_b_fails_revocation_still_holds(
         # The orphaned cookie must NOT verify and must NOT refresh,
         # even though the primary key is still alive. The
         # membership check is what enforces this.
+        set_refresh_cookie(client, token)
         verify = client.post(
-            "/api/v1/auth/verify", cookies={"refresh_token": token}
+            "/api/v1/auth/verify"
         )
         assert verify.status_code == 401, verify.json()
 
+        set_refresh_cookie(client, token)
         refresh = client.post(
-            "/api/v1/auth/refresh", cookies={"refresh_token": token}
+            "/api/v1/auth/refresh"
         )
         assert refresh.status_code == 401, refresh.json()
         assert _canonical_refresh_cookie(refresh.headers) is None

--- a/backend/tests/auth/test_verify_and_cookie_path.py
+++ b/backend/tests/auth/test_verify_and_cookie_path.py
@@ -29,7 +29,7 @@ from app.models.user import Organization, Role, User
 from app.rate_limit import limiter
 from app.routers.auth import router as auth_router
 from app.security import create_refresh_token, hash_password
-from tests.conftest import issue_test_refresh_token
+from tests.conftest import issue_test_refresh_token, set_refresh_cookie
 
 
 PASSWORD = "S3cret-Pass!"
@@ -111,9 +111,9 @@ async def test_verify_returns_user_and_access_token(session_factory):
     with TestClient(app) as client:
         # First call `/me` after login to know the canonical user shape; here
         # we just assert the verify body contains the same key fields.
+        set_refresh_cookie(client, refresh)
         res = client.post(
-            "/api/v1/auth/verify",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/verify"
         )
 
     assert res.status_code == 200
@@ -151,9 +151,9 @@ async def test_verify_user_shape_matches_me(session_factory):
         )
         assert me.status_code == 200
 
+        set_refresh_cookie(client, refresh)
         verify = client.post(
-            "/api/v1/auth/verify",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/verify"
         )
         assert verify.status_code == 200
 
@@ -175,9 +175,9 @@ async def test_verify_no_cookie_returns_401(session_factory):
 async def test_verify_invalid_refresh_token_returns_401(session_factory):
     app = make_app(session_factory)
     with TestClient(app) as client:
+        set_refresh_cookie(client, "this.is.not.a.jwt")
         res = client.post(
-            "/api/v1/auth/verify",
-            cookies={"refresh_token": "this.is.not.a.jwt"},
+            "/api/v1/auth/verify"
         )
 
     assert res.status_code == 401
@@ -193,9 +193,9 @@ async def test_verify_access_token_not_accepted_as_refresh(session_factory):
 
     app = make_app(session_factory)
     with TestClient(app) as client:
+        set_refresh_cookie(client, access)
         res = client.post(
-            "/api/v1/auth/verify",
-            cookies={"refresh_token": access},
+            "/api/v1/auth/verify"
         )
 
     assert res.status_code == 401
@@ -208,9 +208,9 @@ async def test_verify_inactive_user_returns_401(session_factory):
 
     app = make_app(session_factory)
     with TestClient(app) as client:
+        set_refresh_cookie(client, refresh)
         res = client.post(
-            "/api/v1/auth/verify",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/verify"
         )
 
     assert res.status_code == 401
@@ -229,9 +229,9 @@ async def test_verify_does_not_rotate_or_set_cookie(session_factory):
 
     app = make_app(session_factory)
     with TestClient(app) as client:
+        set_refresh_cookie(client, refresh)
         res = client.post(
-            "/api/v1/auth/verify",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/verify"
         )
 
     assert res.status_code == 200
@@ -286,9 +286,9 @@ async def test_cookie_path_is_root_on_refresh_rotation(session_factory):
 
     app = make_app(session_factory)
     with TestClient(app) as client:
+        set_refresh_cookie(client, refresh)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/refresh"
         )
 
     assert res.status_code == 200
@@ -376,9 +376,9 @@ async def test_verify_rejects_invalidated_refresh_token(session_factory):
 
     app = make_app(session_factory)
     with TestClient(app) as client:
+        set_refresh_cookie(client, refresh)
         res = client.post(
-            "/api/v1/auth/verify",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/verify"
         )
 
     assert res.status_code == 401
@@ -411,9 +411,9 @@ async def test_verify_rejects_expired_session_lifetime(session_factory):
 
     app = make_app(session_factory)
     with TestClient(app) as client:
+        set_refresh_cookie(client, refresh)
         res = client.post(
-            "/api/v1/auth/verify",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/verify"
         )
 
     assert res.status_code == 401
@@ -445,9 +445,9 @@ async def test_refresh_clears_cookie_on_session_lifetime_expiry(session_factory)
 
     app = make_app(session_factory)
     with TestClient(app) as client:
+        set_refresh_cookie(client, refresh)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/refresh"
         )
 
     assert res.status_code == 401

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -30,6 +30,23 @@ os.environ.setdefault("APP_ENV", "development")
 logging.getLogger("ofxtools").setLevel(logging.WARNING)
 
 
+def set_refresh_cookie(client: Any, token: str) -> None:
+    """Pin ``refresh_token`` on the test client's cookie jar.
+
+    Replaces the deprecated per-request ``cookies={"refresh_token": ...}``
+    kwarg (Starlette/httpx warn that per-request cookie persistence is
+    ambiguous). We first ``delete`` every existing ``refresh_token`` entry
+    across all domains/paths — including any canonical or legacy-path cookie
+    the server set on a prior rotation — then ``set`` exactly the intended
+    value, so the next request sends only this token. This reproduces the
+    per-request override behaviour deterministically (no duplicate-cookie
+    ``CookieConflict``). Works for both ``TestClient`` and
+    ``httpx.AsyncClient`` (both expose an ``httpx.Cookies`` jar).
+    """
+    client.cookies.delete("refresh_token")
+    client.cookies.set("refresh_token", token)
+
+
 # ── Fake in-process Redis (PR 2 — backend session model) ────────────────────
 #
 # After PR 2 of ``specs/2026-05-17-backend-session-model.md`` every refresh

--- a/backend/tests/routers/test_admin_rate_limit_overrides.py
+++ b/backend/tests/routers/test_admin_rate_limit_overrides.py
@@ -19,7 +19,7 @@ Pins the architect-locked invariants:
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytest_asyncio
@@ -274,7 +274,7 @@ async def test_create_rejects_past_expiry(session_factory):
     seeded = await _seed(session_factory)
     app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
     client = TestClient(app)
-    past = (datetime.utcnow() - timedelta(hours=1)).isoformat()
+    past = (datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=1)).isoformat()
     resp = client.post(
         "/api/v1/admin/rate-limit-overrides",
         json={

--- a/backend/tests/routers/test_auth_cookie_max_age.py
+++ b/backend/tests/routers/test_auth_cookie_max_age.py
@@ -53,7 +53,7 @@ from app.security import (
     create_refresh_token,
     hash_password,
 )
-from tests.conftest import issue_test_refresh_token
+from tests.conftest import issue_test_refresh_token, set_refresh_cookie
 from app.services.mfa_service import (
     generate_recovery_codes,
     hash_recovery_code,
@@ -279,9 +279,9 @@ async def test_refresh_rotation_cookie_max_age_matches_settings(
     app = _make_app(session_factory)
 
     with TestClient(app) as client:
+        set_refresh_cookie(client, refresh)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/refresh"
         )
 
     assert res.status_code == 200, res.json()
@@ -381,9 +381,9 @@ async def test_all_four_sites_emit_same_max_age_when_setting_changes(
     # 2. Refresh rotation.
     refresh = issue_test_refresh_token(seed["user_id"])
     with TestClient(app) as client:
+        set_refresh_cookie(client, refresh)
         refresh_res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/refresh"
         )
     assert refresh_res.status_code == 200, refresh_res.json()
     refresh_raw = _canonical_refresh_cookie(refresh_res.headers)

--- a/backend/tests/routers/test_auth_debug_logging_gate.py
+++ b/backend/tests/routers/test_auth_debug_logging_gate.py
@@ -37,6 +37,8 @@ from app.models import Base
 from app.rate_limit import limiter
 from app.routers.auth import router as auth_router
 
+from tests.conftest import set_refresh_cookie
+
 
 @pytest_asyncio.fixture
 async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
@@ -92,9 +94,9 @@ class TestAuthDebugLoggingGate:
         app = _make_app(session_factory)
         with structlog.testing.capture_logs() as captured:
             with TestClient(app) as client:
+                set_refresh_cookie(client, "not.a.jwt")
                 res = client.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": "not.a.jwt"},
+                    "/api/v1/auth/refresh"
                 )
         assert res.status_code == 401, res.json()
         rejection_logs = [
@@ -137,9 +139,9 @@ class TestAuthDebugLoggingGate:
         app = _make_app(session_factory)
         with structlog.testing.capture_logs() as captured:
             with TestClient(app) as client:
+                set_refresh_cookie(client, "not.a.jwt")
                 res = client.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": "not.a.jwt"},
+                    "/api/v1/auth/refresh"
                 )
         assert res.status_code == 401
         rejection_logs = [

--- a/backend/tests/routers/test_refresh_cookie_catchup.py
+++ b/backend/tests/routers/test_refresh_cookie_catchup.py
@@ -58,6 +58,8 @@ from app.rate_limit import limiter
 from app.routers.auth import router as auth_router
 from app.security import create_refresh_token, hash_password
 
+from tests.conftest import set_refresh_cookie
+
 
 PASSWORD = "starting-password-1"
 
@@ -200,9 +202,9 @@ class TestGraceBranchCatchupCookie:
 
         app = _make_app(session_factory)
         with TestClient(app) as client:
+            set_refresh_cookie(client, token)
             res = client.post(
-                "/api/v1/auth/refresh",
-                cookies={"refresh_token": token},
+                "/api/v1/auth/refresh"
             )
 
         assert res.status_code == 200, res.json()
@@ -288,9 +290,9 @@ class TestGraceBranchCatchupCookie:
         )
         app = _make_app(session_factory)
         with TestClient(app) as cli:
+            set_refresh_cookie(cli, token)
             res = cli.post(
-                "/api/v1/auth/refresh",
-                cookies={"refresh_token": token},
+                "/api/v1/auth/refresh"
             )
 
         assert res.status_code == 200, res.json()
@@ -348,9 +350,9 @@ class TestConcurrentRaceConvergence:
         decoded_jtis: list[str] = []
         with TestClient(app) as client:
             for _ in range(2):
+                set_refresh_cookie(client, token)
                 res = client.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": token},
+                    "/api/v1/auth/refresh"
                 )
                 assert res.status_code == 200
                 set_cookie = next(
@@ -402,9 +404,9 @@ class TestCatchupCookieValidatesAgainstPrimary:
         app = _make_app(session_factory)
         with TestClient(app) as client:
             # Round 1: grace path → catch-up cookie.
+            set_refresh_cookie(client, token)
             res1 = client.post(
-                "/api/v1/auth/refresh",
-                cookies={"refresh_token": token},
+                "/api/v1/auth/refresh"
             )
             assert res1.status_code == 200
             set_cookie = next(
@@ -418,9 +420,9 @@ class TestCatchupCookieValidatesAgainstPrimary:
             # Round 2: send the catch-up token. The validator should
             # find ``successor_jti`` as primary, run the rotation,
             # and emit a NEW Set-Cookie with a DIFFERENT jti.
+            set_refresh_cookie(client, new_token)
             res2 = client.post(
-                "/api/v1/auth/refresh",
-                cookies={"refresh_token": new_token},
+                "/api/v1/auth/refresh"
             )
             assert res2.status_code == 200
             second_set_cookie = next(
@@ -492,9 +494,9 @@ class TestNoRedisWriteOnCatchup:
 
         app = _make_app(session_factory)
         with TestClient(app) as client:
+            set_refresh_cookie(client, token)
             res = client.post(
-                "/api/v1/auth/refresh",
-                cookies={"refresh_token": token},
+                "/api/v1/auth/refresh"
             )
         assert res.status_code == 200
         assert write_calls == [], (
@@ -532,9 +534,9 @@ class TestMissingSuccessorFailsClosed:
         app = _make_app(session_factory)
         with structlog.testing.capture_logs() as captured:
             with TestClient(app) as cli:
+                set_refresh_cookie(cli, token)
                 res = cli.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": token},
+                    "/api/v1/auth/refresh"
                 )
         assert res.status_code == 401
         # Reason log emitted.
@@ -597,9 +599,9 @@ class TestMissingSuccessorFailsClosed:
         app = _make_app(session_factory)
         with structlog.testing.capture_logs() as captured:
             with TestClient(app) as cli:
+                set_refresh_cookie(cli, token)
                 res = cli.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": token},
+                    "/api/v1/auth/refresh"
                 )
         assert res.status_code == 401
         rejection_logs = [
@@ -650,9 +652,9 @@ class TestMissingSuccessorFailsClosed:
         app = _make_app(session_factory)
         with structlog.testing.capture_logs() as captured:
             with TestClient(app) as cli:
+                set_refresh_cookie(cli, token)
                 res = cli.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": token},
+                    "/api/v1/auth/refresh"
                 )
         assert res.status_code == 401
         rejection_logs = [
@@ -691,9 +693,9 @@ class TestVerifyNeverEmitsCookie:
 
         app = _make_app(session_factory)
         with TestClient(app) as cli:
+            set_refresh_cookie(cli, token)
             res = cli.post(
-                "/api/v1/auth/verify",
-                cookies={"refresh_token": token},
+                "/api/v1/auth/verify"
             )
         assert res.status_code == 200
         # No Set-Cookie header at all from /verify — neither the

--- a/backend/tests/routers/test_refresh_redis_transport_integration.py
+++ b/backend/tests/routers/test_refresh_redis_transport_integration.py
@@ -39,7 +39,7 @@ from app.models.user import Organization, Role, User
 from app.rate_limit import limiter
 from app.routers.auth import router as auth_router
 from app.security import hash_password
-from tests.conftest import issue_test_refresh_token
+from tests.conftest import issue_test_refresh_token, set_refresh_cookie
 
 
 PASSWORD = "starting-password-1"
@@ -156,9 +156,9 @@ class TestRefreshReturns503OnClosedTransport:
 
         with self._patch_client_get(side_effect=closed_transport_error):
             with TestClient(app) as client:
+                set_refresh_cookie(client, token)
                 res = client.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": token},
+                    "/api/v1/auth/refresh"
                 )
 
         # The contract: 503, not 500. The frontend reactive-recovery
@@ -185,9 +185,9 @@ class TestRefreshReturns503OnClosedTransport:
             side_effect=BrokenPipeError(32, "Broken pipe")
         ):
             with TestClient(app) as client:
+                set_refresh_cookie(client, token)
                 res = client.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": token},
+                    "/api/v1/auth/refresh"
                 )
         assert res.status_code == 503
 
@@ -212,9 +212,9 @@ class TestRefreshReturns503OnClosedTransport:
             # 500 response instead of re-raising the inner exception —
             # we want to assert on the response, not catch the bug.
             with TestClient(app, raise_server_exceptions=False) as client:
+                set_refresh_cookie(client, token)
                 res = client.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": token},
+                    "/api/v1/auth/refresh"
                 )
         assert res.status_code == 500, (
             f"Genuine RuntimeError must stay a 500; got {res.status_code}"
@@ -244,9 +244,9 @@ class TestRefreshRejectedLogging:
         app = _make_app(session_factory)
         with structlog.testing.capture_logs() as captured:
             with TestClient(app) as client:
+                set_refresh_cookie(client, "not.a.jwt")
                 res = client.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": "not.a.jwt"},
+                    "/api/v1/auth/refresh"
                 )
         assert res.status_code == 401
         rejection_logs = [
@@ -284,9 +284,9 @@ class TestRefreshRejectedLogging:
         app = _make_app(session_factory)
         with structlog.testing.capture_logs() as captured:
             with TestClient(app) as client:
+                set_refresh_cookie(client, legacy_token)
                 res = client.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": legacy_token},
+                    "/api/v1/auth/refresh"
                 )
         assert res.status_code == 401
         rejection_logs = [
@@ -320,9 +320,9 @@ class TestRefreshRejectedLogging:
         app = _make_app(session_factory)
         with structlog.testing.capture_logs() as captured:
             with TestClient(app) as client:
+                set_refresh_cookie(client, token)
                 res = client.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": token},
+                    "/api/v1/auth/refresh"
                 )
         assert res.status_code == 401
 
@@ -459,9 +459,9 @@ class TestRefreshPrefersTransientOverTerminal:
         no transient ever seen."""
         app = _make_app(session_factory)
         with TestClient(app) as client:
+            set_refresh_cookie(client, "not.a.jwt")
             res = client.post(
-                "/api/v1/auth/refresh",
-                cookies={"refresh_token": "not.a.jwt"},
+                "/api/v1/auth/refresh"
             )
         assert res.status_code == 401
 
@@ -529,9 +529,9 @@ class TestRefreshLuaRotationLogging:
 
         with structlog.testing.capture_logs() as captured:
             with TestClient(app) as client:
+                set_refresh_cookie(client, token)
                 res = client.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": token},
+                    "/api/v1/auth/refresh"
                 )
         assert res.status_code == 401
         assert "invalidated" in res.json()["detail"].lower()
@@ -590,9 +590,9 @@ class TestRefreshLuaRotationLogging:
 
         with structlog.testing.capture_logs() as captured:
             with TestClient(app) as client:
+                set_refresh_cookie(client, token)
                 res = client.post(
-                    "/api/v1/auth/refresh",
-                    cookies={"refresh_token": token},
+                    "/api/v1/auth/refresh"
                 )
         assert res.status_code == 401
 

--- a/backend/tests/routers/test_session_ttl_per_org.py
+++ b/backend/tests/routers/test_session_ttl_per_org.py
@@ -52,7 +52,7 @@ from app.rate_limit import limiter
 from app.routers.auth import LEGACY_REFRESH_COOKIE_PATH, router as auth_router
 from app.routers.settings import router as settings_router
 from app.security import hash_password
-from tests.conftest import issue_test_refresh_token
+from tests.conftest import issue_test_refresh_token, set_refresh_cookie
 
 
 PASSWORD = "starting-password-1"
@@ -342,9 +342,9 @@ async def test_refresh_rotation_uses_current_per_org_session_lifetime_days(
     app = _make_app(session_factory)
 
     with TestClient(app) as client:
+        set_refresh_cookie(client, refresh)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": refresh},
+            "/api/v1/auth/refresh"
         )
 
     assert res.status_code == 200, res.json()
@@ -372,9 +372,9 @@ async def test_refresh_rejects_session_older_than_per_org_lifetime(
     app = _make_app(session_factory)
 
     with TestClient(app) as client:
+        set_refresh_cookie(client, expired)
         res = client.post(
-            "/api/v1/auth/refresh",
-            cookies={"refresh_token": expired},
+            "/api/v1/auth/refresh"
         )
 
     assert res.status_code == 401, res.json()

--- a/backend/tests/services/test_rate_limit_overrides_service.py
+++ b/backend/tests/services/test_rate_limit_overrides_service.py
@@ -13,7 +13,7 @@ Covers the architect-locked invariants:
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytest_asyncio
@@ -228,7 +228,7 @@ async def test_resolve_falls_through_to_org(session_factory, fake_redis):
 @pytest.mark.asyncio
 async def test_resolve_ignores_expired_row(session_factory, fake_redis):
     org_id, _ = await _seed_org_user(session_factory)
-    past = datetime.utcnow() - timedelta(hours=1)
+    past = datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=1)
     async with session_factory() as db:
         await svc.create_override(
             db,
@@ -254,7 +254,7 @@ async def test_resolve_ignores_expired_row(session_factory, fake_redis):
 @pytest.mark.asyncio
 async def test_resolve_honours_future_expiry(session_factory, fake_redis):
     org_id, _ = await _seed_org_user(session_factory)
-    future = datetime.utcnow() + timedelta(hours=1)
+    future = datetime.now(UTC).replace(tzinfo=None) + timedelta(hours=1)
     async with session_factory() as db:
         await svc.create_override(
             db,

--- a/backend/tests/test_account_balance_adjustment.py
+++ b/backend/tests/test_account_balance_adjustment.py
@@ -494,7 +494,7 @@ async def test_malformed_json_as_non_admin_returns_403_not_422(session_factory, 
     with TestClient(app) as client:
         res = client.post(
             f"/api/v1/accounts/{seeded['account_id']}/adjust-balance",
-            data=b"not json",
+            content=b"not json",
             headers={"content-type": "application/json"},
         )
     assert res.status_code == 403
@@ -521,7 +521,7 @@ async def test_malformed_json_with_full_permissions_returns_422(session_factory,
     with TestClient(app) as client:
         res = client.post(
             f"/api/v1/accounts/{seeded['account_id']}/adjust-balance",
-            data=b"not json",
+            content=b"not json",
             headers={"content-type": "application/json"},
         )
     assert res.status_code == 422

--- a/backend/tests/test_backfill_subscriptions_migration.py
+++ b/backend/tests/test_backfill_subscriptions_migration.py
@@ -18,11 +18,24 @@ itself only relies on standard SQL.
 """
 from __future__ import annotations
 
+import datetime
 import importlib.util
 import pathlib
+import sqlite3
 
 import pytest
 import sqlalchemy as sa
+
+
+# Python 3.12 deprecated sqlite3's built-in date/datetime adapters. The
+# migration under test binds ``datetime.date`` / ``datetime.datetime``
+# objects (trial_start, trial_end, created_at, updated_at), which would
+# otherwise trip the default-adapter DeprecationWarning. Register the
+# explicit ISO-8601 adapters the 3.12 docs recommend so the stored values
+# stay byte-for-byte identical (ISO strings the tests parse back via
+# ``date.fromisoformat``).
+sqlite3.register_adapter(datetime.date, lambda d: d.isoformat())
+sqlite3.register_adapter(datetime.datetime, lambda d: d.isoformat())
 
 
 _MIGRATION_PATH = (


### PR DESCRIPTION
## What

Test-only sweep eliminating 4 classes of Python deprecation warnings from the backend suite. No runtime/behavior change — only `backend/tests/`.

Full-suite warnings: **167 → 81** (all 4 targeted classes → 0; the remaining 81 are out-of-scope `ResourceWarning`/unraisable from unclosed aiomysql sockets).

## Classes fixed
- **Per-request `cookies=`** (~85, 10 files) — Starlette/httpx deprecate per-request cookie persistence. Replaced with a small `set_refresh_cookie(client, token)` conftest helper that `delete`s then `set`s on the client jar, so exactly the intended `refresh_token` is sent (no `CookieConflict` from a server-rotated cookie). This also makes the refresh-token grace/replay tests deterministic regardless of httpx's per-request cookie-merge behavior.
- **`datetime.utcnow()`** (3, 2 files) → `datetime.now(UTC).replace(tzinfo=None)` to preserve the existing naive-UTC value the production service uses.
- **httpx `data=` raw bytes** (2, 1 file) → `content=`; same 403/422 assertions.
- **sqlite3 default date adapter** (40, 1 file) → module-level `register_adapter` emitting ISO-8601, stored values unchanged.

15 files changed (14 tests + `tests/conftest.py`).