### PR TITLE
feat(admin): server-side sort + pagination on orgs, subscriptions, audit, rate-limits, roles

### DIFF
--- a/backend/app/routers/admin_audit.py
+++ b/backend/app/routers/admin_audit.py
@@ -13,13 +13,14 @@ from __future__ import annotations
 import datetime
 from typing import Literal
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.permissions import require_permission
 from app.database import get_db
 from app.schemas.audit import AuditEventListResponse, AuditEventResponse
 from app.services import audit_service
+from app.services.exceptions import ValidationError
 
 
 router = APIRouter(prefix="/api/v1/admin/audit", tags=["admin-audit"])
@@ -40,21 +41,28 @@ async def list_audit_events(
     outcome: Literal["success", "failure"] | None = Query(default=None),
     from_dt: datetime.datetime | None = Query(default=None),
     to_dt: datetime.datetime | None = Query(default=None),
+    sort_by: str | None = Query(default=None),
+    sort_dir: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     db: AsyncSession = Depends(get_db),
 ) -> AuditEventListResponse:
-    rows, total = await audit_service.list_audit_events(
-        db,
-        actor_user_id=actor_user_id,
-        target_org_id=target_org_id,
-        event_type=event_type,
-        outcome=outcome,
-        from_dt=from_dt,
-        to_dt=to_dt,
-        limit=limit,
-        offset=offset,
-    )
+    try:
+        rows, total = await audit_service.list_audit_events(
+            db,
+            actor_user_id=actor_user_id,
+            target_org_id=target_org_id,
+            event_type=event_type,
+            outcome=outcome,
+            from_dt=from_dt,
+            to_dt=to_dt,
+            sort_by=sort_by,
+            sort_dir=sort_dir,
+            limit=limit,
+            offset=offset,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=exc.detail) from exc
     return AuditEventListResponse(
         items=[AuditEventResponse.model_validate(r) for r in rows],
         total=total,

--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -77,11 +77,18 @@ def _request_id() -> str | None:
 )
 async def list_orgs(
     q: str | None = Query(default=None, max_length=120),
+    sort_by: str | None = Query(default=None),
+    sort_dir: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     db: AsyncSession = Depends(get_db),
 ):
