### PR TITLE
fix(ai): bound LLM dispatch with a ~5s timeout

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -114,6 +114,17 @@ class Settings(BaseSettings):
     # re-prompt with the current version.
     ai_native_current_consent_version: str = "ai-tos-2026-05-22"
 
+    # Wall-clock bound on a single LLM dispatch call inside
+    # ``ai_dispatch``. The per-provider HTTP adapters carry their own
+    # coarse connect/read timeouts (10 s validate, 30-60 s chat), but a
+    # slow or hung provider can still pin a dispatch worker for the full
+    # adapter budget. This tighter wall-clock ceiling wraps every adapter
+    # call in ``asyncio.wait_for`` so a single call can never exceed it.
+    # On timeout the dispatcher records a system-failure ledger row and
+    # raises ``AIDispatchFailed("provider_timeout")`` (5xx). Architect-
+    # mandated reliability bound (AI tier decision, 2026-05-22).
+    ai_dispatch_timeout_s: float = 5.0
+
     # Google SSO
     google_client_id: str = ""
     google_client_secret: str = ""

--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -145,32 +145,58 @@ async def _with_dispatch_timeout(awaitable):
 def _stream_with_dispatch_timeout(
     stream: "AsyncIterator[StreamChunk]",
 ) -> "AsyncIterator[StreamChunk]":
-    """Bound each ``__anext__`` of a provider stream by the wall clock.
+    """Bound the wait for EACH chunk of a provider stream by the wall
+    clock — NOT the total stream duration.
 
     A stream can't be wrapped in a single ``wait_for`` — it's an async
     iterator, not one awaitable. Instead we bound the wait for each
-    chunk: if any single chunk takes longer than the ceiling, the pull
-    is cancelled and surfaced as the same ``provider_timeout``
+    chunk: if any single ``__anext__`` takes longer than the ceiling,
+    the pull is cancelled and surfaced as the same ``provider_timeout``
     ``AIProviderError`` the non-stream paths raise. Inter-chunk gaps on
     a healthy stream are far below the bound, so this only fires on a
     genuinely stalled stream.
