### PR TITLE
test(frontend): shared SWR test harness (renderWithSWR)

### DIFF
--- a/frontend/tests/app/forecast-plans-page.test.tsx
+++ b/frontend/tests/app/forecast-plans-page.test.tsx
@@ -1,6 +1,11 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import {
+  renderWithSWR,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "../utils/render-with-swr";
 
 import ForecastPlansClient from "@/app/forecast-plans/ForecastPlansClient";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -167,14 +172,12 @@ function renderClient(plan: ForecastPlan | null) {
   // Each render gets a fresh SWR cache so state doesn't leak between
   // tests (the default cache is module-scoped and would let an earlier
   // empty-plan test paint stale data into a later with-items test).
-  return render(
-    <SWRConfig value={{ provider: () => new Map() }}>
-      <ForecastPlansClient
-        initialPeriods={[PERIOD]}
-        initialCategories={CATEGORIES}
-        initialPlan={plan}
-      />
-    </SWRConfig>,
+  return renderWithSWR(
+    <ForecastPlansClient
+      initialPeriods={[PERIOD]}
+      initialCategories={CATEGORIES}
+      initialPlan={plan}
+    />,
   );
 }
 
@@ -1010,14 +1013,12 @@ describe("ForecastPlansClient — dropdown + refresh", () => {
       },
     );
 
-    render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <ForecastPlansClient
-          initialPeriods={initialPeriods}
-          initialCategories={CATEGORIES}
-          initialPlan={planForCurrent}
-        />
-      </SWRConfig>,
+    renderWithSWR(
+      <ForecastPlansClient
+        initialPeriods={initialPeriods}
+        initialCategories={CATEGORIES}
+        initialPlan={planForCurrent}
+      />,
     );
 
     // Wait for ensure-future + the periods re-fetch to settle. The

--- a/frontend/tests/app/import-page.test.tsx
+++ b/frontend/tests/app/import-page.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR } from "../utils/render-with-swr";
 
 import ImportPage from "@/app/import/page";
 import { apiFetch } from "@/lib/api";
@@ -560,11 +560,7 @@ describe("ImportPage transfer pill column", () => {
       return Promise.resolve(undefined);
     }) as never);
 
-    render(
-      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-        <ImportPage />
-      </SWRConfig>,
-    );
+    renderWithSWR(<ImportPage />);
     const uploadButton = await screen.findByRole("button", {
       name: /upload & preview/i,
     });
@@ -605,11 +601,7 @@ describe("ImportPage transfer pill column", () => {
       return Promise.resolve(undefined);
     }) as never);
 
-    render(
-      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-        <ImportPage />
-      </SWRConfig>,
-    );
+    renderWithSWR(<ImportPage />);
     const uploadButton = await screen.findByRole("button", {
       name: /upload & preview/i,
     });
@@ -736,11 +728,7 @@ describe("ImportPage transfer pill column", () => {
       return Promise.resolve(undefined);
     }) as never);
 
-    render(
-      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-        <ImportPage />
-      </SWRConfig>,
-    );
+    renderWithSWR(<ImportPage />);
     const uploadButton = await screen.findByRole("button", {
       name: /upload & preview/i,
     });
@@ -806,11 +794,7 @@ describe("ImportPage transfer pill column", () => {
       return Promise.resolve(undefined);
     }) as never);
 
-    render(
-      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-        <ImportPage />
-      </SWRConfig>,
-    );
+    renderWithSWR(<ImportPage />);
     const uploadButton = await screen.findByRole("button", {
       name: /upload & preview/i,
     });

--- a/frontend/tests/app/reconcile-page.test.tsx
+++ b/frontend/tests/app/reconcile-page.test.tsx
@@ -1,6 +1,10 @@
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import {
+  renderWithSWR,
+  screen,
+  fireEvent,
+  waitFor,
+} from "../utils/render-with-swr";
 
 import ReconcileClient from "@/app/import/[import_id]/reconcile/ReconcileClient";
 import { apiFetch } from "@/lib/api";
@@ -12,11 +16,7 @@ import type { ImportBatchDetail } from "@/lib/types";
 function renderClient(
   props: React.ComponentProps<typeof ReconcileClient>,
 ) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      <ReconcileClient {...props} />