-    return await admin_orgs_service.list_orgs(db, q=q, limit=limit, offset=offset)
+    try:
+        return await admin_orgs_service.list_orgs(
+            db, q=q, sort_by=sort_by, sort_dir=sort_dir, limit=limit, offset=offset
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=exc.detail) from exc
 
 
 @router.get(

--- a/backend/app/routers/admin_rate_limit_overrides.py
+++ b/backend/app/routers/admin_rate_limit_overrides.py
@@ -36,6 +36,7 @@ from app.schemas.rate_limit_override import (
 )
 from app.services import audit_service
 from app.services import rate_limit_overrides_service as svc
+from app.services.exceptions import ValidationError
 
 
 logger = structlog.stdlib.get_logger()
@@ -103,6 +104,8 @@ async def list_overrides_endpoint(
     org_id: Optional[int] = Query(default=None, ge=1),
     user_id: Optional[int] = Query(default=None, ge=1),
     endpoint_pattern: Optional[str] = Query(default=None, max_length=80),
+    sort_by: Optional[str] = Query(default=None),
+    sort_dir: Optional[str] = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     _current_user: User = Depends(require_superadmin),
@@ -113,14 +116,19 @@ async def list_overrides_endpoint(
     ``AuditEventListResponse`` shape so the admin table can reuse the
     same pagination component.
     """
-    rows, total = await svc.list_overrides(
-        db,
-        org_id=org_id,
-        user_id=user_id,
-        endpoint_pattern=endpoint_pattern,
-        limit=limit,
-        offset=offset,
-    )
+    try:
+        rows, total = await svc.list_overrides(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            endpoint_pattern=endpoint_pattern,
+            sort_by=sort_by,
+            sort_dir=sort_dir,
+            limit=limit,
+            offset=offset,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=exc.detail) from exc
     return {
         "items": [RateLimitOverrideResponse.model_validate(r) for r in rows],
         "total": total,

--- a/backend/app/routers/admin_roles.py
+++ b/backend/app/routers/admin_roles.py
@@ -78,8 +78,12 @@ async def list_permission_catalog() -> PermissionCatalogResponse:
 )
 async def list_roles(db: AsyncSession = Depends(get_db)) -> RoleListResponse:
     items = await role_service.list_roles(db)
+    # Roles are fully listed (no offset/limit), so ``total`` is simply
+    # the row count. The envelope now matches the other admin tables so
+    # the FE can reuse the shared <Pagination> component.
     return RoleListResponse(
-        items=[RoleListItem(**item) for item in items]
+        items=[RoleListItem(**item) for item in items],
+        total=len(items),
     )
 
 

--- a/backend/app/routers/admin_subscriptions.py
+++ b/backend/app/routers/admin_subscriptions.py
@@ -45,7 +45,7 @@ from app.schemas.admin_subscriptions import (
     SubscriptionListResponse,
 )
 from app.services import admin_subscription_service, audit_service
-from app.services.exceptions import NotFoundError
+from app.services.exceptions import NotFoundError, ValidationError
 
 
 logger = structlog.stdlib.get_logger()
@@ -179,19 +179,26 @@ async def list_subscriptions(
     ),
     plan: Optional[str] = Query(default=None, max_length=80),
     q: Optional[str] = Query(default=None, max_length=120),
+    sort_by: Optional[str] = Query(default=None),
+    sort_dir: Optional[str] = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     db: AsyncSession = Depends(get_db),
     session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ) -> SubscriptionListResponse:
-    payload = await admin_subscription_service.list_subscriptions(
-        db,
-        status_filter=status_filter,
-        plan_filter=plan,
-        q=q,
-        limit=limit,
-        offset=offset,
-    )
+    try:
+        payload = await admin_subscription_service.list_subscriptions(
+            db,
+            status_filter=status_filter,
+            plan_filter=plan,
+            q=q,
+            sort_by=sort_by,
+            sort_dir=sort_dir,
+            limit=limit,
+            offset=offset,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=exc.detail) from exc
     await _emit_view_audit(
         event_type="admin.subscriptions.viewed",
         actor=current_user,

--- a/backend/app/schemas/role.py
+++ b/backend/app/schemas/role.py
@@ -30,7 +30,13 @@ class RoleListItem(BaseModel):
 
 
 class RoleListResponse(BaseModel):
+    # ``total`` lets the admin roles table reuse the shared <Pagination>
+    # component (matching the orgs / subscriptions / audit envelope).
+    # Roles are a small, fully-listed set today, so ``total`` always
+    # equals ``len(items)``; the field exists so the FE never has to
+    # special-case its absence if server-side paging lands later.
     items: list[RoleListItem]
+    total: int
 
 
 class RoleDetailResponse(BaseModel):

--- a/backend/app/services/admin_orgs_service.py
+++ b/backend/app/services/admin_orgs_service.py
@@ -29,6 +29,7 @@ from app.models.subscription import Plan, Subscription, SubscriptionStatus
 from app.models.transaction import Transaction
 from app.models.user import Organization, User
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+from app.services.list_query import resolve_order_by
 from app.services.org_data_service import wipe_org_data
 
 
@@ -52,6 +53,8 @@ async def list_orgs(
     db: AsyncSession,
     *,
     q: Optional[str] = None,
+    sort_by: Optional[str] = None,
+    sort_dir: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
 ) -> dict:
@@ -61,6 +64,11 @@ async def list_orgs(
     plus correlated user-count subqueries — bounded query cost
     regardless of page size. `last_user_created_at` is a soft proxy
     ("Newest member") for activity until L4.7 audit log lands.
+
+    ``sort_by`` is resolved against a closed whitelist (see below); an
+    unknown key raises ``ValidationError`` (router → 400). When omitted,
+    defaults to ``created_at`` desc. ``Organization.id`` desc is appended
+    as a stable tiebreaker so pagination is deterministic.
     """
     user_count_sq = (
         select(func.count())
@@ -82,6 +90,22 @@ async def list_orgs(
         .correlate(Organization)
         .scalar_subquery()
     )
+
+    # Closed whitelist of sortable columns. Keys are the public sort
+    # tokens the frontend sends; values are the column/expression to
+    # order by. Subquery aggregates (user_count / last member) order on
+    # the bare subquery expression — MySQL and SQLite both accept a
+    # scalar subquery in ORDER BY. Anything not here is a 400 (see
+    # ``list_query.resolve_order_by``).
+    sortable = {
+        "name": Organization.name,
+        "created_at": Organization.created_at,
+        "plan_slug": Plan.slug,
+        "subscription_status": Subscription.status,
+        "user_count": user_count_sq,
+        "active_user_count": active_user_count_sq,
+        "last_user_created_at": newest_member_sq,
+    }
 
     stmt = (
         select(
@@ -107,9 +131,18 @@ async def list_orgs(
         total_stmt = total_stmt.where(Organization.name.ilike(f"%{q}%"))
     total = (await db.scalar(total_stmt)) or 0
 
+    order_by = resolve_order_by(
+        sort_by,
+        sort_dir,
+        allowed=sortable,
+        default_key="created_at",
+        default_dir="desc",
+        tiebreaker=Organization.id.desc(),
+    )
+
     rows = (
         await db.execute(
-            stmt.order_by(Organization.created_at.desc())
+            stmt.order_by(*order_by)
             .limit(limit)
             .offset(offset)
         )

--- a/backend/app/services/admin_subscription_service.py
+++ b/backend/app/services/admin_subscription_service.py
@@ -38,6 +38,23 @@ from app.models.subscription import (
 from app.models.user import Organization, User
 from app.services.admin_users_search_service import _normalize_like
 from app.services.exceptions import NotFoundError
+from app.services.list_query import resolve_order_by
+
+
+# Closed whitelist of sortable columns for the subscriptions list. Keys
+# are the public sort tokens the frontend sends; values are the column
+# to order by. ``org_name`` / ``plan_slug`` / ``plan_name`` sort on the
+# joined Organization / Plan columns. Anything not here is a 400 (see
+# ``list_query.resolve_order_by``).
+_SORTABLE = {
+    "org_name": Organization.name,
+    "plan_slug": Plan.slug,
+    "plan_name": Plan.name,
+    "status": Subscription.status,
+    "created_at": Subscription.created_at,
+    "trial_end": Subscription.trial_end,
+    "current_period_end": Subscription.current_period_end,
+}
 
 
 # How far ahead "trial expiring soon" looks. Locked at 7 days to match
@@ -84,6 +101,8 @@ async def list_subscriptions(
     status_filter: Optional[str] = None,
     plan_filter: Optional[str] = None,
     q: Optional[str] = None,
+    sort_by: Optional[str] = None,
+    sort_dir: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
 ) -> dict[str, Any]:
@@ -168,9 +187,19 @@ async def list_subscriptions(
         count_q = count_q.where(clause)
 
     total = (await db.execute(count_q)).scalar_one()
+
+    order_by = resolve_order_by(
+        sort_by,
+        sort_dir,
+        allowed=_SORTABLE,
+        default_key="created_at",
+        default_dir="desc",
+        tiebreaker=Subscription.id.desc(),
+    )
+
     rows = (
         await db.execute(
-            base.order_by(Subscription.created_at.desc(), Subscription.id.desc())
+            base.order_by(*order_by)
             .limit(limit)
             .offset(offset)
         )

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -31,9 +31,22 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.audit_event import AuditEvent, AuditOutcome
+from app.services.list_query import resolve_order_by
 
 
 logger = structlog.stdlib.get_logger()
+
+
+# Closed whitelist of sortable columns for the admin audit list. Keys are
+# the public sort tokens the frontend sends; values are the column to
+# order by. Anything not here is a 400 (see ``list_query.resolve_order_by``).
+_SORTABLE = {
+    "created_at": AuditEvent.created_at,
+    "event_type": AuditEvent.event_type,
+    "outcome": AuditEvent.outcome,
+    "actor_email": AuditEvent.actor_email,
+    "target_org_name": AuditEvent.target_org_name,
+}
 
 
 def _build_audit_event(
@@ -182,13 +195,18 @@ async def list_audit_events(
     outcome: Optional[str] = None,
     from_dt: Optional[datetime] = None,
     to_dt: Optional[datetime] = None,
+    sort_by: Optional[str] = None,
+    sort_dir: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
 ) -> tuple[list[AuditEvent], int]:
     """Return ``(rows, total)`` for the admin audit table.
 
-    Ordered by ``created_at DESC`` (then id DESC for stable sort
-    across same-timestamp events).
+    Default ordering is ``created_at DESC`` (then id DESC for stable
+    sort across same-timestamp events). ``sort_by`` is resolved against
+    a closed whitelist (see ``_SORTABLE``); an unknown key raises
+    ``ValidationError`` (router → 400). ``id`` desc is always appended as
+    the stable tiebreaker.
     """
     where = []
     if actor_user_id is not None:
@@ -218,8 +236,17 @@ async def list_audit_events(
 
     total = (await db.execute(count_q)).scalar_one()
 
+    order_by = resolve_order_by(
+        sort_by,
+        sort_dir,
+        allowed=_SORTABLE,
+        default_key="created_at",
+        default_dir="desc",
+        tiebreaker=AuditEvent.id.desc(),
+    )
+
     rows_result = await db.execute(
-        base.order_by(AuditEvent.created_at.desc(), AuditEvent.id.desc())
+        base.order_by(*order_by)
         .limit(limit)
         .offset(offset)
     )

--- a/backend/app/services/rate_limit_overrides_service.py
+++ b/backend/app/services/rate_limit_overrides_service.py
@@ -43,9 +43,25 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.rate_limit_override import RateLimitOverride
+from app.services.list_query import resolve_order_by
 
 
 logger = structlog.stdlib.get_logger()
+
+
+# Closed whitelist of sortable columns for the admin rate-limit-override
+# list. Keys are the public sort tokens the frontend sends; values are
+# the column to order by. Anything not here is a 400 (see
+# ``list_query.resolve_order_by``).
+_SORTABLE = {
+    "created_at": RateLimitOverride.created_at,
+    "endpoint_pattern": RateLimitOverride.endpoint_pattern,
+    "max_requests": RateLimitOverride.max_requests,
+    "period_seconds": RateLimitOverride.period_seconds,
+    "expires_at": RateLimitOverride.expires_at,
+    "org_id": RateLimitOverride.org_id,
+    "user_id": RateLimitOverride.user_id,
+}
 
 # Sentinel stored in Redis when a lookup hits no row. Distinct from
 # the wire format of a real override ("<max>/<period>") so the
@@ -168,11 +184,17 @@ async def list_overrides(
     org_id: Optional[int] = None,
     user_id: Optional[int] = None,
     endpoint_pattern: Optional[str] = None,
+    sort_by: Optional[str] = None,
+    sort_dir: Optional[str] = None,
     limit: int = 100,
     offset: int = 0,
 ) -> tuple[Sequence[RateLimitOverride], int]:
     """List overrides with optional scope filters. Returns
     ``(items, total)`` to support a paginated admin table.
+
+    ``sort_by`` is resolved against a closed whitelist (see
+    ``_SORTABLE``); an unknown key raises ``ValidationError`` (router →
+    400). Defaults to ``created_at`` desc with an ``id`` desc tiebreaker.
     """
     base = select(RateLimitOverride)
     filters_q = base
@@ -195,10 +217,17 @@ async def list_overrides(
     total_result = await db.execute(count_q)
     total = int(total_result.scalar() or 0)
 
+    order_by = resolve_order_by(
+        sort_by,
+        sort_dir,
+        allowed=_SORTABLE,
+        default_key="created_at",
+        default_dir="desc",
+        tiebreaker=RateLimitOverride.id.desc(),
+    )
+
     rows_result = await db.execute(
-        filters_q.order_by(
-            RateLimitOverride.created_at.desc(), RateLimitOverride.id.desc()
-        )
+        filters_q.order_by(*order_by)
         .limit(limit)
         .offset(offset)
     )

--- a/backend/app/services/rate_limit_overrides_service.py
+++ b/backend/app/services/rate_limit_overrides_service.py
@@ -59,8 +59,6 @@ _SORTABLE = {
     "max_requests": RateLimitOverride.max_requests,
     "period_seconds": RateLimitOverride.period_seconds,
     "expires_at": RateLimitOverride.expires_at,
-    "org_id": RateLimitOverride.org_id,
-    "user_id": RateLimitOverride.user_id,
 }
 
 # Sentinel stored in Redis when a lookup hits no row. Distinct from

--- a/backend/tests/routers/test_admin_audit.py
+++ b/backend/tests/routers/test_admin_audit.py
@@ -180,6 +180,73 @@ async def test_get_audit_list_pagination(session_factory):
         assert len(body2["items"]) == 1
 
 
+# ── sort contract (shared list contract) ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_audit_list_sort_event_type_asc(session_factory):
+    await _seed(session_factory)
+    await _seed_events(session_factory, 5)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(
+            "/api/v1/admin/audit",
+            params={"sort_by": "event_type", "sort_dir": "asc"},
+        )
+    assert res.status_code == 200
+    types = [item["event_type"] for item in res.json()["items"]]
+    assert types == sorted(types)
+
+
+@pytest.mark.asyncio
+async def test_get_audit_list_sort_actor_email_desc(session_factory):
+    await _seed(session_factory)
+    await _seed_events(session_factory, 5)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(
+            "/api/v1/admin/audit",
+            params={"sort_by": "actor_email", "sort_dir": "desc"},
+        )
+    assert res.status_code == 200
+    emails = [item["actor_email"] for item in res.json()["items"]]
+    assert emails == sorted(emails, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_get_audit_list_default_sort_is_created_at_desc(session_factory):
+    await _seed(session_factory)
+    await _seed_events(session_factory, 4)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/audit")
+    assert res.status_code == 200
+    created = [item["created_at"] for item in res.json()["items"]]
+    assert created == sorted(created, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_get_audit_list_invalid_sort_by_returns_400(session_factory):
+    await _seed(session_factory)
+    await _seed_events(session_factory, 1)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/audit", params={"sort_by": "not_a_column"})
+    assert res.status_code == 400
+    assert "invalid_sort_by" in res.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_audit_list_invalid_sort_dir_returns_400(session_factory):
+    await _seed(session_factory)
+    await _seed_events(session_factory, 1)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/audit", params={"sort_dir": "sideways"})
+    assert res.status_code == 400
+    assert "invalid_sort_dir" in res.json()["detail"]
+
+
 # ── outcome filter validation (PR-C / PR #139 #3) ──────────────────────────
 
 

--- a/backend/tests/routers/test_admin_orgs.py
+++ b/backend/tests/routers/test_admin_orgs.py
@@ -166,6 +166,66 @@ async def test_list_orgs_200_for_superadmin(session_factory):
     assert "Admin Org" in names and "Target Inc" in names
 
 
+# ── sort contract (shared list contract) ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_orgs_sort_name_asc(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(
+            "/api/v1/admin/orgs", params={"sort_by": "name", "sort_dir": "asc"}
+        )
+    assert res.status_code == 200
+    names = [item["name"] for item in res.json()["items"]]
+    assert names == sorted(names)
+
+
+@pytest.mark.asyncio
+async def test_list_orgs_sort_name_desc_reverses(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(
+            "/api/v1/admin/orgs", params={"sort_by": "name", "sort_dir": "desc"}
+        )
+    assert res.status_code == 200
+    names = [item["name"] for item in res.json()["items"]]
+    assert names == sorted(names, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_list_orgs_default_sort_is_created_at_desc(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/orgs")
+    assert res.status_code == 200
+    created = [item["created_at"] for item in res.json()["items"]]
+    assert created == sorted(created, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_list_orgs_invalid_sort_by_returns_400(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/orgs", params={"sort_by": "not_a_column"})
+    assert res.status_code == 400
+    assert "invalid_sort_by" in res.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_list_orgs_invalid_sort_dir_returns_400(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/orgs", params={"sort_dir": "sideways"})
+    assert res.status_code == 400
+    assert "invalid_sort_dir" in res.json()["detail"]
+
+
 # ── drill-down ─────────────────────────────────────────────────────────────
 
 

--- a/backend/tests/routers/test_admin_rate_limit_overrides.py
+++ b/backend/tests/routers/test_admin_rate_limit_overrides.py
@@ -614,3 +614,83 @@ async def test_endpoint_catalogue_non_superadmin_403(session_factory):
             "/api/v1/admin/rate-limit-overrides/endpoint-catalogue"
         )
         assert resp.status_code == 403, who
+
+
+# ── sort contract (shared list contract) ────────────────────────────────────
+
+
+def _seed_two_overrides(client, seeded: dict) -> None:
+    """Two org-scoped overrides with distinct endpoint_pattern +
+    max_requests so sort assertions have something to order."""
+    client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "reports.query",
+            "max_requests": 100,
+            "period_seconds": 60,
+        },
+    )
+    client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "accounts.adjust_balance",
+            "max_requests": 5,
+            "period_seconds": 60,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_sort_endpoint_pattern_asc(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    _seed_two_overrides(client, seeded)
+    resp = client.get(
+        "/api/v1/admin/rate-limit-overrides",
+        params={"sort_by": "endpoint_pattern", "sort_dir": "asc"},
+    )
+    assert resp.status_code == 200
+    patterns = [r["endpoint_pattern"] for r in resp.json()["items"]]
+    assert patterns == sorted(patterns)
+
+
+@pytest.mark.asyncio
+async def test_list_sort_max_requests_desc(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    _seed_two_overrides(client, seeded)
+    resp = client.get(
+        "/api/v1/admin/rate-limit-overrides",
+        params={"sort_by": "max_requests", "sort_dir": "desc"},
+    )
+    assert resp.status_code == 200
+    maxes = [r["max_requests"] for r in resp.json()["items"]]
+    assert maxes == sorted(maxes, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_list_invalid_sort_by_returns_400(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.get(
+        "/api/v1/admin/rate-limit-overrides", params={"sort_by": "not_a_column"}
+    )
+    assert resp.status_code == 400
+    assert "invalid_sort_by" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_list_invalid_sort_dir_returns_400(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.get(
+        "/api/v1/admin/rate-limit-overrides", params={"sort_dir": "sideways"}
+    )
+    assert resp.status_code == 400
+    assert "invalid_sort_dir" in resp.json()["detail"]

--- a/backend/tests/routers/test_admin_roles.py
+++ b/backend/tests/routers/test_admin_roles.py
@@ -186,6 +186,9 @@ async def test_list_roles_returns_seeded_frozen(session_factory):
     assert res.status_code == 200
     body = res.json()
     assert len(body["items"]) == 1
+    # ``total`` mirrors the other admin-table list envelopes so the FE
+    # can reuse the shared <Pagination> component.
+    assert body["total"] == 1
     item = body["items"][0]
     assert item["slug"] == "superadmin"
     assert item["is_system_frozen"] is True

--- a/backend/tests/routers/test_admin_subscriptions.py
+++ b/backend/tests/routers/test_admin_subscriptions.py
@@ -227,6 +227,61 @@ async def test_list_rejects_unknown_status_with_422(session_factory):
     assert res.status_code == 422
 
 
+# ── sort contract (shared list contract) ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_sort_org_name_asc(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(
+            "/api/v1/admin/subscriptions",
+            params={"sort_by": "org_name", "sort_dir": "asc"},
+        )
+    assert res.status_code == 200
+    names = [row["org_name"] for row in res.json()["items"]]
+    assert names == sorted(names)
+
+
+@pytest.mark.asyncio
+async def test_list_sort_org_name_desc_reverses(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(
+            "/api/v1/admin/subscriptions",
+            params={"sort_by": "org_name", "sort_dir": "desc"},
+        )
+    assert res.status_code == 200
+    names = [row["org_name"] for row in res.json()["items"]]
+    assert names == sorted(names, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_list_invalid_sort_by_returns_400(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(
+            "/api/v1/admin/subscriptions", params={"sort_by": "not_a_column"}
+        )
+    assert res.status_code == 400
+    assert "invalid_sort_by" in res.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_list_invalid_sort_dir_returns_400(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(
+            "/api/v1/admin/subscriptions", params={"sort_dir": "sideways"}
+        )
+    assert res.status_code == 400
+    assert "invalid_sort_dir" in res.json()["detail"]
+
+
 @pytest.mark.asyncio
 async def test_detail_returns_full_envelope(session_factory):
     seeded = await _seed(session_factory)

--- a/frontend/app/admin/audit/page.tsx
+++ b/frontend/app/admin/audit/page.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useCallback, useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AppShell from "@/components/AppShell";
+import Pagination from "@/components/ui/Pagination";
+import SortableHeader from "@/components/ui/SortableHeader";
 import Spinner from "@/components/ui/Spinner";
+import { pageCount } from "@/lib/hooks/use-table-state";
+import type { SortDir } from "@/lib/hooks/use-table-state";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { hasPlatformPermission } from "@/lib/auth";
@@ -17,7 +21,22 @@ import {
   pageTitle,
 } from "@/lib/styles";
 
-const PAGE_SIZE = 50;
+const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_SORT_BY = "created_at";
+const DEFAULT_SORT_DIR: SortDir = "desc";
+
+// Backend-whitelisted sort keys. Unknown keys 400, so we clamp a seeded
+// URL value back to the default rather than send garbage.
+const SORT_FIELDS = [
+  "created_at",
+  "event_type",
+  "actor_email",
+  "target_org_name",
+  "outcome",
+] as const;
+type SortField = (typeof SORT_FIELDS)[number];
+
+const PAGE_SIZE_VALUES = [10, 25, 50, 100] as const;
 
 const dtFmt = new Intl.DateTimeFormat(undefined, {
   year: "numeric",
@@ -34,14 +53,60 @@ function shortRequestId(value: string | null): string {
 }
 
 export default function AdminAuditPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <Spinner />
+        </div>
+      }
+    >
+      <AdminAuditPageContent />
+    </Suspense>
+  );
+}
+
+function AdminAuditPageContent() {
   const { user, loading } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const initialPageSize = (() => {
+    const raw = searchParams.get("page_size");
+    if (raw === null || raw === "") return DEFAULT_PAGE_SIZE;
+    const n = Number(raw);
+    return (PAGE_SIZE_VALUES as readonly number[]).includes(n)
+      ? n
+      : DEFAULT_PAGE_SIZE;
+  })();
+  const initialOffset = (() => {
+    const raw = searchParams.get("offset");
+    if (raw === null || raw === "") return 0;
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < 0) return 0;
+    return Math.floor(n / initialPageSize) * initialPageSize;
+  })();
+  const initialSortBy: SortField = (() => {
+    const raw = searchParams.get("sort_by");
+    return raw && (SORT_FIELDS as readonly string[]).includes(raw)
+      ? (raw as SortField)
+      : DEFAULT_SORT_BY;
+  })();
+  const initialSortDir: SortDir = (() => {
+    const raw = searchParams.get("sort_dir");
+    return raw === "asc" || raw === "desc" ? raw : DEFAULT_SORT_DIR;
+  })();
+
   const [data, setData] = useState<AuditEventListResponse | null>(null);
   const [error, setError] = useState("");
   const [eventTypeInput, setEventTypeInput] = useState("");
   const [outcomeInput, setOutcomeInput] = useState("");
   const [targetOrgInput, setTargetOrgInput] = useState("");
-  const [offset, setOffset] = useState(0);
+  const [offset, setOffset] = useState(initialOffset);
+  const [sortBy, setSortBy] = useState<SortField>(initialSortBy);
+  const [sortDir, setSortDir] = useState<SortDir>(initialSortDir);
+  const [pageSize, setPageSize] = useState(initialPageSize);
   const [fetching, setFetching] = useState(true);
 
   useEffect(() => {
@@ -59,8 +124,10 @@ export default function AdminAuditPage() {
     if (loading || !user || !hasPlatformPermission(user, "audit.view")) return;
     setFetching(true);
     const params = new URLSearchParams({
-      limit: String(PAGE_SIZE),
+      limit: String(pageSize),
       offset: String(offset),
+      sort_by: sortBy,
+      sort_dir: sortDir,
     });
     if (eventTypeInput.trim()) params.set("event_type", eventTypeInput.trim());
     if (outcomeInput) params.set("outcome", outcomeInput);
@@ -74,7 +141,53 @@ export default function AdminAuditPage() {
       .then((d) => setData(d))
       .catch((err) => setError(extractErrorMessage(err, "Failed to load")))
       .finally(() => setFetching(false));
-  }, [loading, user, eventTypeInput, outcomeInput, targetOrgInput, offset]);
+  }, [
+    loading,
+    user,
+    eventTypeInput,
+    outcomeInput,
+    targetOrgInput,
+    offset,
+    sortBy,
+    sortDir,
+    pageSize,
+  ]);
+
+  // Clamp an over-offset URL back to the last valid page once data lands.
+  useEffect(() => {
+    if (!data) return;
+    if (offset > 0 && offset >= data.total) {
+      const lastOffset = Math.max(0, (pageCount(data.total, pageSize) - 1) * pageSize);
+      if (lastOffset !== offset) setOffset(lastOffset);
+    }
+  }, [data, offset, pageSize]);
+
+  // Mirror sort + pagination state back to the URL (router.replace,
+  // scroll:false). Filter inputs stay local-only.
+  useEffect(() => {
+    if (loading || !user || !hasPlatformPermission(user, "audit.view")) return;
+    const params = new URLSearchParams();
+    if (offset > 0) params.set("offset", String(offset));
+    if (sortBy !== DEFAULT_SORT_BY) params.set("sort_by", sortBy);
+    if (sortDir !== DEFAULT_SORT_DIR) params.set("sort_dir", sortDir);
+    if (pageSize !== DEFAULT_PAGE_SIZE) params.set("page_size", String(pageSize));
+    const query = params.toString();
+    const current = searchParams.toString();
+    if (query === current) return;
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, user, offset, sortBy, sortDir, pageSize, pathname, router]);
+
+  const handleSort = useCallback(
+    (field: string) => {
+      if (!(SORT_FIELDS as readonly string[]).includes(field)) return;
+      const f = field as SortField;
+      setSortBy(f);
+      setSortDir(f === sortBy ? (sortDir === "asc" ? "desc" : "asc") : "asc");
+      setOffset(0);
+    },
+    [sortBy, sortDir],
+  );
 
   if (loading || !user || !hasPlatformPermission(user, "audit.view")) {
     return (
@@ -140,11 +253,41 @@ export default function AdminAuditPage() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
-                <th className="px-6 py-3">When</th>
-                <th className="px-6 py-3">Event type</th>
-                <th className="px-6 py-3">Actor email</th>
-                <th className="px-6 py-3">Target org</th>
-                <th className="px-6 py-3">Outcome</th>
+                <SortableHeader
+                  label="When"
+                  field="created_at"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Event type"
+                  field="event_type"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Actor email"
+                  field="actor_email"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Target org"
+                  field="target_org_name"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Outcome"
+                  field="outcome"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
                 <th className="px-6 py-3">Request ID</th>
                 <th className="px-6 py-3">IP</th>
               </tr>
@@ -216,30 +359,18 @@ export default function AdminAuditPage() {
           </table>
         </div>
 
-        {data && data.total > PAGE_SIZE && (
-          <div className="flex items-center justify-between px-6 py-3 text-xs text-text-muted">
-            <span>
-              {offset + 1}–{Math.min(offset + PAGE_SIZE, data.total)} of{" "}
-              {data.total}
-            </span>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                disabled={offset === 0}
-                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
-              >
-                Prev
-              </button>
-              <button
-                type="button"
-                disabled={offset + PAGE_SIZE >= data.total}
-                onClick={() => setOffset(offset + PAGE_SIZE)}
-                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
-              >
-                Next
-              </button>
-            </div>
+        {data && (data.total > pageSize || offset > 0) && (
+          <div className="px-6">
+            <Pagination
+              page={Math.max(1, Math.floor(offset / pageSize) + 1)}
+              pageSize={pageSize}
+              total={data.total}
+              onPageChange={(n) => setOffset((n - 1) * pageSize)}
+              onPageSizeChange={(n) => {
+                setPageSize(n);
+                setOffset(0);
+              }}
+            />
           </div>
         )}
       </div>

--- a/frontend/app/admin/orgs/page.tsx
+++ b/frontend/app/admin/orgs/page.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import ConfirmModal from "@/components/ui/ConfirmModal";
+import Pagination from "@/components/ui/Pagination";
+import SortableHeader from "@/components/ui/SortableHeader";
 import Spinner from "@/components/ui/Spinner";
+import { pageCount } from "@/lib/hooks/use-table-state";
+import type { SortDir } from "@/lib/hooks/use-table-state";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { hasPlatformPermission } from "@/lib/auth";
@@ -19,6 +23,12 @@ import {
   pageTitle,
   success as successCls,
 } from "@/lib/styles";
+
+// Admin orgs list. URL-synced sort + pagination mirrors
+// /admin/users/page.tsx (the reference implementation). The query
+// string is the source of truth for q / offset / sort / page_size; we
+// seed React state from it on first render and mirror state back via
+// router.replace so a refreshed or shared URL keeps the table state.
 
 type OrgRow = {
   id: number;
@@ -39,15 +49,82 @@ type OrgListResponse = {
   offset: number;
 };
 
-const PAGE_SIZE = 50;
+const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_SORT_BY = "created_at";
+const DEFAULT_SORT_DIR: SortDir = "desc";
+const SEARCH_DEBOUNCE_MS = 300;
+
+// Backend-whitelisted sort keys. Unknown keys 400, so we clamp a seeded
+// URL value back to the default rather than send garbage.
+const SORT_FIELDS = [
+  "name",
+  "created_at",
+  "plan_slug",
+  "subscription_status",
+  "user_count",
+  "active_user_count",
+  "last_user_created_at",
+] as const;
+type SortField = (typeof SORT_FIELDS)[number];
+
+const PAGE_SIZE_VALUES = [10, 25, 50, 100] as const;
 
 export default function AdminOrgsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <Spinner />
+        </div>
+      }
+    >
+      <AdminOrgsPageContent />
+    </Suspense>
+  );
+}
+
+function AdminOrgsPageContent() {
   const { user, loading } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const initialQ = searchParams.get("q") ?? "";
+  const initialPageSize = (() => {
+    const raw = searchParams.get("page_size");
+    if (raw === null || raw === "") return DEFAULT_PAGE_SIZE;
+    const n = Number(raw);
+    return (PAGE_SIZE_VALUES as readonly number[]).includes(n)
+      ? n
+      : DEFAULT_PAGE_SIZE;
+  })();
+  const initialOffset = (() => {
+    const raw = searchParams.get("offset");
+    if (raw === null || raw === "") return 0;
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < 0) return 0;
+    return Math.floor(n / initialPageSize) * initialPageSize;
+  })();
+  const initialSortBy: SortField = (() => {
+    const raw = searchParams.get("sort_by");
+    return raw && (SORT_FIELDS as readonly string[]).includes(raw)
+      ? (raw as SortField)
+      : DEFAULT_SORT_BY;
+  })();
+  const initialSortDir: SortDir = (() => {
+    const raw = searchParams.get("sort_dir");
+    return raw === "asc" || raw === "desc" ? raw : DEFAULT_SORT_DIR;
+  })();
+
+  const [qInput, setQInput] = useState(initialQ);
+  const [q, setQ] = useState(initialQ);
+  const [offset, setOffset] = useState(initialOffset);
+  const [sortBy, setSortBy] = useState<SortField>(initialSortBy);
+  const [sortDir, setSortDir] = useState<SortDir>(initialSortDir);
+  const [pageSize, setPageSize] = useState(initialPageSize);
+
   const [data, setData] = useState<OrgListResponse | null>(null);
   const [error, setError] = useState("");
-  const [q, setQ] = useState("");
-  const [offset, setOffset] = useState(0);
   const [fetching, setFetching] = useState(true);
   const [sweepConfirmOpen, setSweepConfirmOpen] = useState(false);
   const [sweepBusy, setSweepBusy] = useState(false);
@@ -82,19 +159,71 @@ export default function AdminOrgsPage() {
     }
   }, [loading, user, router]);
 
+  // Debounce search input; resets offset to 0 on a new query. Skip the
+  // first run so a seeded non-zero offset isn't clobbered on mount.
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setQ((prev) => {
+        const next = qInput.trim();
+        if (next !== prev) setOffset(0);
+        return next;
+      });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [qInput]);
+
   useEffect(() => {
     if (loading || !user || !hasPlatformPermission(user, "orgs.view")) return;
     setFetching(true);
+    setError("");
     const params = new URLSearchParams({
-      limit: String(PAGE_SIZE),
+      limit: String(pageSize),
       offset: String(offset),
+      sort_by: sortBy,
+      sort_dir: sortDir,
     });
-    if (q.trim()) params.set("q", q.trim());
+    if (q) params.set("q", q);
     apiFetch<OrgListResponse>(`/api/v1/admin/orgs?${params.toString()}`)
       .then((d) => setData(d))
       .catch((err) => setError(extractErrorMessage(err, "Failed to load")))
       .finally(() => setFetching(false));
-  }, [loading, user, q, offset]);
+  }, [loading, user, q, offset, sortBy, sortDir, pageSize]);
+
+  // Clamp an over-offset URL back to the last valid page once data lands.
+  useEffect(() => {
+    if (!data) return;
+    if (offset > 0 && offset >= data.total) {
+      const lastOffset = Math.max(0, (pageCount(data.total, pageSize) - 1) * pageSize);
+      if (lastOffset !== offset) setOffset(lastOffset);
+    }
+  }, [data, offset, pageSize]);
+
+  // Mirror state back to the URL (router.replace, scroll:false).
+  useEffect(() => {
+    if (loading || !user || !hasPlatformPermission(user, "orgs.view")) return;
+    const params = new URLSearchParams();
+    if (q) params.set("q", q);
+    if (offset > 0) params.set("offset", String(offset));
+    if (sortBy !== DEFAULT_SORT_BY) params.set("sort_by", sortBy);
+    if (sortDir !== DEFAULT_SORT_DIR) params.set("sort_dir", sortDir);
+    if (pageSize !== DEFAULT_PAGE_SIZE) params.set("page_size", String(pageSize));
+    const query = params.toString();
+    const current = searchParams.toString();
+    if (query === current) return;
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, user, q, offset, sortBy, sortDir, pageSize, pathname, router]);
+
+  const handleSort = useCallback(
+    (field: string) => {
+      if (!(SORT_FIELDS as readonly string[]).includes(field)) return;
+      const f = field as SortField;
+      setSortBy(f);
+      setSortDir(f === sortBy ? (sortDir === "asc" ? "desc" : "asc") : "asc");
+      setOffset(0);
+    },
+    [sortBy, sortDir],
+  );
 
   if (loading || !user || !hasPlatformPermission(user, "orgs.view")) {
     return (
@@ -148,11 +277,8 @@ export default function AdminOrgsPage() {
         <div className="px-6 py-4">
           <input
             type="search"
-            value={q}
-            onChange={(e) => {
-              setOffset(0);
-              setQ(e.target.value);
-            }}
+            value={qInput}
+            onChange={(e) => setQInput(e.target.value)}
             placeholder="Search by name…"
             className={`${input} w-full max-w-sm`}
             aria-label="Search organizations"
@@ -162,12 +288,48 @@ export default function AdminOrgsPage() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
-                <th className="px-6 py-3">Name</th>
-                <th className="px-6 py-3">Plan</th>
-                <th className="px-6 py-3">Status</th>
-                <th className="px-6 py-3">Users</th>
-                <th className="px-6 py-3">Newest member</th>
-                <th className="px-6 py-3">Created</th>
+                <SortableHeader
+                  label="Name"
+                  field="name"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Plan"
+                  field="plan_slug"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Status"
+                  field="subscription_status"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Users"
+                  field="user_count"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Newest member"
+                  field="last_user_created_at"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Created"
+                  field="created_at"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
               </tr>
             </thead>
             <tbody>
@@ -217,30 +379,18 @@ export default function AdminOrgsPage() {
           </table>
         </div>
 
-        {data && data.total > PAGE_SIZE && (
-          <div className="flex items-center justify-between px-6 py-3 text-xs text-text-muted">
-            <span>
-              {offset + 1}–{Math.min(offset + PAGE_SIZE, data.total)} of{" "}
-              {data.total}
-            </span>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                disabled={offset === 0}
-                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
-              >
-                Prev
-              </button>
-              <button
-                type="button"
-                disabled={offset + PAGE_SIZE >= data.total}
-                onClick={() => setOffset(offset + PAGE_SIZE)}
-                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
-              >
-                Next
-              </button>
-            </div>
+        {data && (data.total > pageSize || offset > 0) && (
+          <div className="px-6">
+            <Pagination
+              page={Math.max(1, Math.floor(offset / pageSize) + 1)}
+              pageSize={pageSize}
+              total={data.total}
+              onPageChange={(n) => setOffset((n - 1) * pageSize)}
+              onPageSizeChange={(n) => {
+                setPageSize(n);
+                setOffset(0);
+              }}
+            />
           </div>
         )}
       </div>

--- a/frontend/app/admin/orgs/page.tsx
+++ b/frontend/app/admin/orgs/page.tsx
@@ -159,8 +159,10 @@ function AdminOrgsPageContent() {
     }
   }, [loading, user, router]);
 
-  // Debounce search input; resets offset to 0 on a new query. Skip the
-  // first run so a seeded non-zero offset isn't clobbered on mount.
+  // Debounce search input; resets offset to 0 only when the trimmed query
+  // actually changes. On mount, qInput and q are both seeded from the same
+  // URL params, so next === prev and the seeded offset is left intact (no
+  // explicit first-run guard needed).
   useEffect(() => {
     const handle = setTimeout(() => {
       setQ((prev) => {

--- a/frontend/app/admin/rate-limit-overrides/page.tsx
+++ b/frontend/app/admin/rate-limit-overrides/page.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useCallback, useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AppShell from "@/components/AppShell";
+import Pagination from "@/components/ui/Pagination";
+import SortableHeader from "@/components/ui/SortableHeader";
 import Spinner from "@/components/ui/Spinner";
+import { pageCount } from "@/lib/hooks/use-table-state";
+import type { SortDir } from "@/lib/hooks/use-table-state";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { isSuperadmin } from "@/lib/auth";
@@ -40,7 +44,22 @@ import type {
 // the backend rejects scope keys in the update payload, so the
 // scope inputs are hidden / disabled in edit mode.
 
-const PAGE_SIZE = 50;
+const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_SORT_BY = "created_at";
+const DEFAULT_SORT_DIR: SortDir = "desc";
+
+// Backend-whitelisted sort keys. Unknown keys 400, so we clamp a seeded
+// URL value back to the default rather than send garbage.
+const SORT_FIELDS = [
+  "created_at",
+  "endpoint_pattern",
+  "max_requests",
+  "period_seconds",
+  "expires_at",
+] as const;
+type SortField = (typeof SORT_FIELDS)[number];
+
+const PAGE_SIZE_VALUES = [10, 25, 50, 100] as const;
 
 const dtFmt = new Intl.DateTimeFormat(undefined, {
   year: "numeric",
@@ -101,15 +120,61 @@ function rowToForm(row: RateLimitOverride): FormState {
 }
 
 export default function AdminRateLimitOverridesPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <Spinner />
+        </div>
+      }
+    >
+      <AdminRateLimitOverridesPageContent />
+    </Suspense>
+  );
+}
+
+function AdminRateLimitOverridesPageContent() {
   const { user, loading: authLoading } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const initialPageSize = (() => {
+    const raw = searchParams.get("page_size");
+    if (raw === null || raw === "") return DEFAULT_PAGE_SIZE;
+    const n = Number(raw);
+    return (PAGE_SIZE_VALUES as readonly number[]).includes(n)
+      ? n
+      : DEFAULT_PAGE_SIZE;
+  })();
+  const initialOffset = (() => {
+    const raw = searchParams.get("offset");
+    if (raw === null || raw === "") return 0;
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < 0) return 0;
+    return Math.floor(n / initialPageSize) * initialPageSize;
+  })();
+  const initialSortBy: SortField = (() => {
+    const raw = searchParams.get("sort_by");
+    return raw && (SORT_FIELDS as readonly string[]).includes(raw)
+      ? (raw as SortField)
+      : DEFAULT_SORT_BY;
+  })();
+  const initialSortDir: SortDir = (() => {
+    const raw = searchParams.get("sort_dir");
+    return raw === "asc" || raw === "desc" ? raw : DEFAULT_SORT_DIR;
+  })();
+
   const [data, setData] = useState<RateLimitOverrideListResponse | null>(null);
   const [error, setError] = useState("");
   const [fetching, setFetching] = useState(true);
   const [orgIdFilter, setOrgIdFilter] = useState("");
   const [userIdFilter, setUserIdFilter] = useState("");
   const [endpointFilter, setEndpointFilter] = useState("");
-  const [offset, setOffset] = useState(0);
+  const [offset, setOffset] = useState(initialOffset);
+  const [sortBy, setSortBy] = useState<SortField>(initialSortBy);
+  const [sortDir, setSortDir] = useState<SortDir>(initialSortDir);
+  const [pageSize, setPageSize] = useState(initialPageSize);
 
   // Modal state. null = closed, "new" = create, row = edit.
   const [editing, setEditing] = useState<RateLimitOverride | "new" | null>(
@@ -145,8 +210,10 @@ export default function AdminRateLimitOverridesPage() {
     setFetching(true);
     setError("");
     const params = new URLSearchParams({
-      limit: String(PAGE_SIZE),
+      limit: String(pageSize),
       offset: String(offset),
+      sort_by: sortBy,
+      sort_dir: sortDir,
     });
     if (orgIdFilter.trim() && /^[1-9][0-9]*$/.test(orgIdFilter.trim())) {
       params.set("org_id", orgIdFilter.trim());
@@ -167,13 +234,49 @@ export default function AdminRateLimitOverridesPage() {
     } finally {
       setFetching(false);
     }
-  }, [canView, offset, orgIdFilter, userIdFilter, endpointFilter]);
+  }, [canView, offset, orgIdFilter, userIdFilter, endpointFilter, sortBy, sortDir, pageSize]);
 
   useEffect(() => {
     if (!authLoading && canView) {
       void refresh();
     }
   }, [authLoading, canView, refresh]);
+
+  // Clamp an over-offset URL back to the last valid page once data lands.
+  useEffect(() => {
+    if (!data) return;
+    if (offset > 0 && offset >= data.total) {
+      const lastOffset = Math.max(0, (pageCount(data.total, pageSize) - 1) * pageSize);
+      if (lastOffset !== offset) setOffset(lastOffset);
+    }
+  }, [data, offset, pageSize]);
+
+  // Mirror sort + pagination state back to the URL (router.replace,
+  // scroll:false). Filter inputs stay local-only.
+  useEffect(() => {
+    if (authLoading || !canView) return;
+    const params = new URLSearchParams();
+    if (offset > 0) params.set("offset", String(offset));
+    if (sortBy !== DEFAULT_SORT_BY) params.set("sort_by", sortBy);
+    if (sortDir !== DEFAULT_SORT_DIR) params.set("sort_dir", sortDir);
+    if (pageSize !== DEFAULT_PAGE_SIZE) params.set("page_size", String(pageSize));
+    const query = params.toString();
+    const current = searchParams.toString();
+    if (query === current) return;
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authLoading, canView, offset, sortBy, sortDir, pageSize, pathname, router]);
+
+  const handleSort = useCallback(
+    (field: string) => {
+      if (!(SORT_FIELDS as readonly string[]).includes(field)) return;
+      const f = field as SortField;
+      setSortBy(f);
+      setSortDir(f === sortBy ? (sortDir === "asc" ? "desc" : "asc") : "asc");
+      setOffset(0);
+    },
+    [sortBy, sortDir],
+  );
 
   // Fetch the endpoint catalogue once. The dropdown in the modal
   // sources its options from this; failure is non-fatal but the
@@ -399,11 +502,41 @@ export default function AdminRateLimitOverridesPage() {
             <thead>
               <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
                 <th className="px-6 py-3">Scope</th>
-                <th className="px-6 py-3">Endpoint</th>
-                <th className="px-6 py-3">Limit</th>
-                <th className="px-6 py-3">Period</th>
-                <th className="px-6 py-3">Expires</th>
-                <th className="px-6 py-3">Created</th>
+                <SortableHeader
+                  label="Endpoint"
+                  field="endpoint_pattern"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Limit"
+                  field="max_requests"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Period"
+                  field="period_seconds"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Expires"
+                  field="expires_at"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Created"
+                  field="created_at"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
                 <th className="px-6 py-3 text-right">Actions</th>
               </tr>
             </thead>
@@ -471,30 +604,18 @@ export default function AdminRateLimitOverridesPage() {
           </table>
         </div>
 
-        {data && data.total > PAGE_SIZE && (
-          <div className="flex items-center justify-between px-6 py-3 text-xs text-text-muted">
-            <span>
-              {offset + 1}-{Math.min(offset + PAGE_SIZE, data.total)} of{" "}
-              {data.total}
-            </span>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                disabled={offset === 0}
-                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
-              >
-                Prev
-              </button>
-              <button
-                type="button"
-                disabled={offset + PAGE_SIZE >= data.total}
-                onClick={() => setOffset(offset + PAGE_SIZE)}
-                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
-              >
-                Next
-              </button>
-            </div>
+        {data && (data.total > pageSize || offset > 0) && (
+          <div className="px-6">
+            <Pagination
+              page={Math.max(1, Math.floor(offset / pageSize) + 1)}
+              pageSize={pageSize}
+              total={data.total}
+              onPageChange={(n) => setOffset((n - 1) * pageSize)}
+              onPageSizeChange={(n) => {
+                setPageSize(n);
+                setOffset(0);
+              }}
+            />
           </div>
         )}
       </div>

--- a/frontend/app/admin/roles/page.tsx
+++ b/frontend/app/admin/roles/page.tsx
@@ -266,7 +266,9 @@ export default function AdminRolesPage() {
     });
   }, [data]);
 
-  const total = sortedItems.length;
+  // Honor the list envelope's total (equals items length today since roles
+  // are fully listed, but keeps the UI correct if server-side paging lands).
+  const total = data?.total ?? 0;
   const pageItems = useMemo(
     () => paginate(sortedItems, page, pageSize),
     [sortedItems, page, pageSize],

--- a/frontend/app/admin/roles/page.tsx
+++ b/frontend/app/admin/roles/page.tsx
@@ -4,7 +4,9 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
+import Pagination from "@/components/ui/Pagination";
 import Spinner from "@/components/ui/Spinner";
+import { paginate } from "@/lib/hooks/use-table-state";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { hasPlatformPermission } from "@/lib/auth";
@@ -219,6 +221,13 @@ export default function AdminRolesPage() {
   const [fetching, setFetching] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
   const [reloadCounter, setReloadCounter] = useState(0);
+  // Client-side pagination over the fully-listed roles set. Roles are a
+  // tiny, semantically-ordered list (frozen-first, then name) so column
+  // sort is intentionally not surfaced here; the shared <Pagination>
+  // keeps the table consistent with the other admin tables and degrades
+  // to nothing when there is only one page.
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
 
   useEffect(() => {
     if (loading) return;
@@ -256,6 +265,12 @@ export default function AdminRolesPage() {
       return a.name.localeCompare(b.name);
     });
   }, [data]);
+
+  const total = sortedItems.length;
+  const pageItems = useMemo(
+    () => paginate(sortedItems, page, pageSize),
+    [sortedItems, page, pageSize],
+  );
 
   if (loading || !user || !hasPlatformPermission(user, "roles.manage")) {
     return (
@@ -311,7 +326,7 @@ export default function AdminRolesPage() {
                   </td>
                 </tr>
               )}
-              {!fetching && sortedItems.length === 0 && (
+              {!fetching && total === 0 && (
                 <tr>
                   <td
                     colSpan={5}
@@ -322,7 +337,7 @@ export default function AdminRolesPage() {
                 </tr>
               )}
               {!fetching &&
-                sortedItems.map((row) => (
+                pageItems.map((row) => (
                   <tr
                     key={row.id}
                     className="border-b border-border-subtle"
@@ -368,6 +383,21 @@ export default function AdminRolesPage() {
             </tbody>
           </table>
         </div>
+
+        {data && total > pageSize && (
+          <div className="px-6">
+            <Pagination
+              page={page}
+              pageSize={pageSize}
+              total={total}
+              onPageChange={setPage}
+              onPageSizeChange={(n) => {
+                setPageSize(n);
+                setPage(1);
+              }}
+            />
+          </div>
+        )}
       </div>
 
       {showCreate && catalog && (

--- a/frontend/app/admin/subscriptions/page.tsx
+++ b/frontend/app/admin/subscriptions/page.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import HelpAnchor from "@/components/HelpAnchor";
+import Pagination from "@/components/ui/Pagination";
+import SortableHeader from "@/components/ui/SortableHeader";
 import Spinner from "@/components/ui/Spinner";
+import { pageCount } from "@/lib/hooks/use-table-state";
+import type { SortDir } from "@/lib/hooks/use-table-state";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { hasPlatformPermission } from "@/lib/auth";
@@ -25,7 +29,23 @@ import type {
   SubscriptionStatus,
 } from "@/lib/types";
 
-const PAGE_SIZE = 50;
+const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_SORT_BY = "created_at";
+const DEFAULT_SORT_DIR: SortDir = "desc";
+
+// Backend-whitelisted sort keys. Unknown keys 400, so we clamp a seeded
+// URL value back to the default rather than send garbage.
+const SORT_FIELDS = [
+  "org_name",
+  "plan_slug",
+  "status",
+  "trial_end",
+  "current_period_end",
+  "created_at",
+] as const;
+type SortField = (typeof SORT_FIELDS)[number];
+
+const PAGE_SIZE_VALUES = [10, 25, 50, 100] as const;
 
 // Status filter chips. ``null`` represents "All", which clears the
 // filter — kept first in the list so an admin paging through the
@@ -169,8 +189,51 @@ function PlanDistribution({ kpis }: { kpis: AdminSubscriptionKPIs }) {
 }
 
 export default function AdminSubscriptionsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <Spinner />
+        </div>
+      }
+    >
+      <AdminSubscriptionsPageContent />
+    </Suspense>
+  );
+}
+
+function AdminSubscriptionsPageContent() {
   const { user, loading } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const initialPageSize = (() => {
+    const raw = searchParams.get("page_size");
+    if (raw === null || raw === "") return DEFAULT_PAGE_SIZE;
+    const n = Number(raw);
+    return (PAGE_SIZE_VALUES as readonly number[]).includes(n)
+      ? n
+      : DEFAULT_PAGE_SIZE;
+  })();
+  const initialOffset = (() => {
+    const raw = searchParams.get("offset");
+    if (raw === null || raw === "") return 0;
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < 0) return 0;
+    return Math.floor(n / initialPageSize) * initialPageSize;
+  })();
+  const initialSortBy: SortField = (() => {
+    const raw = searchParams.get("sort_by");
+    return raw && (SORT_FIELDS as readonly string[]).includes(raw)
+      ? (raw as SortField)
+      : DEFAULT_SORT_BY;
+  })();
+  const initialSortDir: SortDir = (() => {
+    const raw = searchParams.get("sort_dir");
+    return raw === "asc" || raw === "desc" ? raw : DEFAULT_SORT_DIR;
+  })();
+
   const [data, setData] = useState<AdminSubscriptionListResponse | null>(null);
   const [kpis, setKpis] = useState<AdminSubscriptionKPIs | null>(null);
   const [error, setError] = useState("");
@@ -178,7 +241,10 @@ export default function AdminSubscriptionsPage() {
   const [statusFilter, setStatusFilter] =
     useState<SubscriptionStatus | null>(null);
   const [planFilter, setPlanFilter] = useState<string | null>(null);
-  const [offset, setOffset] = useState(0);
+  const [offset, setOffset] = useState(initialOffset);
+  const [sortBy, setSortBy] = useState<SortField>(initialSortBy);
+  const [sortDir, setSortDir] = useState<SortDir>(initialSortDir);
+  const [pageSize, setPageSize] = useState(initialPageSize);
   const [fetching, setFetching] = useState(true);
 
   useEffect(() => {
@@ -213,8 +279,10 @@ export default function AdminSubscriptionsPage() {
     }
     setFetching(true);
     const params = new URLSearchParams({
-      limit: String(PAGE_SIZE),
+      limit: String(pageSize),
       offset: String(offset),
+      sort_by: sortBy,
+      sort_dir: sortDir,
     });
     if (q.trim()) params.set("q", q.trim());
     if (statusFilter) params.set("status", statusFilter);
@@ -225,7 +293,46 @@ export default function AdminSubscriptionsPage() {
       .then((d) => setData(d))
       .catch((err) => setError(extractErrorMessage(err, "Failed to load")))
       .finally(() => setFetching(false));
-  }, [loading, user, q, statusFilter, planFilter, offset]);
+  }, [loading, user, q, statusFilter, planFilter, offset, sortBy, sortDir, pageSize]);
+
+  // Clamp an over-offset URL back to the last valid page once data lands.
+  useEffect(() => {
+    if (!data) return;
+    if (offset > 0 && offset >= data.total) {
+      const lastOffset = Math.max(0, (pageCount(data.total, pageSize) - 1) * pageSize);
+      if (lastOffset !== offset) setOffset(lastOffset);
+    }
+  }, [data, offset, pageSize]);
+
+  // Mirror sort + pagination state back to the URL (router.replace,
+  // scroll:false). q / status / plan stay local-only — they are
+  // filter chips whose state does not need to survive a refresh here.
+  useEffect(() => {
+    if (loading || !user || !hasPlatformPermission(user, "subscriptions.view")) {
+      return;
+    }
+    const params = new URLSearchParams();
+    if (offset > 0) params.set("offset", String(offset));
+    if (sortBy !== DEFAULT_SORT_BY) params.set("sort_by", sortBy);
+    if (sortDir !== DEFAULT_SORT_DIR) params.set("sort_dir", sortDir);
+    if (pageSize !== DEFAULT_PAGE_SIZE) params.set("page_size", String(pageSize));
+    const query = params.toString();
+    const current = searchParams.toString();
+    if (query === current) return;
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, user, offset, sortBy, sortDir, pageSize, pathname, router]);
+
+  const handleSort = useCallback(
+    (field: string) => {
+      if (!(SORT_FIELDS as readonly string[]).includes(field)) return;
+      const f = field as SortField;
+      setSortBy(f);
+      setSortDir(f === sortBy ? (sortDir === "asc" ? "desc" : "asc") : "asc");
+      setOffset(0);
+    },
+    [sortBy, sortDir],
+  );
 
   const planChips = useMemo(() => {
     if (!kpis) return [] as { slug: string; name: string; count: number }[];
@@ -362,12 +469,48 @@ export default function AdminSubscriptionsPage() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
-                <th className="px-6 py-3">Organization</th>
-                <th className="px-6 py-3">Plan</th>
-                <th className="px-6 py-3">Status</th>
-                <th className="px-6 py-3">Trial ends</th>
-                <th className="px-6 py-3">Period ends</th>
-                <th className="px-6 py-3">Created</th>
+                <SortableHeader
+                  label="Organization"
+                  field="org_name"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Plan"
+                  field="plan_slug"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Status"
+                  field="status"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Trial ends"
+                  field="trial_end"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Period ends"
+                  field="current_period_end"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label="Created"
+                  field="created_at"
+                  activeField={sortBy}
+                  dir={sortDir}
+                  onSort={handleSort}
+                />
               </tr>
             </thead>
             <tbody>
@@ -431,30 +574,18 @@ export default function AdminSubscriptionsPage() {
           </table>
         </div>
 
-        {data && data.total > PAGE_SIZE && (
-          <div className="flex items-center justify-between px-6 py-3 text-xs text-text-muted">
-            <span>
-              {offset + 1}–{Math.min(offset + PAGE_SIZE, data.total)} of{" "}
-              {data.total}
-            </span>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                disabled={offset === 0}
-                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
-              >
-                Prev
-              </button>
-              <button
-                type="button"
-                disabled={offset + PAGE_SIZE >= data.total}
-                onClick={() => setOffset(offset + PAGE_SIZE)}
-                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
-              >
-                Next
-              </button>
-            </div>
+        {data && (data.total > pageSize || offset > 0) && (
+          <div className="px-6">
+            <Pagination
+              page={Math.max(1, Math.floor(offset / pageSize) + 1)}
+              pageSize={pageSize}
+              total={data.total}
+              onPageChange={(n) => setOffset((n - 1) * pageSize)}
+              onPageSizeChange={(n) => {
+                setPageSize(n);
+                setOffset(0);
+              }}
+            />
           </div>
         )}
       </div>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -489,6 +489,7 @@ export interface RoleListItem {
 
 export interface RoleListResponse {
   items: RoleListItem[];
+  total: number;
 }
 
 export interface RoleDetail {

--- a/frontend/tests/app/admin-audit-page.test.tsx
+++ b/frontend/tests/app/admin-audit-page.test.tsx
@@ -24,6 +24,7 @@ const replaceMock = vi.fn();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
   usePathname: () => "/admin/audit",
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 const SUPERADMIN = {

--- a/frontend/tests/app/admin-orgs-page.test.tsx
+++ b/frontend/tests/app/admin-orgs-page.test.tsx
@@ -17,9 +17,11 @@ vi.mock("@/components/auth/AuthProvider", async () => {
 });
 
 const replaceMock = vi.fn();
+const currentSearchParams = new URLSearchParams();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
   usePathname: () => "/admin/orgs",
+  useSearchParams: () => currentSearchParams,
 }));
 
 

--- a/frontend/tests/app/admin-rate-limit-overrides-page.test.tsx
+++ b/frontend/tests/app/admin-rate-limit-overrides-page.test.tsx
@@ -27,6 +27,7 @@ const replaceMock = vi.fn();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
   usePathname: () => "/admin/rate-limit-overrides",
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 const SUPERADMIN = {

--- a/frontend/tests/app/admin-roles-page.test.tsx
+++ b/frontend/tests/app/admin-roles-page.test.tsx
@@ -101,6 +101,7 @@ describe("AdminRolesPage", () => {
               updated_at: "2026-05-07T09:00:00",
             },
           ],
+          total: 1,
         };
       }
       if (path === "/api/v1/admin/permissions") return CATALOG;
@@ -134,7 +135,7 @@ describe("AdminRolesPage", () => {
 
   it("renders for a non-superadmin who carries roles.manage in permissions", async () => {
     apiFetchMock.mockImplementation(async (path: string) => {
-      if (path === "/api/v1/admin/roles") return { items: [] };
+      if (path === "/api/v1/admin/roles") return { items: [], total: 0 };
       if (path === "/api/v1/admin/permissions") return CATALOG;
       throw new Error(`unexpected path: ${path}`);
     });
@@ -163,7 +164,7 @@ describe("AdminRolesPage", () => {
   it("opens the create modal and submits a new role", async () => {
     apiFetchMock.mockImplementation(async (path: string, init?: RequestInit) => {
       if (path === "/api/v1/admin/roles" && (!init || init.method === undefined)) {
-        return { items: [] };
+        return { items: [], total: 0 };
       }
       if (path === "/api/v1/admin/permissions") return CATALOG;
       if (path === "/api/v1/admin/roles" && init?.method === "POST") {

--- a/frontend/tests/app/admin-subscriptions-page.test.tsx
+++ b/frontend/tests/app/admin-subscriptions-page.test.tsx
@@ -8,6 +8,8 @@ import { apiFetch } from "@/lib/api";
 
 vi.mock("next/navigation", () => ({
   useRouter: vi.fn(),
+  usePathname: () => "/admin/subscriptions",
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock("@/components/AppShell", () => ({


### PR DESCRIPTION
## What
Extends the merged #389 server-side sort + shared pagination pattern (Admin Users as reference) to the five admin-group tables. Per table: backend gains `sort_by`/`sort_dir` resolved against a **closed sort-key whitelist** via `list_query.resolve_order_by` (id-desc tiebreaker, 400 on unknown key/dir, org-scoped counts); frontend wires shared `<SortableHeader>` + `<Pagination>` with URL-synced sort/offset/page-size state.

## Per table
- **orgs** — sort on name/created/plan/status/user-count/active-count/newest-member.
- **subscriptions** — sort on org/plan/status/created/trial-end/period-end.
- **audit** — sort on when/event-type/outcome/actor/target-org.
- **rate-limit-overrides** — sort on endpoint/limit/period/expires/created.
- **roles** — smallest: no column sort (semantic frozen-first order, documented in code); added `total` to the endpoint + `RoleListResponse` schema and wired shared `<Pagination>`. Consumers updated (`lib/types.ts` + test mocks).

Filters (status/plan/event-type/org-id) kept as local state — only sort + pagination are URL-synced, matching the additive scope.

## Verification
Backend: 116 tests pass across the changed routers/services, each with asc/desc + default + invalid-sort(400) cases. Frontend: `tsc` clean, 102 admin tests pass, design-tokens pass.

System/settings tables (plans/announcements/members/AI providers) are intentionally a separate follow-up PR.