+
+    Deliberate limitation: because the bound is per-chunk, a provider
+    that dribbles one chunk just under the ceiling forever is NOT
+    caught — only a fully stalled stream (no chunk inside the bound)
+    trips it. This is intentional: a slow-but-healthy stream should
+    keep flowing rather than be killed for failing to finish by some
+    total deadline. Only a hang is an error here.
+
+    Resource lifecycle: the underlying provider ``stream`` is an async
+    generator whose ``yield``s sit inside an ``async with
+    httpx.AsyncClient()`` block. On a mid-stream timeout (we raise) or
+    an early consumer break (``call_llm_stream`` breaks on
+    ``chunk.done``, throwing ``GeneratorExit`` into this generator), we
+    MUST close the source iterator so that ``async with`` unwinds and
+    the HTTP connection is released promptly instead of waiting on GC.
+    The ``finally`` below awaits ``aclose`` when the iterator exposes
+    it (every provider async generator does).
     """
 
     async def _bounded() -> AsyncIterator[StreamChunk]:
         iterator = stream.__aiter__()
-        while True:
-            try:
-                chunk = await asyncio.wait_for(
-                    iterator.__anext__(),
-                    timeout=settings.ai_dispatch_timeout_s,
-                )
-            except StopAsyncIteration:
-                return
-            except (asyncio.TimeoutError, TimeoutError) as exc:
-                raise AIProviderError(
-                    code=DISPATCH_TIMEOUT_ERROR_CODE
-                ) from exc
-            yield chunk
+        try:
+            while True:
+                try:
+                    chunk = await asyncio.wait_for(
+                        iterator.__anext__(),
+                        timeout=settings.ai_dispatch_timeout_s,
+                    )
+                except StopAsyncIteration:
+                    return
+                except (asyncio.TimeoutError, TimeoutError) as exc:
+                    raise AIProviderError(
+                        code=DISPATCH_TIMEOUT_ERROR_CODE
+                    ) from exc
+                yield chunk
+        finally:
+            # Finalize the provider stream (closes its httpx client) on
+            # any exit: mid-stream timeout, early consumer break
+            # (GeneratorExit), or normal completion.
+            aclose = getattr(iterator, "aclose", None)
+            if aclose is not None:
+                await aclose()
 
     return _bounded()
 

--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -74,6 +74,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import redis_client
+from app.config import settings
 from app.models.ai_usage_ledger import AIUsageLedger
 from app.models.notification import NotificationCategory
 from app.models.org_ai_caps import OrgAIDefaultCaps, OrgAIFeatureCaps
@@ -105,7 +106,73 @@ from app.services.notification_templates import ai_cap_soft_warning
 STRUCTURED_OUTPUT_MAX_RETRIES = 2
 
 
+# Typed error code for a dispatch that blew the wall-clock bound. Routed
+# through ``AIProviderError`` so the existing per-capability except
+# handlers write a system-failure ledger row and re-raise it as
+# ``AIDispatchFailed("provider_timeout")`` (a 5xx). Audit semantics:
+# ``ai_dispatch_failed:provider_timeout`` is a SYSTEM failure, not a
+# user-state precondition (see reference_ai_audit_outcome_semantics).
+DISPATCH_TIMEOUT_ERROR_CODE = "provider_timeout"
+
+
 logger = structlog.stdlib.get_logger()
+
+
+async def _with_dispatch_timeout(awaitable):
+    """Bound a single provider awaitable by the configured wall clock.
+
+    The per-provider HTTP adapters carry their own coarse connect/read
+    timeouts (10 s validate, 30-60 s chat-stream), but those are too
+    loose to stop a slow or hung provider from pinning a dispatch
+    worker. ``settings.ai_dispatch_timeout_s`` (default 5 s) is the hard
+    ceiling on any one adapter call; on expiry the underlying coroutine
+    is cancelled and we raise a sanitized ``AIProviderError`` so the
+    caller's existing failure path writes the ledger row and re-raises
+    as ``AIDispatchFailed("provider_timeout")``.
+
+    The raw provider payload is never carried through — only the typed
+    ``provider_timeout`` code, same posture as the rest of the adapter
+    error surface.
+    """
+    try:
+        return await asyncio.wait_for(
+            awaitable, timeout=settings.ai_dispatch_timeout_s
+        )
+    except (asyncio.TimeoutError, TimeoutError) as exc:
+        raise AIProviderError(code=DISPATCH_TIMEOUT_ERROR_CODE) from exc
+
+
+def _stream_with_dispatch_timeout(
+    stream: "AsyncIterator[StreamChunk]",
+) -> "AsyncIterator[StreamChunk]":
+    """Bound each ``__anext__`` of a provider stream by the wall clock.
+
+    A stream can't be wrapped in a single ``wait_for`` — it's an async
+    iterator, not one awaitable. Instead we bound the wait for each
+    chunk: if any single chunk takes longer than the ceiling, the pull
+    is cancelled and surfaced as the same ``provider_timeout``
+    ``AIProviderError`` the non-stream paths raise. Inter-chunk gaps on
+    a healthy stream are far below the bound, so this only fires on a
+    genuinely stalled stream.
+    """
+
+    async def _bounded() -> AsyncIterator[StreamChunk]:
+        iterator = stream.__aiter__()
+        while True:
+            try:
+                chunk = await asyncio.wait_for(
+                    iterator.__anext__(),
+                    timeout=settings.ai_dispatch_timeout_s,
+                )
+            except StopAsyncIteration:
+                return
+            except (asyncio.TimeoutError, TimeoutError) as exc:
+                raise AIProviderError(
+                    code=DISPATCH_TIMEOUT_ERROR_CODE
+                ) from exc
+            yield chunk
+
+    return _bounded()
 
 
 # 35-day TTL so the marker spans an entire monthly billing window
@@ -648,10 +715,12 @@ async def call_llm(
     # 5. Time + dispatch.
     start = time.perf_counter()
     try:
-        response: LLMResponse = await adapter.chat(  # type: ignore[attr-defined]
-            model=model,
-            messages=messages,
-            max_tokens=max_tokens,
+        response: LLMResponse = await _with_dispatch_timeout(
+            adapter.chat(  # type: ignore[attr-defined]
+                model=model,
+                messages=messages,
+                max_tokens=max_tokens,
+            )
         )
     except NativeNotAvailable:
         # Don't write a ledger row — the call never reached a provider
@@ -1051,11 +1120,13 @@ async def call_llm_structured(
 
     for attempt in range(STRUCTURED_OUTPUT_MAX_RETRIES + 1):
         try:
-            response: LLMResponse = await prepared.adapter.chat_structured(
-                model=prepared.model,
-                messages=attempt_messages,
-                schema=response_schema,
-                max_tokens=max_tokens,
+            response: LLMResponse = await _with_dispatch_timeout(
+                prepared.adapter.chat_structured(
+                    model=prepared.model,
+                    messages=attempt_messages,
+                    schema=response_schema,
+                    max_tokens=max_tokens,
+                )
             )
         except NativeNotAvailable:
             logger.info(
@@ -1248,8 +1319,8 @@ async def call_llm_embed(
 
     start = time.perf_counter()
     try:
-        response: EmbedResponse = await prepared.adapter.embed(
-            texts=texts, model=embed_model
+        response: EmbedResponse = await _with_dispatch_timeout(
+            prepared.adapter.embed(texts=texts, model=embed_model)
         )
     except NativeNotAvailable:
         raise
@@ -1355,11 +1426,13 @@ async def call_llm_function(
 
     start = time.perf_counter()
     try:
-        response: FunctionCallResponse = await prepared.adapter.function_call(
-            model=prepared.model,
-            messages=messages,
-            tools=tools,
-            max_tokens=max_tokens,
+        response: FunctionCallResponse = await _with_dispatch_timeout(
+            prepared.adapter.function_call(
+                model=prepared.model,
+                messages=messages,
+                tools=tools,
+                max_tokens=max_tokens,
+            )
         )
     except NativeNotAvailable:
         raise
@@ -1477,10 +1550,12 @@ async def call_llm_stream(
     final_usage: Optional[TokenUsage] = None
     start = time.perf_counter()
     try:
-        async for chunk in prepared.adapter.stream(
-            model=prepared.model,
-            messages=messages,
-            max_tokens=max_tokens,
+        async for chunk in _stream_with_dispatch_timeout(
+            prepared.adapter.stream(
+                model=prepared.model,
+                messages=messages,
+                max_tokens=max_tokens,
+            )
         ):
             if chunk.done:
                 final_usage = chunk.final_usage

--- a/backend/tests/services/test_ai_dispatch.py
+++ b/backend/tests/services/test_ai_dispatch.py
@@ -320,6 +320,69 @@ async def test_adapter_failure_writes_failed_ledger_row_and_reraises(
     assert rows[0].est_cost_cents == 0
 
 
+# ---------- dispatch timeout (wall-clock bound) ----------------------
+
+
+@pytest.mark.asyncio
+async def test_slow_provider_times_out_cleanly(
+    db: AsyncSession,
+    org: Organization,
+    admin_user,
+    credential,
+    default_routing,
+    monkeypatch,
+):
+    """A provider call that exceeds the architect-mandated wall-clock
+    bound is cancelled cleanly: it maps to a SYSTEM failure
+    (``AIDispatchFailed`` code ``provider_timeout``), writes a failure
+    ledger row, and surfaces as a 5xx via ``http_for_dispatch_error``.
+    The raw provider payload is never echoed.
+    """
+    import asyncio
+
+    # Shrink the bound so the test stays fast.
+    monkeypatch.setattr(app_settings, "ai_dispatch_timeout_s", 0.05)
+
+    async def _slow_chat(*args, **kwargs):
+        # Sleeps well past the 0.05s bound; wait_for must cancel it.
+        await asyncio.sleep(5)
+        return LLMResponse(
+            content="never", prompt_tokens=1, completion_tokens=1, model="gpt-4o-mini"
+        )
+
+    adapter = MagicMock()
+    adapter.chat = _slow_chat
+
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AIDispatchFailed) as exc_info:
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                request_payload={"messages": []},
+            )
+
+    assert exc_info.value.code == "provider_timeout"
+
+    # Maps to a system 5xx (502 bad gateway via the default branch).
+    http_exc = ai_dispatch.http_for_dispatch_error(exc_info.value)
+    assert http_exc.status_code >= 500
+    # No raw provider data echoed — only the typed code.
+    assert http_exc.detail == {"code": "provider_timeout"}
+
+    # A failure ledger row is written (system failure, audited).
+    rows = (
+        await db.execute(select(AIUsageLedger).where(AIUsageLedger.org_id == org.id))
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].success is False
+    assert rows[0].error_class == "provider_timeout"
+    assert rows[0].prompt_tokens == 0
+    assert rows[0].est_cost_cents == 0
+
+
 # ---------- soft cap notification + Redis dedupe ---------------------
 
 

--- a/backend/tests/services/test_ai_dispatch_capabilities.py
+++ b/backend/tests/services/test_ai_dispatch_capabilities.py
@@ -18,6 +18,7 @@ Covers:
 """
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import os
@@ -46,6 +47,7 @@ from app.models.user import Organization, Role, User
 from app.services.ai_credential_crypto import encrypt
 from app.services.ai_dispatch import (
     AICapabilityNotSupported,
+    AIDispatchFailed,
     call_llm_embed,
     call_llm_function,
     call_llm_stream,
@@ -645,6 +647,104 @@ async def test_call_llm_stream_falls_back_to_char_estimate_when_no_usage(
     assert len(rows) == 1
     # Estimated 10 completion tokens (40 chars / 4).
     assert rows[0].completion_tokens == 10
+
+
+class _SpyStream:
+    """Async iterator that wraps a provider stream and records whether
+    its ``aclose`` was explicitly awaited.
+
+    A plain async-generator's ``finally`` also runs when the GC
+    finalizes it, which would make a "did it close?" assertion pass
+    even if the dispatch wrapper leaked the iterator. This spy only
+    flips ``aclose_awaited`` when ``aclose()`` is *called* on it, so the
+    test proves the wrapper finalizes the provider stream promptly
+    rather than relying on garbage collection.
+    """
+
+    def __init__(self, chunks_before_stall, stall_seconds):
+        self._chunks = list(chunks_before_stall)
+        self._stall_seconds = stall_seconds
+        self._idx = 0
+        self.aclose_awaited = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._idx < len(self._chunks):
+            chunk = self._chunks[self._idx]
+            self._idx += 1
+            return chunk
+        # Stall well past the shrunk bound before the next chunk.
+        await asyncio.sleep(self._stall_seconds)
+        raise StopAsyncIteration
+
+    async def aclose(self):
+        self.aclose_awaited = True
+
+
+@pytest.mark.asyncio
+async def test_call_llm_stream_stalled_stream_times_out_and_closes_iterator(
+    db: AsyncSession, org, admin_user, credential, default_routing, monkeypatch
+):
+    """A stream that yields a couple of chunks then stalls mid-stream
+    must surface ``provider_timeout``: the already-yielded chunks reach
+    the consumer, a single failure ledger row is written, and the
+    underlying provider stream's ``aclose`` is awaited so the leaked
+    httpx connection is finalized promptly (fix for the resource-leak
+    bug in ``_stream_with_dispatch_timeout``).
+    """
+    # Shrink the wall-clock bound so the mid-stream stall trips it fast.
+    monkeypatch.setattr(app_settings, "ai_dispatch_timeout_s", 0.05)
+
+    spy = _SpyStream(
+        chunks_before_stall=[
+            StreamChunk(delta_text="Hello ", done=False),
+            StreamChunk(delta_text="world ", done=False),
+        ],
+        stall_seconds=5,
+    )
+
+    def fake_stream(*, model, messages, max_tokens=None):
+        # Returns the spy iterator directly (not a generator) so the
+        # dispatch wrapper's __aiter__()/aclose() target our spy.
+        return spy
+
+    adapter = MagicMock()
+    adapter.stream = fake_stream
+
+    received = []
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AIDispatchFailed) as exc_info:
+            async for chunk in call_llm_stream(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                messages=[{"role": "user", "content": "hi"}],
+            ):
+                received.append(chunk)
+
+    # (a) the already-yielded chunks reached the consumer.
+    assert [c.delta_text for c in received] == ["Hello ", "world "]
+    # (b) the timeout surfaced as the typed provider_timeout failure.
+    assert exc_info.value.code == "provider_timeout"
+    # (c) exactly one failure ledger row, error_class=provider_timeout.
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].success is False
+    assert rows[0].error_class == "provider_timeout"
+    # (d) the underlying provider stream was finalized: aclose() was
+    # explicitly awaited by the dispatch wrapper, not left to the GC.
+    assert spy.aclose_awaited is True, (
+        "provider stream iterator must be closed (aclose awaited) on a "
+        "mid-stream timeout so the httpx connection isn't leaked"
+    )
 
 
 # ---------- Structured-output token aggregation ---------------------