-    </SWRConfig>,
-  );
+  return renderWithSWR(<ReconcileClient {...props} />);
 }
 
 vi.mock("@/components/AppShell", () => ({

--- a/frontend/tests/app/reports-editor-page.test.tsx
+++ b/frontend/tests/app/reports-editor-page.test.tsx
@@ -1,5 +1,10 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import {
+  renderWithSWR,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "../utils/render-with-swr";
 
 // Stub the canvas (react-grid-layout) — jsdom can't measure container
 // width so the responsive grid silently collapses to width=-1 and
@@ -126,14 +131,6 @@ function makeParams(id = "10") {
   return { id };
 }
 
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
-
 describe("ReportEditorPage", () => {
   const getReportMock = vi.mocked(reportsApi.getReport);
   const saveLayoutMock = vi.mocked(reportsApi.saveLayout);
@@ -181,7 +178,7 @@ describe("ReportEditorPage", () => {
       updated_at: "2026-05-22T10:00:00",
     });
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("report-editor");
     // The editor renders inside AppShell so users keep the
@@ -224,7 +221,7 @@ describe("ReportEditorPage", () => {
       updated_at: "2026-05-22T10:00:00",
     });
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("report-editor");
     fireEvent.click(screen.getByTestId("report-editor-add-widget"));
@@ -270,7 +267,7 @@ describe("ReportEditorPage", () => {
       updated_at: "2026-05-22T10:00:01",
     });
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("report-editor");
     // Make the report dirty by adding a widget.
@@ -329,7 +326,7 @@ describe("ReportEditorPage", () => {
       updated_at: "2026-05-22T10:00:00",
     });
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await waitFor(() => expect(runQueryMock).toHaveBeenCalled());
     const lastCall = runQueryMock.mock.calls[runQueryMock.mock.calls.length - 1];
@@ -379,7 +376,7 @@ describe("ReportEditorPage", () => {
       updated_at: "2026-05-22T10:00:00",
     });
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     // Report has widgets → opens in view mode. Enter edit mode so the
     // config rail can mount on widget selection.
@@ -414,7 +411,7 @@ describe("ReportEditorPage", () => {
     });
     deleteReportMock.mockResolvedValue(undefined);
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("report-editor");
     fireEvent.click(screen.getByTestId("report-editor-delete"));
@@ -443,7 +440,7 @@ describe("ReportEditorPage", () => {
       updated_at: "2026-05-22T10:00:00",
     });
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("report-editor");
     // Make a dirty change.
@@ -507,7 +504,7 @@ describe("ReportEditorPage", () => {
     mockUser(true);
     getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("kpi-widget");
     // View-mode toolbar.
@@ -526,7 +523,7 @@ describe("ReportEditorPage", () => {
     mockUser(true);
     getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("kpi-widget");
     fireEvent.click(screen.getByTestId("report-editor-toggle-edit"));
@@ -556,7 +553,7 @@ describe("ReportEditorPage", () => {
     mockUser(true);
     getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("kpi-widget");
     // Enter edit.
@@ -592,7 +589,7 @@ describe("ReportEditorPage", () => {
       updated_at: "2026-05-22T10:00:00",
     });
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("report-editor");
     // Edit mode: Add widget present, toggle reads "Done".
@@ -624,7 +621,7 @@ describe("ReportEditorPage", () => {
       updated_at: "2026-05-22T10:00:05",
     });
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("kpi-widget");
     fireEvent.click(screen.getByTestId("report-editor-history"));
@@ -669,7 +666,7 @@ describe("ReportEditorPage", () => {
       updated_at: "2026-05-22T11:00:00",
     } as never);
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("kpi-widget");
     const toggle = screen.getByTestId("report-editor-visibility-toggle");
@@ -701,7 +698,7 @@ describe("ReportEditorPage", () => {
       visibility: "org",
     } as never);
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("kpi-widget");
     // No enabled toggle for a non-editor.
@@ -719,7 +716,7 @@ describe("ReportEditorPage", () => {
       visibility: "org",
     } as never);
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("kpi-widget");
     // The Edit/Done toggle is owner-only.
@@ -742,7 +739,7 @@ describe("ReportEditorPage", () => {
       updated_at: "2026-05-22T10:00:00",
     } as never);
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("report-editor-empty");
     // Owner-only CTA must not render for a view-only user; the backend
@@ -764,7 +761,7 @@ describe("ReportEditorPage", () => {
       id: 77,
     } as never);
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("kpi-widget");
     fireEvent.click(screen.getByTestId("report-editor-duplicate"));
@@ -806,7 +803,7 @@ describe("ReportEditorPage", () => {
       updated_at: "2026-05-22T10:00:01",
     });
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("report-editor");
     fireEvent.click(screen.getByTestId("report-editor-add-widget"));
@@ -858,7 +855,7 @@ describe("ReportEditorPage", () => {
       },
     } as never);
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("report-editor");
     // Read-only stack renders (NOT the grid Canvas).
@@ -914,7 +911,7 @@ describe("ReportEditorPage", () => {
       id: 10,
     } as never);
 
-    renderIsolated(<ReportEditorPage params={makeParams()} />);
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
 
     await waitFor(() =>
       expect(replaceMock).toHaveBeenCalledWith("/dashboard"),

--- a/frontend/tests/components/notifications/notification-bell.test.tsx
+++ b/frontend/tests/components/notifications/notification-bell.test.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import {
+  renderWithSWR,
   act,
   fireEvent,
-  render,
   screen,
   waitFor,
-} from "@testing-library/react";
-import { SWRConfig } from "swr";
+} from "../../utils/render-with-swr";
 
 // vitest.setup.ts mocks ``@/components/notifications/NotificationBell``
 // globally so AppShell-mounting page tests don't trip on the
@@ -51,15 +50,10 @@ function mkNotification(
 }
 
 function renderBell() {
-  return render(
-    // Disable de-duping cache so each test gets a clean slate of
-    // SWR state — without this, the in-memory cache from a prior
-    // test bleeds into the next render and the mocked apiFetch is
-    // never re-invoked.
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      <NotificationBell />
-    </SWRConfig>,
-  );
+  // renderWithSWR disables de-duping and hands a fresh cache to each
+  // test so SWR state from a prior render can't bleed into the next
+  // mount (which would stop the mocked apiFetch from being re-invoked).
+  return renderWithSWR(<NotificationBell />);
 }
 
 /**

--- a/frontend/tests/components/reports/config-rail-secondary-dimension.test.tsx
+++ b/frontend/tests/components/reports/config-rail-secondary-dimension.test.tsx
@@ -8,7 +8,6 @@
  * ``dimensions[0]``, so they expose no secondary picker.
  */
 import { renderWithSWR, fireEvent, screen } from "../../utils/render-with-swr";
-import { SWRConfig } from "swr";
 
 import ConfigRail from "@/components/reports/ConfigRail";
 import { apiFetch } from "@/lib/api";
@@ -221,14 +220,12 @@ describe("ConfigRail — secondary dimension picker visibility", () => {
     expect(afterSet.config.dimensions).toEqual(["category", "account"]);
 
     rerender(
-      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-        <ConfigRail
-          widget={afterSet}
-          canvasFilters={{}}
-          onUpdate={(w) => updates.push(w)}
-          onClose={() => {}}
-        />
-      </SWRConfig>,
+      <ConfigRail
+        widget={afterSet}
+        canvasFilters={{}}
+        onUpdate={(w) => updates.push(w)}
+        onClose={() => {}}
+      />,
     );
 
     fireEvent.change(screen.getByLabelText("Break down by"), {

--- a/frontend/tests/components/reports/config-rail-secondary-dimension.test.tsx
+++ b/frontend/tests/components/reports/config-rail-secondary-dimension.test.tsx
@@ -7,7 +7,7 @@
  * line / area / stacked-bar / kpi / pie / sparkline still only consume
  * ``dimensions[0]``, so they expose no secondary picker.
  */
-import { fireEvent, render, screen } from "@testing-library/react";
+import { renderWithSWR, fireEvent, screen } from "../../utils/render-with-swr";
 import { SWRConfig } from "swr";
 
 import ConfigRail from "@/components/reports/ConfigRail";
@@ -27,14 +27,6 @@ import type {
 vi.mock("@/lib/api", () => ({
   apiFetch: vi.fn(),
 }));
-
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
 
 beforeEach(() => {
   vi.mocked(apiFetch).mockReset();
@@ -166,7 +158,7 @@ const HIDDEN_CASES: Array<{ name: string; widget: Widget }> = [
 describe("ConfigRail — secondary dimension picker visibility", () => {
   for (const { name, widget } of HIDDEN_CASES) {
     it(`does NOT render the secondary dimension picker for ${name}`, () => {
-      renderIsolated(
+      renderWithSWR(
         <ConfigRail
           widget={widget}
           canvasFilters={{}}
@@ -181,7 +173,7 @@ describe("ConfigRail — secondary dimension picker visibility", () => {
   }
 
   it("DOES render the secondary dimension picker for table", () => {
-    renderIsolated(
+    renderWithSWR(
       <ConfigRail
         widget={makeTable()}
         canvasFilters={{}}
@@ -195,7 +187,7 @@ describe("ConfigRail — secondary dimension picker visibility", () => {
   });
 
   it("DOES render the 'Break down by' picker for bar", () => {
-    renderIsolated(
+    renderWithSWR(
       <ConfigRail
         widget={makeBar()}
         canvasFilters={{}}
@@ -213,7 +205,7 @@ describe("ConfigRail — secondary dimension picker visibility", () => {
   it("sets dimensions[1] when a bar break-down is chosen, and clears it on None", () => {
     const updates: Widget[] = [];
     const bar = makeBar();
-    const { rerender } = renderIsolated(
+    const { rerender } = renderWithSWR(
       <ConfigRail
         widget={bar}
         canvasFilters={{}}

--- a/frontend/tests/components/reports/config-rail-tooltips.test.tsx
+++ b/frontend/tests/components/reports/config-rail-tooltips.test.tsx
@@ -7,8 +7,7 @@
  * explainer. We assert the tooltip triggers render (by their ARIA
  * label from the content map) rather than driving the portal open.
  */
-import { fireEvent, render, screen } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR, fireEvent, screen } from "../../utils/render-with-swr";
 
 import ConfigRail from "@/components/reports/ConfigRail";
 import { apiFetch } from "@/lib/api";
@@ -18,14 +17,6 @@ import type { BarWidget, LineWidget } from "@/lib/reports/types";
 vi.mock("@/lib/api", () => ({
   apiFetch: vi.fn(),
 }));
-
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
 
 beforeEach(() => {
   vi.mocked(apiFetch).mockReset();
@@ -64,7 +55,7 @@ function makeLine(): LineWidget {
 
 describe("ConfigRail — help tooltips", () => {
   it("renders the aggregation tooltip trigger for a single-measure widget", () => {
-    renderIsolated(
+    renderWithSWR(
       <ConfigRail
         widget={makeBar()}
         canvasFilters={{}}
@@ -82,7 +73,7 @@ describe("ConfigRail — help tooltips", () => {
 
   it("swaps the aggregation tooltip to match the selected aggregation", () => {
     const updates: BarWidget[] = [];
-    renderIsolated(
+    renderWithSWR(
       <ConfigRail
         widget={makeBar()}
         canvasFilters={{}}
@@ -98,7 +89,7 @@ describe("ConfigRail — help tooltips", () => {
   });
 
   it("renders the master-category explainer next to the dimension label", () => {
-    renderIsolated(
+    renderWithSWR(
       <ConfigRail
         widget={makeBar()}
         canvasFilters={{}}
@@ -116,7 +107,7 @@ describe("ConfigRail — help tooltips", () => {
   });
 
   it("renders a per-series aggregation tooltip for multi-series widgets", () => {
-    renderIsolated(
+    renderWithSWR(
       <ConfigRail
         widget={makeLine()}
         canvasFilters={{}}

--- a/frontend/tests/components/reports/filters/account-filter.test.tsx
+++ b/frontend/tests/components/reports/filters/account-filter.test.tsx
@@ -1,5 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR, fireEvent, screen, waitFor } from "../../../utils/render-with-swr";
 
 import AccountFilter from "@/components/reports/filters/AccountFilter";
 import { apiFetch } from "@/lib/api";
@@ -35,14 +34,6 @@ const ACCOUNTS = [
   },
 ];
 
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
-
 describe("AccountFilter", () => {
   const apiFetchMock = vi.mocked(apiFetch);
 
@@ -53,7 +44,7 @@ describe("AccountFilter", () => {
   it("fetches accounts on mount and renders one chip per account", async () => {
     apiFetchMock.mockResolvedValueOnce(ACCOUNTS);
 
-    renderIsolated(<AccountFilter value={[]} onChange={() => {}} />);
+    renderWithSWR(<AccountFilter value={[]} onChange={() => {}} />);
 
     expect(await screen.findByTestId("account-filter-chip-1")).toBeInTheDocument();
     expect(screen.getByTestId("account-filter-chip-2")).toBeInTheDocument();
@@ -64,7 +55,7 @@ describe("AccountFilter", () => {
     apiFetchMock.mockResolvedValueOnce(ACCOUNTS);
     const onChange = vi.fn();
 
-    renderIsolated(<AccountFilter value={[]} onChange={onChange} />);
+    renderWithSWR(<AccountFilter value={[]} onChange={onChange} />);
 
     const chip = await screen.findByTestId("account-filter-chip-1");
     fireEvent.click(chip);
@@ -75,7 +66,7 @@ describe("AccountFilter", () => {
     apiFetchMock.mockResolvedValueOnce(ACCOUNTS);
     const onChange = vi.fn();
 
-    renderIsolated(<AccountFilter value={[1, 2]} onChange={onChange} />);
+    renderWithSWR(<AccountFilter value={[1, 2]} onChange={onChange} />);
 
     const chip = await screen.findByTestId("account-filter-chip-1");
     fireEvent.click(chip);
@@ -110,7 +101,7 @@ describe("AccountFilter", () => {
       },
     ]);
 
-    renderIsolated(<AccountFilter value={[]} onChange={() => {}} />);
+    renderWithSWR(<AccountFilter value={[]} onChange={() => {}} />);
 
     expect(await screen.findByTestId("account-filter-chip-10")).toBeInTheDocument();
     expect(screen.getByText("Checking")).toBeInTheDocument();
@@ -121,7 +112,7 @@ describe("AccountFilter", () => {
   it("renders an error state when the fetch fails", async () => {
     apiFetchMock.mockRejectedValueOnce(new Error("boom"));
 
-    renderIsolated(<AccountFilter value={[]} onChange={() => {}} />);
+    renderWithSWR(<AccountFilter value={[]} onChange={() => {}} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("account-filter-error")).toBeInTheDocument(),

--- a/frontend/tests/components/reports/filters/category-picker.test.tsx
+++ b/frontend/tests/components/reports/filters/category-picker.test.tsx
@@ -1,5 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR, fireEvent, screen, waitFor } from "../../../utils/render-with-swr";
 
 import CategoryPicker from "@/components/reports/filters/CategoryPicker";
 import { apiFetch } from "@/lib/api";
@@ -67,14 +66,6 @@ const CATEGORIES: Category[] = [
   },
 ];
 
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
-
 describe("CategoryPicker", () => {
   const apiFetchMock = vi.mocked(apiFetch);
 
@@ -85,7 +76,7 @@ describe("CategoryPicker", () => {
   it("fetches categories on mount and renders the master/sub tree", async () => {
     apiFetchMock.mockResolvedValueOnce(CATEGORIES);
 
-    renderIsolated(<CategoryPicker value={[]} onChange={() => {}} />);
+    renderWithSWR(<CategoryPicker value={[]} onChange={() => {}} />);
 
     expect(await screen.findByTestId("category-master-10")).toBeInTheDocument();
     expect(screen.getByTestId("category-master-20")).toBeInTheDocument();
@@ -98,7 +89,7 @@ describe("CategoryPicker", () => {
     apiFetchMock.mockResolvedValueOnce(CATEGORIES);
     const onChange = vi.fn();
 
-    renderIsolated(<CategoryPicker value={[]} onChange={onChange} />);
+    renderWithSWR(<CategoryPicker value={[]} onChange={onChange} />);
 
     const masterFood = await screen.findByTestId("category-master-10");
     fireEvent.click(masterFood);
@@ -111,7 +102,7 @@ describe("CategoryPicker", () => {
   it("leaves the master partial-checked when only one sub is unselected", async () => {
     apiFetchMock.mockResolvedValueOnce(CATEGORIES);
 
-    renderIsolated(
+    renderWithSWR(
       <CategoryPicker value={[10, 11]} onChange={() => {}} />,
     );
 
@@ -126,7 +117,7 @@ describe("CategoryPicker", () => {
   it("filters the tree by the search input", async () => {
     apiFetchMock.mockResolvedValueOnce(CATEGORIES);
 
-    renderIsolated(<CategoryPicker value={[]} onChange={() => {}} />);
+    renderWithSWR(<CategoryPicker value={[]} onChange={() => {}} />);
 
     await screen.findByTestId("category-master-10");
     fireEvent.change(screen.getByTestId("category-picker-search"), {
@@ -145,7 +136,7 @@ describe("CategoryPicker", () => {
   it("renders an error state when the fetch fails", async () => {
     apiFetchMock.mockRejectedValueOnce(new Error("boom"));
 
-    renderIsolated(<CategoryPicker value={[]} onChange={() => {}} />);
+    renderWithSWR(<CategoryPicker value={[]} onChange={() => {}} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("category-picker-error")).toBeInTheDocument(),

--- a/frontend/tests/components/reports/filters/tag-filter.test.tsx
+++ b/frontend/tests/components/reports/filters/tag-filter.test.tsx
@@ -1,5 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR, fireEvent, screen, waitFor } from "../../../utils/render-with-swr";
 
 import TagFilter from "@/components/reports/filters/TagFilter";
 import { apiFetch } from "@/lib/api";
@@ -13,14 +12,6 @@ const TAGS = [
   { id: 2, name: "essentials", name_normalized: "essentials", usage_count: 2 },
 ];
 
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
-
 describe("TagFilter", () => {
   const apiFetchMock = vi.mocked(apiFetch);
 
@@ -31,7 +22,7 @@ describe("TagFilter", () => {
   it("fetches tags on mount and renders chips", async () => {
     apiFetchMock.mockResolvedValueOnce(TAGS);
 
-    renderIsolated(
+    renderWithSWR(
       <TagFilter value={[]} match="all" onChange={() => {}} />,
     );
 
@@ -48,7 +39,7 @@ describe("TagFilter", () => {
     apiFetchMock.mockResolvedValueOnce(TAGS);
     const onChange = vi.fn();
 
-    renderIsolated(
+    renderWithSWR(
       <TagFilter value={[]} match="all" onChange={onChange} />,
     );
 
@@ -64,7 +55,7 @@ describe("TagFilter", () => {
     apiFetchMock.mockResolvedValueOnce(TAGS);
     const onChange = vi.fn();
 
-    renderIsolated(
+    renderWithSWR(
       <TagFilter
         value={["groceries", "essentials"]}
         match="all"
@@ -84,7 +75,7 @@ describe("TagFilter", () => {
     apiFetchMock.mockResolvedValueOnce(TAGS);
     const onChange = vi.fn();
 
-    renderIsolated(
+    renderWithSWR(
       <TagFilter
         value={["groceries"]}
         match="all"
@@ -103,7 +94,7 @@ describe("TagFilter", () => {
   it("renders an error state when the fetch fails", async () => {
     apiFetchMock.mockRejectedValueOnce(new Error("boom"));
 
-    renderIsolated(
+    renderWithSWR(
       <TagFilter value={[]} match="all" onChange={() => {}} />,
     );
 

--- a/frontend/tests/components/reports/override-pill-pickers.test.tsx
+++ b/frontend/tests/components/reports/override-pill-pickers.test.tsx
@@ -6,7 +6,7 @@
  * ``WidgetFilters`` shape — these tests pin the equality semantics
  * survive the swap.
  */
-import { fireEvent, render, screen } from "@testing-library/react";
+import { renderWithSWR, fireEvent, screen } from "../../utils/render-with-swr";
 import { SWRConfig } from "swr";
 
 import ConfigRail from "@/components/reports/ConfigRail";
@@ -58,14 +58,6 @@ const ACCOUNTS: Account[] = [
   },
 ];
 
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
-
 function makeWidget(filters: BarWidget["config"]["filters"] = undefined): BarWidget {
   return {
     id: "w_bar",
@@ -107,7 +99,7 @@ describe("Override pill — picker-based filters", () => {
   });
 
   it("does NOT show the pill when the widget category selection matches the canvas selection", async () => {
-    renderIsolated(
+    renderWithSWR(
       <ConfigRail
         widget={makeWidget({ category_ids: [1, 2] })}
         canvasFilters={{ category_ids: [2, 1] }}
@@ -127,7 +119,7 @@ describe("Override pill — picker-based filters", () => {
   });
 
   it("DOES show the pill when the widget category selection differs from the canvas", async () => {
-    renderIsolated(
+    renderWithSWR(
       <ConfigRail
         widget={makeWidget({ category_ids: [1] })}
         canvasFilters={{ category_ids: [2] }}
@@ -141,7 +133,7 @@ describe("Override pill — picker-based filters", () => {
   });
 
   it("does NOT show the pill when the widget account selection matches the canvas selection", async () => {
-    renderIsolated(
+    renderWithSWR(
       <ConfigRail
         widget={makeWidget({ account_ids: [1] })}
         canvasFilters={{ account_ids: [1] }}
@@ -156,7 +148,7 @@ describe("Override pill — picker-based filters", () => {
 
   it("DOES show the pill once the user toggles a different account chip", async () => {
     const onUpdate = vi.fn();
-    const { rerender } = renderIsolated(
+    const { rerender } = renderWithSWR(
       <ConfigRail
         widget={makeWidget({ account_ids: [1] })}
         canvasFilters={{ account_ids: [1] }}

--- a/frontend/tests/components/reports/override-pill-pickers.test.tsx
+++ b/frontend/tests/components/reports/override-pill-pickers.test.tsx
@@ -7,7 +7,6 @@
  * survive the swap.
  */
 import { renderWithSWR, fireEvent, screen } from "../../utils/render-with-swr";
-import { SWRConfig } from "swr";
 
 import ConfigRail from "@/components/reports/ConfigRail";
 import { apiFetch } from "@/lib/api";
@@ -164,14 +163,12 @@ describe("Override pill — picker-based filters", () => {
     // widget value, since picker click → onUpdate flows through the
     // parent in real use.
     rerender(
-      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-        <ConfigRail
-          widget={makeWidget({ account_ids: [] })}
-          canvasFilters={{ account_ids: [1] }}
-          onUpdate={onUpdate}
-          onClose={() => {}}
-        />
-      </SWRConfig>,
+      <ConfigRail
+        widget={makeWidget({ account_ids: [] })}
+        canvasFilters={{ account_ids: [1] }}
+        onUpdate={onUpdate}
+        onClose={() => {}}
+      />,
     );
     // Empty widget account_ids means inherit — pill stays off.
     expect(screen.queryAllByTestId("override-pill").length).toBe(0);

--- a/frontend/tests/components/reports/widgets/area-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/area-widget.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR, screen, waitFor } from "../../../utils/render-with-swr";
 
 import AreaWidget from "@/components/reports/widgets/AreaWidget";
 import type { AreaWidget as AreaWidgetType } from "@/lib/reports/types";
@@ -8,14 +7,6 @@ import { runQuery } from "@/lib/reports/api";
 vi.mock("@/lib/reports/api", () => ({
   runQuery: vi.fn(),
 }));
-
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
 
 function makeWidget(): AreaWidgetType {
   return {
@@ -48,7 +39,7 @@ describe("AreaWidget", () => {
       meta: { row_count: 1, truncated: false, query_ms: 2 },
     });
 
-    renderIsolated(<AreaWidget widget={makeWidget()} />);
+    renderWithSWR(<AreaWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.queryByTestId("area-widget-loading")).toBeNull(),
@@ -63,7 +54,7 @@ describe("AreaWidget", () => {
       meta: { row_count: 0, truncated: false, query_ms: 0 },
     });
 
-    renderIsolated(<AreaWidget widget={makeWidget()} />);
+    renderWithSWR(<AreaWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("area-widget-empty")).toBeInTheDocument(),
@@ -73,7 +64,7 @@ describe("AreaWidget", () => {
   it("renders an inline error when the query fails", async () => {
     runQueryMock.mockRejectedValueOnce(new Error("nope"));
 
-    renderIsolated(<AreaWidget widget={makeWidget()} />);
+    renderWithSWR(<AreaWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("area-widget-error")).toBeInTheDocument(),

--- a/frontend/tests/components/reports/widgets/bar-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/bar-widget.test.tsx
@@ -1,5 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR, fireEvent, screen, waitFor } from "../../../utils/render-with-swr";
 
 import BarWidget from "@/components/reports/widgets/BarWidget";
 import type { BarWidget as BarWidgetType } from "@/lib/reports/types";
@@ -22,14 +21,6 @@ vi.mock("@/lib/reports/csv", async (importOriginal) => {
 // chart body. We assert on the data-binding path (chart container
 // present, no error / empty state) and on the DOM legend the widget
 // renders itself (outside the SVG) when a break-down dimension is set.
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
-
 function makeWidget(
   overrides: Partial<BarWidgetType["config"]> = {},
 ): BarWidgetType {
@@ -68,7 +59,7 @@ describe("BarWidget", () => {
       meta: { row_count: 2, truncated: false, query_ms: 4 },
     });
 
-    renderIsolated(<BarWidget widget={makeWidget()} />);
+    renderWithSWR(<BarWidget widget={makeWidget()} />);
 
     await waitFor(() => {
       // Empty / loading states must NOT be shown when rows arrive.
@@ -87,7 +78,7 @@ describe("BarWidget", () => {
       meta: { row_count: 0, truncated: false, query_ms: 2 },
     });
 
-    renderIsolated(<BarWidget widget={makeWidget()} />);
+    renderWithSWR(<BarWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("bar-widget-empty")).toBeInTheDocument(),
@@ -97,7 +88,7 @@ describe("BarWidget", () => {
   it("renders an inline error when the query fails", async () => {
     runQueryMock.mockRejectedValueOnce(new Error("nope"));
 
-    renderIsolated(<BarWidget widget={makeWidget()} />);
+    renderWithSWR(<BarWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("bar-widget-error")).toBeInTheDocument(),
@@ -113,7 +104,7 @@ describe("BarWidget", () => {
       meta: { row_count: 2, truncated: false, query_ms: 4 },
     });
 
-    renderIsolated(<BarWidget widget={makeWidget()} />);
+    renderWithSWR(<BarWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.queryByTestId("bar-widget-loading")).toBeNull(),
@@ -133,7 +124,7 @@ describe("BarWidget", () => {
       meta: { row_count: 4, truncated: false, query_ms: 6 },
     });
 
-    renderIsolated(
+    renderWithSWR(
       <BarWidget widget={makeWidget({ dimensions: ["category", "account"] })} />,
     );
 
@@ -170,7 +161,7 @@ describe("BarWidget", () => {
       meta: { row_count: 2, truncated: false, query_ms: 4 },
     });
 
-    renderIsolated(<BarWidget widget={makeWidget()} />);
+    renderWithSWR(<BarWidget widget={makeWidget()} />);
 
     const exportBtn = await screen.findByTestId("widget-csv-export");
     expect(exportBtn).toBeInTheDocument();
@@ -194,7 +185,7 @@ describe("BarWidget", () => {
       meta: { row_count: 3, truncated: false, query_ms: 6 },
     });
 
-    renderIsolated(
+    renderWithSWR(
       <BarWidget widget={makeWidget({ dimensions: ["category", "account"] })} />,
     );
 
@@ -216,7 +207,7 @@ describe("BarWidget", () => {
       meta: { row_count: 1, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<BarWidget widget={makeWidget()} editMode />);
+    renderWithSWR(<BarWidget widget={makeWidget()} editMode />);
 
     await waitFor(() =>
       expect(screen.queryByTestId("bar-widget-loading")).toBeNull(),

--- a/frontend/tests/components/reports/widgets/kpi-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/kpi-widget.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR, screen, waitFor } from "../../../utils/render-with-swr";
 
 import KPIWidget from "@/components/reports/widgets/KPIWidget";
 import type { KPIWidget as KPIWidgetType } from "@/lib/reports/types";
@@ -11,14 +10,6 @@ vi.mock("@/lib/reports/api", () => ({
 
 // Fresh SWR provider per test prevents cache reuse from leaking
 // a previous test's resolved value into the next test's mount.
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
-
 function makeWidget(overrides: Partial<KPIWidgetType> = {}): KPIWidgetType {
   return {
     id: `w_kpi_${Math.random().toString(36).slice(2, 10)}`,
@@ -47,7 +38,7 @@ describe("KPIWidget", () => {
       meta: { row_count: 1, truncated: false, query_ms: 12 },
     });
 
-    renderIsolated(<KPIWidget widget={makeWidget()} />);
+    renderWithSWR(<KPIWidget widget={makeWidget()} />);
 
     const value = await screen.findByTestId("kpi-widget-value");
     // Currency formatting renders the symbol; assert the digits are
@@ -70,7 +61,7 @@ describe("KPIWidget", () => {
       meta: { row_count: 1, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<KPIWidget widget={widget} priorValue={100} />);
+    renderWithSWR(<KPIWidget widget={widget} priorValue={100} />);
 
     const delta = await screen.findByTestId("kpi-widget-delta");
     // 100 → 200 is a +100% change.
@@ -85,7 +76,7 @@ describe("KPIWidget", () => {
       meta: { row_count: 1, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<KPIWidget widget={makeWidget()} priorValue={100} />);
+    renderWithSWR(<KPIWidget widget={makeWidget()} priorValue={100} />);
 
     await screen.findByTestId("kpi-widget-value");
     expect(screen.queryByTestId("kpi-widget-delta")).toBeNull();
@@ -94,7 +85,7 @@ describe("KPIWidget", () => {
   it("renders an inline error when the query fails", async () => {
     runQueryMock.mockRejectedValueOnce(new Error("boom"));
 
-    renderIsolated(<KPIWidget widget={makeWidget()} />);
+    renderWithSWR(<KPIWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("kpi-widget-error")).toBeInTheDocument(),

--- a/frontend/tests/components/reports/widgets/line-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/line-widget.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR, screen, waitFor } from "../../../utils/render-with-swr";
 
 import LineWidget from "@/components/reports/widgets/LineWidget";
 import type { LineWidget as LineWidgetType } from "@/lib/reports/types";
@@ -8,14 +7,6 @@ import { runQuery } from "@/lib/reports/api";
 vi.mock("@/lib/reports/api", () => ({
   runQuery: vi.fn(),
 }));
-
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
 
 function makeWidget(overrides: Partial<LineWidgetType["config"]> = {}): LineWidgetType {
   return {
@@ -51,7 +42,7 @@ describe("LineWidget", () => {
       meta: { row_count: 2, truncated: false, query_ms: 5 },
     });
 
-    renderIsolated(<LineWidget widget={makeWidget()} />);
+    renderWithSWR(<LineWidget widget={makeWidget()} />);
 
     await waitFor(() => {
       expect(screen.queryByTestId("line-widget-empty")).toBeNull();
@@ -67,7 +58,7 @@ describe("LineWidget", () => {
       meta: { row_count: 0, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<LineWidget widget={makeWidget()} />);
+    renderWithSWR(<LineWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("line-widget-empty")).toBeInTheDocument(),
@@ -77,7 +68,7 @@ describe("LineWidget", () => {
   it("renders an inline error when the query fails", async () => {
     runQueryMock.mockRejectedValueOnce(new Error("boom"));
 
-    renderIsolated(<LineWidget widget={makeWidget()} />);
+    renderWithSWR(<LineWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("line-widget-error")).toBeInTheDocument(),
@@ -90,7 +81,7 @@ describe("LineWidget", () => {
       meta: { row_count: 1, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(
+    renderWithSWR(
       <LineWidget
         widget={makeWidget({
           measures: [

--- a/frontend/tests/components/reports/widgets/pie-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/pie-widget.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR, screen, waitFor } from "../../../utils/render-with-swr";
 
 import PieWidget from "@/components/reports/widgets/PieWidget";
 import type { PieWidget as PieWidgetType } from "@/lib/reports/types";
@@ -8,14 +7,6 @@ import { runQuery } from "@/lib/reports/api";
 vi.mock("@/lib/reports/api", () => ({
   runQuery: vi.fn(),
 }));
-
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
 
 function makeWidget(overrides: Partial<PieWidgetType["config"]> = {}): PieWidgetType {
   return {
@@ -52,7 +43,7 @@ describe("PieWidget", () => {
       meta: { row_count: 2, truncated: false, query_ms: 3 },
     });
 
-    renderIsolated(<PieWidget widget={makeWidget()} />);
+    renderWithSWR(<PieWidget widget={makeWidget()} />);
 
     await waitFor(() => {
       expect(screen.queryByTestId("pie-widget-empty")).toBeNull();
@@ -68,7 +59,7 @@ describe("PieWidget", () => {
       meta: { row_count: 0, truncated: false, query_ms: 0 },
     });
 
-    renderIsolated(<PieWidget widget={makeWidget()} />);
+    renderWithSWR(<PieWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("pie-widget-empty")).toBeInTheDocument(),
@@ -78,7 +69,7 @@ describe("PieWidget", () => {
   it("renders an inline error when the query fails", async () => {
     runQueryMock.mockRejectedValueOnce(new Error("nope"));
 
-    renderIsolated(<PieWidget widget={makeWidget()} />);
+    renderWithSWR(<PieWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("pie-widget-error")).toBeInTheDocument(),

--- a/frontend/tests/components/reports/widgets/sparkline-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/sparkline-widget.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR, screen, waitFor } from "../../../utils/render-with-swr";
 
 import SparklineWidget from "@/components/reports/widgets/SparklineWidget";
 import type { SparklineWidget as SparklineWidgetType } from "@/lib/reports/types";
@@ -8,14 +7,6 @@ import { runQuery } from "@/lib/reports/api";
 vi.mock("@/lib/reports/api", () => ({
   runQuery: vi.fn(),
 }));
-
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
 
 function makeWidget(): SparklineWidgetType {
   return {
@@ -50,7 +41,7 @@ describe("SparklineWidget", () => {
       meta: { row_count: 2, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<SparklineWidget widget={makeWidget()} />);
+    renderWithSWR(<SparklineWidget widget={makeWidget()} />);
 
     const value = await screen.findByTestId("sparkline-widget-value");
     // Last row was 220 -> headline shows it.
@@ -63,7 +54,7 @@ describe("SparklineWidget", () => {
       meta: { row_count: 0, truncated: false, query_ms: 0 },
     });
 
-    renderIsolated(<SparklineWidget widget={makeWidget()} />);
+    renderWithSWR(<SparklineWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("sparkline-widget-empty")).toBeInTheDocument(),
@@ -73,7 +64,7 @@ describe("SparklineWidget", () => {
   it("renders an inline error when the query fails", async () => {
     runQueryMock.mockRejectedValueOnce(new Error("nope"));
 
-    renderIsolated(<SparklineWidget widget={makeWidget()} />);
+    renderWithSWR(<SparklineWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("sparkline-widget-error")).toBeInTheDocument(),

--- a/frontend/tests/components/reports/widgets/stacked-bar-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/stacked-bar-widget.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR, screen, waitFor } from "../../../utils/render-with-swr";
 
 import StackedBarWidget from "@/components/reports/widgets/StackedBarWidget";
 import type { StackedBarWidget as StackedBarWidgetType } from "@/lib/reports/types";
@@ -8,14 +7,6 @@ import { runQuery } from "@/lib/reports/api";
 vi.mock("@/lib/reports/api", () => ({
   runQuery: vi.fn(),
 }));
-
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
 
 function makeWidget(overrides: Partial<StackedBarWidgetType["config"]> = {}): StackedBarWidgetType {
   return {
@@ -49,7 +40,7 @@ describe("StackedBarWidget", () => {
       meta: { row_count: 1, truncated: false, query_ms: 2 },
     });
 
-    renderIsolated(<StackedBarWidget widget={makeWidget()} />);
+    renderWithSWR(<StackedBarWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.queryByTestId("stacked-bar-widget-loading")).toBeNull(),
@@ -64,7 +55,7 @@ describe("StackedBarWidget", () => {
       meta: { row_count: 0, truncated: false, query_ms: 0 },
     });
 
-    renderIsolated(<StackedBarWidget widget={makeWidget()} />);
+    renderWithSWR(<StackedBarWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(
@@ -76,7 +67,7 @@ describe("StackedBarWidget", () => {
   it("renders an inline error when the query fails", async () => {
     runQueryMock.mockRejectedValueOnce(new Error("nope"));
 
-    renderIsolated(<StackedBarWidget widget={makeWidget()} />);
+    renderWithSWR(<StackedBarWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(
@@ -91,7 +82,7 @@ describe("StackedBarWidget", () => {
       meta: { row_count: 1, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(
+    renderWithSWR(
       <StackedBarWidget
         widget={makeWidget({
           measures: [

--- a/frontend/tests/components/reports/widgets/table-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/table-widget.test.tsx
@@ -1,5 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderWithSWR, fireEvent, screen, waitFor } from "../../../utils/render-with-swr";
 
 import TableWidget from "@/components/reports/widgets/TableWidget";
 import type { TableWidget as TableWidgetType } from "@/lib/reports/types";
@@ -14,14 +13,6 @@ vi.mock("@/lib/reports/csv", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/reports/csv")>();
   return { ...actual, downloadCsv: vi.fn() };
 });
-
-function renderIsolated(ui: React.ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui}
-    </SWRConfig>,
-  );
-}
 
 function makeWidget(overrides: Partial<TableWidgetType["config"]> = {}): TableWidgetType {
   return {
@@ -59,7 +50,7 @@ describe("TableWidget", () => {
       meta: { row_count: 2, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<TableWidget widget={makeWidget()} />);
+    renderWithSWR(<TableWidget widget={makeWidget()} />);
 
     expect(await screen.findByText("Food")).toBeInTheDocument();
     expect(screen.getByText("Transport")).toBeInTheDocument();
@@ -71,7 +62,7 @@ describe("TableWidget", () => {
       meta: { row_count: 0, truncated: false, query_ms: 0 },
     });
 
-    renderIsolated(<TableWidget widget={makeWidget()} />);
+    renderWithSWR(<TableWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("table-widget-empty")).toBeInTheDocument(),
@@ -81,7 +72,7 @@ describe("TableWidget", () => {
   it("renders an inline error when the query fails", async () => {
     runQueryMock.mockRejectedValueOnce(new Error("nope"));
 
-    renderIsolated(<TableWidget widget={makeWidget()} />);
+    renderWithSWR(<TableWidget widget={makeWidget()} />);
 
     await waitFor(() =>
       expect(screen.getByTestId("table-widget-error")).toBeInTheDocument(),
@@ -98,7 +89,7 @@ describe("TableWidget", () => {
       meta: { row_count: 3, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<TableWidget widget={makeWidget()} />);
+    renderWithSWR(<TableWidget widget={makeWidget()} />);
 
     await screen.findByText("Food");
     // First click on a fresh header => sortKey=category, dir=desc
@@ -130,7 +121,7 @@ describe("TableWidget", () => {
       meta: { row_count: 75, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<TableWidget widget={makeWidget()} />);
+    renderWithSWR(<TableWidget widget={makeWidget()} />);
 
     await screen.findByText("Cat 0");
     expect(
@@ -151,7 +142,7 @@ describe("TableWidget", () => {
       meta: { row_count: 3, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<TableWidget widget={makeWidget()} />);
+    renderWithSWR(<TableWidget widget={makeWidget()} />);
 
     const totalRow = await screen.findByTestId("table-widget-total-row");
     // Dimension cell reads "Total".
@@ -172,7 +163,7 @@ describe("TableWidget", () => {
       meta: { row_count: 75, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<TableWidget widget={makeWidget({ format: "number" })} />);
+    renderWithSWR(<TableWidget widget={makeWidget({ format: "number" })} />);
 
     const totalRow = await screen.findByTestId("table-widget-total-row");
     expect(totalRow).toHaveTextContent("Total");
@@ -188,7 +179,7 @@ describe("TableWidget", () => {
       meta: { row_count: 2, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(
+    renderWithSWR(
       <TableWidget
         widget={makeWidget({
           format: "number",
@@ -229,7 +220,7 @@ describe("TableWidget", () => {
         meta: { row_count: 2, truncated: false, query_ms: 1 },
       });
 
-    renderIsolated(
+    renderWithSWR(
       <TableWidget
         widget={makeWidget({
           format: "number",
@@ -256,7 +247,7 @@ describe("TableWidget", () => {
       meta: { row_count: 1, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(
+    renderWithSWR(
       <TableWidget
         widget={makeWidget({
           measures: [
@@ -280,7 +271,7 @@ describe("TableWidget", () => {
       meta: { row_count: 2, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<TableWidget widget={makeWidget()} />);
+    renderWithSWR(<TableWidget widget={makeWidget()} />);
 
     const exportBtn = await screen.findByTestId("widget-csv-export");
     await waitFor(() => expect(exportBtn).not.toBeDisabled());
@@ -313,7 +304,7 @@ describe("TableWidget", () => {
         meta: { row_count: 2, truncated: false, query_ms: 1 },
       });
 
-    renderIsolated(
+    renderWithSWR(
       <TableWidget
         widget={makeWidget({
           measures: [
@@ -340,7 +331,7 @@ describe("TableWidget", () => {
       meta: { row_count: 1, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<TableWidget widget={makeWidget()} editMode />);
+    renderWithSWR(<TableWidget widget={makeWidget()} editMode />);
 
     await screen.findByText("Food");
     expect(screen.queryByTestId("widget-csv-export")).toBeNull();
@@ -358,7 +349,7 @@ describe("TableWidget", () => {
       meta: { row_count: 30, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<TableWidget widget={makeWidget()} />);
+    renderWithSWR(<TableWidget widget={makeWidget()} />);
 
     // Wait for data and confirm 25 rows visible on the first page.
     await screen.findByText("Cat 0");
@@ -393,7 +384,7 @@ describe("TableWidget", () => {
       meta: { row_count: 30, truncated: false, query_ms: 1 },
     });
 
-    renderIsolated(<TableWidget widget={makeWidget()} />);
+    renderWithSWR(<TableWidget widget={makeWidget()} />);
 
     await screen.findByText("Cat 0");
     // Previous should be disabled on page 1.

--- a/frontend/tests/utils/render-with-swr.tsx
+++ b/frontend/tests/utils/render-with-swr.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement, ReactNode } from "react";
+import { render, type RenderOptions, type RenderResult } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+/**
+ * Renders `ui` inside a fresh-cache `<SWRConfig>` so each test gets an
+ * isolated SWR cache. SWR's default cache is module-scoped, which would
+ * let one test's resolved data leak into a later test that mounts the
+ * same hook. The `provider: () => new Map()` factory hands every mount a
+ * brand-new Map, and `dedupingInterval: 0` disables request coalescing so
+ * back-to-back renders in a single test each issue their own fetch.
+ *
+ * This is the single shared replacement for the ~20 hand-rolled
+ * `renderIsolated` / inline `<SWRConfig value={{ provider: () => new Map() }}>`
+ * wrappers that used to be copy-pasted across the test suite.
+ *
+ * `options` are forwarded to Testing Library's `render` (e.g. `wrapper`,
+ * `container`), so call sites that need extra render config keep working.
+ */
+export function renderWithSWR(
+  ui: ReactElement,
+  options?: RenderOptions,
+): RenderResult {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui as ReactNode}
+    </SWRConfig>,
+    options,
+  );
+}
+
+export { screen, waitFor, fireEvent, act, within } from "@testing-library/react";

--- a/frontend/tests/utils/render-with-swr.tsx
+++ b/frontend/tests/utils/render-with-swr.tsx
@@ -6,9 +6,15 @@ import { SWRConfig } from "swr";
  * Renders `ui` inside a fresh-cache `<SWRConfig>` so each test gets an
  * isolated SWR cache. SWR's default cache is module-scoped, which would
  * let one test's resolved data leak into a later test that mounts the
- * same hook. The `provider: () => new Map()` factory hands every mount a
- * brand-new Map, and `dedupingInterval: 0` disables request coalescing so
- * back-to-back renders in a single test each issue their own fetch.
+ * same hook. A per-call `Map` isolates the cache, and `dedupingInterval: 0`
+ * disables request coalescing so back-to-back renders in a single test each
+ * issue their own fetch.
+ *
+ * The returned `rerender` is overridden to re-wrap in the SAME `<SWRConfig>`,
+ * so call sites can do `rerender(<Foo … />)` without re-introducing an inline
+ * wrapper. The cache Map is created once per call and reused across rerenders
+ * (the provider is only read on mount; a fresh Map would silently reset SWR
+ * state mid-test).
  *
  * This is the single shared replacement for the ~20 hand-rolled
  * `renderIsolated` / inline `<SWRConfig value={{ provider: () => new Map() }}>`
@@ -21,12 +27,17 @@ export function renderWithSWR(
   ui: ReactElement,
   options?: RenderOptions,
 ): RenderResult {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      {ui as ReactNode}
-    </SWRConfig>,
-    options,
+  const cache = new Map();
+  const withSWR = (node: ReactNode) => (
+    <SWRConfig value={{ provider: () => cache, dedupingInterval: 0 }}>
+      {node}
+    </SWRConfig>
   );
+  const result = render(withSWR(ui), options);
+  return {
+    ...result,
+    rerender: (node: ReactNode) => result.rerender(withSWR(node)),
+  };
 }
 
 export { screen, waitFor, fireEvent, act, within } from "@testing-library/react";


### PR DESCRIPTION
## What
Phase 1 of the SWR reference-data migration: consolidate the SWR test wrapper that was copy-pasted ~20× into one shared `frontend/tests/utils/render-with-swr.tsx` (`renderWithSWR` + a fresh-`Map` cache provider per render). 19 test files migrated onto it; the `renderIsolated`/`renderClient`/`renderBell` local wrappers are removed.

**Test-only — zero production change** (`git diff --stat` is entirely under `frontend/tests/`). Full suite identical before/after: 218 files / 1612 tests passing, tsc clean.

This is the harness the upcoming reference-data migration (Phase 2: accounts/categories/billing-periods → `useSWR`) needs to avoid the cacheless-vitest timeouts that reverted it during the audit.