### PR TITLE
fix(ai): refuse refine estimate at hard spend cap

### DIFF
--- a/backend/app/services/ai_forecast_refine_service.py
+++ b/backend/app/services/ai_forecast_refine_service.py
@@ -688,18 +688,26 @@ async def estimate_refine(
     - The org has no remaining hard-cap budget for this call
       (``reason="ai_cap_exceeded"``)
 
-    Spend-cap pre-check: this mirrors the hard-cap enforcement in
-    ``ai_dispatch.call_llm_structured`` so the quoted estimate and the
-    real dispatch agree. Dispatch refuses (``AICapExceeded``) when the
-    org's already-spent cost for the period is at or over the hard cap
-    (``cost_so_far >= hard_cap``). The estimate refuses on that same
-    boundary AND when the *projected* cost of this call would push the
-    period total past the hard cap (``cost_so_far + est_cost >
-    hard_cap``), i.e. there isn't enough remaining budget to run it. That
-    way the UI never offers Confirm when Confirm would hard-fail at the
-    dispatch chokepoint. Caps + spend are resolved with the same
-    ``ROUTING_KEY`` feature key and calendar-month window the dispatcher
-    uses.
+    Spend-cap pre-check: this estimate is INTENTIONALLY STRICTER than the
+    dispatcher. It mirrors dispatch's hard-cap boundary AND adds a
+    projected-cost gate that dispatch does not pre-check today. Dispatch
+    (``ai_dispatch.call_llm_structured``) refuses (``AICapExceeded``) only
+    when the org's already-spent cost for the period is at or over the
+    hard cap (``cost_so_far >= hard_cap``); it has no projected-cost gate,
+    so a call that fits under the cap at start but overspends it once run
+    would still proceed. The estimate refuses on that same
+    ``cost_so_far >= hard_cap`` boundary AND additionally when this call's
+    *projected* cost would push the period total past the hard cap
+    (``cost_so_far + est_cost > hard_cap``), i.e. there isn't enough
+    remaining budget to run it without overspending. The goal is to stop
+    the UI offering Confirm for a call that would overspend.
+
+    This is BEST-EFFORT, not a guarantee that Confirm never hard-fails:
+    spend can change between this estimate and the actual dispatch
+    (concurrent calls, ledger writes landing in between), so the dispatch
+    chokepoint remains the authority. Caps + spend are resolved with the
+    same ``ROUTING_KEY`` feature key and calendar-month window the
+    dispatcher uses.
     """
     baseline = await forecast_service.compute_forecast(
         db, org_id, period_start=period_start
@@ -749,11 +757,14 @@ async def estimate_refine(
 
     # Spend-cap pre-check. Resolve the effective hard cap and the
     # period's already-spent cost through the SAME helpers the dispatcher
-    # uses (same ROUTING_KEY feature key, same calendar-month window) so
-    # estimate and execution can't disagree. Refuse when the org is at or
-    # over the hard cap (mirrors dispatch's ``cost_so_far >= hard_cap``),
-    # or when this call's projected cost would push the period total past
-    # the hard cap (no remaining budget for it).
+    # uses (same ROUTING_KEY feature key, same calendar-month window).
+    # This is INTENTIONALLY STRICTER than dispatch: dispatch only refuses
+    # on ``cost_so_far >= hard_cap`` (no projected-cost gate today), so we
+    # refuse on that same boundary AND when this call's projected cost
+    # would push the period total past the hard cap (which dispatch would
+    # otherwise run, overspending). Best-effort: spend can shift between
+    # here and dispatch (concurrent calls, ledger writes), so the dispatch
+    # chokepoint stays the authority.
     resolved = await ai_dispatch._resolve_caps(
         db, org_id=org_id, feature_key=ROUTING_KEY
     )

--- a/backend/app/services/ai_forecast_refine_service.py
+++ b/backend/app/services/ai_forecast_refine_service.py
@@ -685,12 +685,21 @@ async def estimate_refine(
     Returns a ``ForecastRefineEstimate`` with ``can_proceed=False`` when:
     - No transaction history exists for the org (``reason="insufficient_history"``)
     - No routing is configured (``reason="ai_routing_not_configured"``)
+    - The org has no remaining hard-cap budget for this call
+      (``reason="ai_cap_exceeded"``)
 
-    KNOWN LIMITATION: checks routing but does NOT pre-check the AI spend
-    cap, so an org at its hard cap can see ``can_proceed=True``. On
-    Confirm the dispatch enforces the cap and returns a graceful baseline
-    fallback with ``fallback_reason="ai_cap_exceeded"`` -- no overspend
-    occurs. Follow-up: add a cap pre-check here.
+    Spend-cap pre-check: this mirrors the hard-cap enforcement in
+    ``ai_dispatch.call_llm_structured`` so the quoted estimate and the
+    real dispatch agree. Dispatch refuses (``AICapExceeded``) when the
+    org's already-spent cost for the period is at or over the hard cap
+    (``cost_so_far >= hard_cap``). The estimate refuses on that same
+    boundary AND when the *projected* cost of this call would push the
+    period total past the hard cap (``cost_so_far + est_cost >
+    hard_cap``), i.e. there isn't enough remaining budget to run it. That
+    way the UI never offers Confirm when Confirm would hard-fail at the
+    dispatch chokepoint. Caps + spend are resolved with the same
+    ``ROUTING_KEY`` feature key and calendar-month window the dispatcher
+    uses.
     """
     baseline = await forecast_service.compute_forecast(
         db, org_id, period_start=period_start
@@ -736,10 +745,39 @@ async def estimate_refine(
     cost = estimate_cost_cents(
         model=model, prompt_tokens=est_prompt, completion_tokens=est_out
     )
+    est_cost = int(cost)
+
+    # Spend-cap pre-check. Resolve the effective hard cap and the
+    # period's already-spent cost through the SAME helpers the dispatcher
+    # uses (same ROUTING_KEY feature key, same calendar-month window) so
+    # estimate and execution can't disagree. Refuse when the org is at or
+    # over the hard cap (mirrors dispatch's ``cost_so_far >= hard_cap``),
+    # or when this call's projected cost would push the period total past
+    # the hard cap (no remaining budget for it).
+    resolved = await ai_dispatch._resolve_caps(
+        db, org_id=org_id, feature_key=ROUTING_KEY
+    )
+    if resolved.hard_cap_cents is not None:
+        cost_so_far = await ai_dispatch._aggregate_cost_cents(
+            db, org_id=org_id, since=ai_dispatch._month_start()
+        )
+        if (
+            cost_so_far >= resolved.hard_cap_cents
+            or cost_so_far + est_cost > resolved.hard_cap_cents
+        ):
+            return ForecastRefineEstimate(
+                est_prompt_tokens=est_prompt,
+                est_output_tokens=est_out,
+                est_cost_cents=est_cost,
+                duration_band=_duration_band(scope),
+                can_proceed=False,
+                reason="ai_cap_exceeded",
+            )
+
     return ForecastRefineEstimate(
         est_prompt_tokens=est_prompt,
         est_output_tokens=est_out,
-        est_cost_cents=int(cost),
+        est_cost_cents=est_cost,
         duration_band=_duration_band(scope),
         can_proceed=True,
         reason=None,

--- a/backend/tests/services/test_ai_forecast_refine_service.py
+++ b/backend/tests/services/test_ai_forecast_refine_service.py
@@ -21,6 +21,8 @@ from sqlalchemy.pool import StaticPool
 
 from app.config import settings as app_settings
 from app.models import Base
+from app.models.ai_usage_ledger import AIUsageLedger
+from app.models.org_ai_caps import OrgAIDefaultCaps
 from app.models.org_ai_credential import AiProvider, OrgAICredential
 from app.models.org_ai_routing import OrgAIDefaultRouting
 from app.models.user import Organization, Role, User
@@ -250,3 +252,137 @@ async def test_estimate_refine_no_history_returns_insufficient_history(
     assert called["dispatch"] is False
     assert est.can_proceed is False
     assert est.reason == "insufficient_history"
+
+
+# ---------- spend-cap pre-check on estimate ---------------------------
+#
+# These mirror the hard-cap enforcement in ai_dispatch.call_llm_structured
+# (cost_so_far >= hard_cap -> refuse) so the /estimate preflight and the
+# real dispatch agree on whether a refine can run. The estimate must also
+# refuse when the projected cost would push the org over the remaining
+# budget, so the UI never offers Confirm when Confirm would hard-fail.
+
+
+def _patch_estimate_internals(monkeypatch, *, est_cost_cents: int):
+    """Stub the no-DB estimate inputs so the cap pre-check is the only
+    variable under test. compute_forecast / history / index are faked, and
+    estimate_cost_cents is pinned to a deterministic projected cost.
+    """
+    async def fake_compute_forecast(db, org_id, period_start=None):
+        return _FAKE_BASELINE
+
+    async def fake_build_history(db, *, org_id, period_start, months=12):
+        return _FAKE_HISTORY
+
+    async def fake_category_index(db, *, org_id):
+        return {1: "Rent", 2: "Food"}
+
+    monkeypatch.setattr(svc.forecast_service, "compute_forecast", fake_compute_forecast)
+    monkeypatch.setattr(svc, "_build_category_history", fake_build_history)
+    monkeypatch.setattr(svc, "_category_index", fake_category_index)
+    monkeypatch.setattr(svc, "estimate_cost_cents", lambda **kw: est_cost_cents)
+
+
+async def _seed_cap_and_spend(
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    hard_cap_cents: int,
+    spent_cents: int,
+):
+    """Create an org hard cap and a settled ledger row of ``spent_cents``."""
+    db_session.add(
+        OrgAIDefaultCaps(
+            org_id=org_id, soft_cap_cents=None, hard_cap_cents=hard_cap_cents
+        )
+    )
+    if spent_cents > 0:
+        db_session.add(
+            AIUsageLedger(
+                org_id=org_id,
+                credential_id=None,
+                feature_key=svc.ROUTING_KEY,
+                model="gpt-4o-mini",
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                est_cost_cents=spent_cents,
+                latency_ms=0,
+                success=True,
+            )
+        )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_estimate_refine_at_hard_cap_refuses(
+    monkeypatch, db_session: AsyncSession, seeded_org: Organization
+):
+    """Org sitting exactly AT its hard cap must get can_proceed=False, even
+    if the projected cost is tiny. Boundary mirrors dispatch's
+    ``cost_so_far >= hard_cap`` (remaining == 0).
+    """
+    _patch_estimate_internals(monkeypatch, est_cost_cents=1)
+    await _seed_cap_and_spend(
+        db_session, org_id=seeded_org.id, hard_cap_cents=500, spent_cents=500
+    )
+
+    est = await svc.estimate_refine(
+        db_session,
+        org_id=seeded_org.id,
+        period_start=None,
+        timeframe_months=6,
+        scope=Scope.TOP_20,
+    )
+    assert est.can_proceed is False
+    assert est.reason == "ai_cap_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_estimate_refine_projected_cost_over_remaining_refuses(
+    monkeypatch, db_session: AsyncSession, seeded_org: Organization
+):
+    """Org has headroom, but the projected cost is larger than what's left
+    before the hard cap. Confirm would hard-fail, so the estimate refuses.
+
+    remaining = 500 - 450 = 50; projected = 80 > 50 -> refuse.
+    """
+    _patch_estimate_internals(monkeypatch, est_cost_cents=80)
+    await _seed_cap_and_spend(
+        db_session, org_id=seeded_org.id, hard_cap_cents=500, spent_cents=450
+    )
+
+    est = await svc.estimate_refine(
+        db_session,
+        org_id=seeded_org.id,
+        period_start=None,
+        timeframe_months=6,
+        scope=Scope.TOP_20,
+    )
+    assert est.can_proceed is False
+    assert est.reason == "ai_cap_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_estimate_refine_ample_budget_allows(
+    monkeypatch, db_session: AsyncSession, seeded_org: Organization
+):
+    """Org with plenty of remaining budget can proceed (regression).
+
+    remaining = 5000 - 100 = 4900; projected = 80 << 4900 -> allow.
+    """
+    _patch_estimate_internals(monkeypatch, est_cost_cents=80)
+    await _seed_cap_and_spend(
+        db_session, org_id=seeded_org.id, hard_cap_cents=5000, spent_cents=100
+    )
+
+    est = await svc.estimate_refine(
+        db_session,
+        org_id=seeded_org.id,
+        period_start=None,
+        timeframe_months=6,
+        scope=Scope.TOP_20,
+    )
+    assert est.can_proceed is True
+    assert est.reason is None
+    assert est.est_cost_cents == 80


### PR DESCRIPTION
## Problem

The AI forecast-refine cost-estimate preflight (`estimate_refine`) could return `can_proceed=true` even when the org was already at or over its AI hard spend cap. The UI would then offer Confirm on a refine that the dispatcher rejects immediately (`AICapExceeded`), wasting the user's click and contradicting the quoted estimate.

## Fix

`estimate_refine` now runs a spend-cap pre-check that mirrors the hard-cap enforcement in `ai_dispatch.call_llm_structured`. It resolves the effective hard cap and the period's already-spent cost through the same helpers the dispatcher uses (`_resolve_caps` with `ROUTING_KEY`, `_aggregate_cost_cents` over the same calendar-month window), then returns `can_proceed=false` with `reason="ai_cap_exceeded"` when:

- the org is at or over the hard cap (`cost_so_far >= hard_cap`, mirrors dispatch exactly, covers the at-cap / remaining-zero boundary), or
- this call's projected cost would push the period total past the hard cap (`cost_so_far + est_cost > hard_cap`, no remaining budget for the call).

Estimate and dispatch now agree, so the UI never offers Confirm when Confirm would hard-fail.

## Tests

Added three service tests covering org exactly at the cap, org with remaining budget just below the estimate, and org with ample budget (regression). All pass alongside the existing service, router, schema, and dispatch suites.