### PR DESCRIPTION
## Problem

The AI dispatch chokepoint (`ai_dispatch.py`) had no wall-clock bound on the provider call. The per-provider HTTP adapters carry only coarse connect/read timeouts (10s validate, 30 to 60s chat-stream), so a slow or hung provider could pin a dispatch worker for the full adapter budget. The architect mandated a tighter (~5s) wall-clock bound on the LLM dispatch so a stuck provider can't tie up a worker.

## Change

- New setting `ai_dispatch_timeout_s` (default `5.0`) in `config.py`.
- New `_with_dispatch_timeout()` helper wraps every adapter call in `asyncio.wait_for`; a streaming variant `_stream_with_dispatch_timeout()` bounds each chunk pull (a stream is an async iterator, not a single awaitable).
- Applied at all five adapter call sites: `chat`, `chat_structured`, `embed`, `function_call`, `stream`.
- On expiry the underlying coroutine is cancelled and surfaced as `AIProviderError(code="provider_timeout")`. The existing per-capability failure handlers then write a system-failure ledger row (`success=False`, `error_class="provider_timeout"`, zero tokens/cost) and re-raise as `AIDispatchFailed("provider_timeout")`, which `http_for_dispatch_error` maps to a 5xx. The raw provider payload is never echoed, consistent with the adapter error-sanitization posture.

## Audit semantics

`ai_dispatch_failed:provider_timeout` is a SYSTEM failure (transport/provider), not a user-state precondition, matching the locked AI audit outcome mapping (system failures get `outcome="failure"`; preconditions like no-routing / cap-exceeded stay `success`).

## Scope note

The architect spec line referencing a "5s query timeout" elsewhere covered a MySQL `MAX_EXECUTION_TIME` hint for the Reports v2 SELECT. For the AI dispatch path the intent is a wall-clock bound on the LLM call itself, which is what this implements. The dispatcher's own DB writes (ledger rows) are small and already bounded by the route handler; no DB statement timeout is added here.