### PR TITLE
feat(seo): llms.txt, welcome AI crawlers, docs structured data

### DIFF
--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -28,7 +28,11 @@ export const metadata: Metadata = {
 // graph links: this doc resolves to the one canonical Organization
 // node. URLs point at the apex (the canonical home for shared pages).
 // We omit author / datePublished — there is no truthful value for them.
+// isPartOf points at the WebSite node (schema.org expects a CreativeWork
+// there, not the Organization); publisher stays the Organization. Both
+// @ids match the landing page's nodes so the graph resolves to one site.
 const orgId = `${apexUrl}/#organization`;
+const websiteId = `${apexUrl}/#website`;
 
 const techArticleLd = {
   "@context": "https://schema.org",
@@ -37,7 +41,7 @@ const techArticleLd = {
   description,
   url: apexCanonical("/docs"),
   inLanguage: "en",
-  isPartOf: { "@id": orgId },
+  isPartOf: { "@id": websiteId },
   publisher: { "@id": orgId },
 };
 

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import ThemeToggle from "@/components/ui/ThemeToggle";
 import BackLink from "@/components/ui/BackLink";
-import { apexCanonical, pageSocialMeta, siteName } from "@/lib/site";
+import { readNonce } from "@/lib/nonce";
+import { apexCanonical, apexUrl, pageSocialMeta, siteName } from "@/lib/site";
 
 const description =
   "Rough user manual for The Better Decision: core concepts, common workflows, and admin tasks.";
@@ -21,6 +22,45 @@ export const metadata: Metadata = {
   }),
   robots: { index: true, follow: true },
 };
+
+// Structured data for rich results + AI-engine entity resolution.
+// Reuse the SAME Organization @id the landing page declares so the
+// graph links: this doc resolves to the one canonical Organization
+// node. URLs point at the apex (the canonical home for shared pages).
+// We omit author / datePublished — there is no truthful value for them.
+const orgId = `${apexUrl}/#organization`;
+
+const techArticleLd = {
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  headline: "The Better Decision docs",
+  description,
+  url: apexCanonical("/docs"),
+  inLanguage: "en",
+  isPartOf: { "@id": orgId },
+  publisher: { "@id": orgId },
+};
+
+const breadcrumbLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: apexCanonical("/"),
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Docs",
+      item: apexCanonical("/docs"),
+    },
+  ],
+};
+
+const structuredData = [techArticleLd, breadcrumbLd];
 
 const sections = [
   { id: "overview", label: "Overview" },
@@ -42,9 +82,25 @@ const sections = [
   { id: "whats-next", label: "What's next" },
 ];
 
-export default function DocsPage() {
+export default async function DocsPage() {
+  // Per-request CSP nonce so the JSON-LD inline scripts pass the strict
+  // prod CSP. readNonce() returns "" on the apex static export (no
+  // request context), so we conditionally spread the prop — same pattern
+  // app/page.tsx uses.
+  const nonce = await readNonce();
+  const nonceProp = nonce ? { nonce } : {};
   return (
     <div className="relative min-h-screen px-4 py-12">
+      {structuredData.map((block) => (
+        <script
+          key={block["@type"]}
+          type="application/ld+json"
+          {...nonceProp}
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(block).replace(/<\/script>/gi, "<\\/script>"),
+          }}
+        />
+      ))}
       <ThemeToggle className="absolute right-6 top-6" />
       <article className="mx-auto max-w-2xl">
         <header className="mb-10">

--- a/frontend/app/docs/plans/page.tsx
+++ b/frontend/app/docs/plans/page.tsx
@@ -27,7 +27,11 @@ export const metadata: Metadata = {
 // Reuse the SAME Organization @id the landing page declares so the
 // graph links to the one canonical Organization node. URLs point at
 // the apex. We omit author / datePublished — no truthful value exists.
+// isPartOf points at the WebSite node (schema.org expects a CreativeWork,
+// not the Organization); publisher stays the Organization. Both @ids
+// match the landing page's nodes so the graph resolves to one site.
 const orgId = `${apexUrl}/#organization`;
+const websiteId = `${apexUrl}/#website`;
 
 const techArticleLd = {
   "@context": "https://schema.org",
@@ -36,7 +40,7 @@ const techArticleLd = {
   description,
   url: apexCanonical("/docs/plans"),
   inLanguage: "en",
-  isPartOf: { "@id": orgId },
+  isPartOf: { "@id": websiteId },
   publisher: { "@id": orgId },
 };
 

--- a/frontend/app/docs/plans/page.tsx
+++ b/frontend/app/docs/plans/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import ThemeToggle from "@/components/ui/ThemeToggle";
 import BackLink from "@/components/ui/BackLink";
-import { apexCanonical, pageSocialMeta, siteName } from "@/lib/site";
+import { readNonce } from "@/lib/nonce";
+import { apexCanonical, apexUrl, pageSocialMeta, siteName } from "@/lib/site";
 
 const description =
   "How the Plans simulation sandbox works: plan types, verdict colors, the math, and the contribution curve.";
@@ -22,6 +23,50 @@ export const metadata: Metadata = {
   robots: { index: true, follow: true },
 };
 
+// Structured data for rich results + AI-engine entity resolution.
+// Reuse the SAME Organization @id the landing page declares so the
+// graph links to the one canonical Organization node. URLs point at
+// the apex. We omit author / datePublished — no truthful value exists.
+const orgId = `${apexUrl}/#organization`;
+
+const techArticleLd = {
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  headline: "Plans guide",
+  description,
+  url: apexCanonical("/docs/plans"),
+  inLanguage: "en",
+  isPartOf: { "@id": orgId },
+  publisher: { "@id": orgId },
+};
+
+const breadcrumbLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: apexCanonical("/"),
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Docs",
+      item: apexCanonical("/docs"),
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: "Plans",
+      item: apexCanonical("/docs/plans"),
+    },
+  ],
+};
+
+const structuredData = [techArticleLd, breadcrumbLd];
+
 const sections = [
   { id: "what-is-plans", label: "What is Plans?" },
   { id: "verdict-colors", label: "The verdict colors" },
@@ -30,9 +75,24 @@ const sections = [
   { id: "curve", label: "The contribution curve" },
 ];
 
-export default function PlansDocsPage() {
+export default async function PlansDocsPage() {
+  // Per-request CSP nonce so the JSON-LD inline scripts pass the strict
+  // prod CSP. readNonce() returns "" on the apex static export (no
+  // request context); conditionally spread the prop, same as app/page.tsx.
+  const nonce = await readNonce();
+  const nonceProp = nonce ? { nonce } : {};
   return (
     <div className="relative min-h-screen px-4 py-12">
+      {structuredData.map((block) => (
+        <script
+          key={block["@type"]}
+          type="application/ld+json"
+          {...nonceProp}
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(block).replace(/<\/script>/gi, "<\\/script>"),
+          }}
+        />
+      ))}
       <ThemeToggle className="absolute right-6 top-6" />
       <article className="mx-auto max-w-2xl">
         <header className="mb-10">

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -1,0 +1,16 @@
+# The Better Decision
+
+> The Better Decision is a personal finance app for households and individuals. Know your current balances, plan ahead for what's coming, and track where your money goes, without spreadsheet fatigue.
+
+The Better Decision tracks accounts, transactions, budgets, and forecasts, all scoped to your organization. Categories are the backbone: budgets and forecasts ride on top of them, and most reporting is grouped by category. The app is pre-launch and free while in beta.
+
+## Docs
+
+- [Docs (user manual)](https://thebetterdecision.com/docs/): Core concepts, common workflows, and admin tasks. Covers accounts, transactions, transfers, recurring templates, categories, budgets, and forecasts.
+- [Plans guide](https://thebetterdecision.com/docs/plans/): How the Plans simulation sandbox works. Model a trip, a purchase, retirement, or a custom life event without touching real transactions.
+
+## Pages
+
+- [Home](https://thebetterdecision.com/): Product overview, how it works, and frequently asked questions.
+- [Privacy](https://thebetterdecision.com/privacy/): How personal and financial data is handled.
+- [Terms](https://thebetterdecision.com/terms/): Terms of use.

--- a/frontend/scripts/build-apex.sh
+++ b/frontend/scripts/build-apex.sh
@@ -90,6 +90,11 @@ ALLOWED_OUTPUT_GLOBS=(
   # twitter:image by lib/site.ts. Copied verbatim from public/ into the
   # export; the dynamic /opengraph-image route is not exported here.
   "og.png"
+  # Static llms.txt (public/llms.txt) describing the product + key apex
+  # pages for AI crawlers / answer engines. Copied verbatim from public/
+  # into the export; must be on this allowlist or the post-build guard
+  # rejects it (same rule that applied to og.png).
+  "llms.txt"
   "__next.*.txt"
   # Reserved directory under public/ for future marketing screenshots
   # used by the landing surface. Next.js copies the whole public/ tree
@@ -248,7 +253,37 @@ APP_URL="${NEXT_PUBLIC_APP_URL:-https://app.thebetterdecision.com}"
 # robots.txt — allow indexing of the apex landing surface, point at the
 # apex sitemap (NOT the app sitemap; the app keeps its own at
 # app.thebetterdecision.com/sitemap.xml).
+#
+# The apex host serves ONLY public marketing + docs content, so we
+# explicitly welcome the major AI crawlers / answer engines (training
+# and live-retrieval bots) in addition to the catch-all. The app host
+# (app.thebetterdecision.com) stays auth-walled and keeps its own
+# noindex robots from app/robots.ts; do not loosen that one.
 cat > "${FRONTEND_DIR}/out-apex/robots.txt" <<EOF
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
 User-agent: *
 Allow: /
 

--- a/frontend/tests/app/docs-plans-page.test.tsx
+++ b/frontend/tests/app/docs-plans-page.test.tsx
@@ -20,9 +20,16 @@ vi.mock("@/components/ui/BackLink", () => ({
   default: () => null,
 }));
 
+// The docs pages are async Server Components that read the per-request
+// CSP nonce. next/headers is unavailable in Vitest; return "" so the
+// inline JSON-LD scripts render without a nonce attribute.
+vi.mock("@/lib/nonce", () => ({
+  readNonce: async () => "",
+}));
+
 describe("/docs/plans", () => {
-  it("renders the page heading and all five sections", () => {
-    render(<PlansDocsPage />);
+  it("renders the page heading and all five sections", async () => {
+    render(await PlansDocsPage());
     expect(
       screen.getByRole("heading", { name: /plans guide/i, level: 1 }),
     ).toBeInTheDocument();
@@ -33,8 +40,8 @@ describe("/docs/plans", () => {
     expect(screen.getByTestId("plans-docs-section-curve")).toBeInTheDocument();
   });
 
-  it("includes the contribution curve worked example", () => {
-    render(<PlansDocsPage />);
+  it("includes the contribution curve worked example", async () => {
+    render(await PlansDocsPage());
     // The math example mentions specific figures that the product
     // owner approved in the spec; pin them so they don't drift.
     const curveSection = screen.getByTestId("plans-docs-section-curve");
@@ -44,8 +51,8 @@ describe("/docs/plans", () => {
     expect(curveSection.textContent).toMatch(/1,200/);
   });
 
-  it("explains the verdict colors", () => {
-    render(<PlansDocsPage />);
+  it("explains the verdict colors", async () => {
+    render(await PlansDocsPage());
     const section = screen.getByTestId("plans-docs-section-verdict");
     expect(section.textContent).toMatch(/green/i);
     expect(section.textContent).toMatch(/yellow/i);
@@ -53,14 +60,14 @@ describe("/docs/plans", () => {
     expect(section.textContent).toMatch(/80 percent/i);
   });
 
-  it("explains the smoothed-with-regression option in the math section", () => {
-    render(<PlansDocsPage />);
+  it("explains the smoothed-with-regression option in the math section", async () => {
+    render(await PlansDocsPage());
     const section = screen.getByTestId("plans-docs-section-math");
     expect(section.textContent).toMatch(/regression/i);
   });
 
-  it("links back to the Plans page and the docs home from the footer", () => {
-    render(<PlansDocsPage />);
+  it("links back to the Plans page and the docs home from the footer", async () => {
+    render(await PlansDocsPage());
     const plansLink = screen.getByRole("link", { name: /^plans$/i });
     expect(plansLink).toHaveAttribute("href", "/plans");
     const docsHome = screen.getByRole("link", { name: /docs home/i });
@@ -69,9 +76,60 @@ describe("/docs/plans", () => {
 });
 
 describe("/docs has a link to /docs/plans", () => {
-  it("renders the Plans guide link in core concepts", () => {
-    render(<DocsPage />);
+  it("renders the Plans guide link in core concepts", async () => {
+    render(await DocsPage());
     const link = screen.getByTestId("docs-plans-link");
     expect(link).toHaveAttribute("href", "/docs/plans");
+  });
+});
+
+describe("docs structured data (JSON-LD)", () => {
+  function parseLd(container: HTMLElement) {
+    return Array.from(
+      container.querySelectorAll('script[type="application/ld+json"]'),
+    ).map((s) => JSON.parse(s.textContent ?? "{}"));
+  }
+
+  // Same Organization @id the landing page declares, so the docs entities
+  // link into the one canonical Organization node.
+  const orgId = "https://thebetterdecision.com/#organization";
+
+  it("/docs emits a TechArticle + BreadcrumbList linked to the Organization @id", async () => {
+    const { container } = render(await DocsPage());
+    const blocks = parseLd(container);
+    const types = blocks.map((b) => b["@type"]);
+    expect(types).toContain("TechArticle");
+    expect(types).toContain("BreadcrumbList");
+
+    const article = blocks.find((b) => b["@type"] === "TechArticle");
+    expect(article.url).toBe("https://thebetterdecision.com/docs/");
+    expect(article.inLanguage).toBe("en");
+    expect(article.isPartOf).toEqual({ "@id": orgId });
+    expect(article.publisher).toEqual({ "@id": orgId });
+    // No fabricated authorship fields.
+    expect(article.author).toBeUndefined();
+    expect(article.datePublished).toBeUndefined();
+
+    const crumb = blocks.find((b) => b["@type"] === "BreadcrumbList");
+    expect(crumb.itemListElement.map((i: { name: string }) => i.name)).toEqual([
+      "Home",
+      "Docs",
+    ]);
+  });
+
+  it("/docs/plans emits a TechArticle + 3-level BreadcrumbList", async () => {
+    const { container } = render(await PlansDocsPage());
+    const blocks = parseLd(container);
+    const article = blocks.find((b) => b["@type"] === "TechArticle");
+    expect(article.url).toBe("https://thebetterdecision.com/docs/plans/");
+    expect(article.isPartOf).toEqual({ "@id": orgId });
+    expect(article.publisher).toEqual({ "@id": orgId });
+
+    const crumb = blocks.find((b) => b["@type"] === "BreadcrumbList");
+    expect(crumb.itemListElement.map((i: { name: string }) => i.name)).toEqual([
+      "Home",
+      "Docs",
+      "Plans",
+    ]);
   });
 });

--- a/frontend/tests/app/docs-plans-page.test.tsx
+++ b/frontend/tests/app/docs-plans-page.test.tsx
@@ -90,9 +90,11 @@ describe("docs structured data (JSON-LD)", () => {
     ).map((s) => JSON.parse(s.textContent ?? "{}"));
   }
 
-  // Same Organization @id the landing page declares, so the docs entities
-  // link into the one canonical Organization node.
+  // Same node @ids the landing page declares, so the docs entities link
+  // into the one canonical site graph. isPartOf → WebSite (a CreativeWork,
+  // per schema.org); publisher → Organization.
   const orgId = "https://thebetterdecision.com/#organization";
+  const websiteId = "https://thebetterdecision.com/#website";
 
   it("/docs emits a TechArticle + BreadcrumbList linked to the Organization @id", async () => {
     const { container } = render(await DocsPage());
@@ -104,7 +106,7 @@ describe("docs structured data (JSON-LD)", () => {
     const article = blocks.find((b) => b["@type"] === "TechArticle");
     expect(article.url).toBe("https://thebetterdecision.com/docs/");
     expect(article.inLanguage).toBe("en");
-    expect(article.isPartOf).toEqual({ "@id": orgId });
+    expect(article.isPartOf).toEqual({ "@id": websiteId });
     expect(article.publisher).toEqual({ "@id": orgId });
     // No fabricated authorship fields.
     expect(article.author).toBeUndefined();
@@ -122,7 +124,7 @@ describe("docs structured data (JSON-LD)", () => {
     const blocks = parseLd(container);
     const article = blocks.find((b) => b["@type"] === "TechArticle");
     expect(article.url).toBe("https://thebetterdecision.com/docs/plans/");
-    expect(article.isPartOf).toEqual({ "@id": orgId });
+    expect(article.isPartOf).toEqual({ "@id": websiteId });
     expect(article.publisher).toEqual({ "@id": orgId });
 
     const crumb = blocks.find((b) => b["@type"] === "BreadcrumbList");

--- a/frontend/tests/build-apex.test.ts
+++ b/frontend/tests/build-apex.test.ts
@@ -119,9 +119,35 @@ describe("apex build target — scripts/build-apex.sh", () => {
       // Static social-share image copied from public/og.png. Must be on
       // the output allowlist or the post-build guard rejects it.
       "og.png",
+      // Static llms.txt copied from public/llms.txt. Must be on the
+      // output allowlist or the post-build guard rejects it.
+      "llms.txt",
     ]) {
       expect(script).toContain(`"${allowed}"`);
     }
+  });
+
+  it("welcomes the major AI crawlers in the apex robots.txt", () => {
+    // The apex hosts only public marketing + docs content, so the
+    // generated robots.txt explicitly allows the major training /
+    // live-retrieval bots in addition to the catch-all User-agent: *.
+    for (const bot of [
+      "GPTBot",
+      "ChatGPT-User",
+      "OAI-SearchBot",
+      "ClaudeBot",
+      "Claude-Web",
+      "anthropic-ai",
+      "PerplexityBot",
+      "Google-Extended",
+    ]) {
+      expect(script, `expected AI crawler group: ${bot}`).toContain(
+        `User-agent: ${bot}`,
+      );
+    }
+    // The catch-all + sitemap pointer must survive.
+    expect(script).toContain("User-agent: *");
+    expect(script).toMatch(/Sitemap: \$\{APEX_URL\}\/sitemap\.xml/);
   });
 
   it("lists /docs/plans in the apex sitemap", () => {


### PR DESCRIPTION
## What
GEO/AEO frontier additions on top of the #380/#402 SEO foundation.

- **`public/llms.txt`** — standards-shaped site description for AI engines/answer bots; added to the apex `build-apex.sh` output allowlist so it ships on the static export.
- **AI-crawler robots rules (apex)** — explicit `Allow: /` for GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, Claude-Web, anthropic-ai, PerplexityBot, Google-Extended (welcome-all stance; apex is marketing-only). App host robots unchanged (stays auth-walled/noindex).
- **Docs structured data** — `TechArticle` + `BreadcrumbList` JSON-LD on `/docs` and `/docs/plans`, reusing the landing page's Organization `@id` so the entity graph links to one node. Same per-request nonce pattern as the landing JSON-LD; no fabricated author/rating. FAQPage intentionally skipped (no genuine Q&A sections).

Verified: tsc clean, design-tokens pass, docs/jsonld/seo tests green, build-apex.test.ts green (throwaway scripts-mounted container).