### PR TITLE
fix(logging): attach client_ip on anonymous routes

### DIFF
--- a/backend/app/middleware/request_context.py
+++ b/backend/app/middleware/request_context.py
@@ -25,6 +25,15 @@ Per HTTP request, this middleware:
   ``request.state.request_id`` works in any FastAPI handler.
 - Echoes the value back as ``X-Request-Id`` on the response so
   callers (frontend, ops) can correlate.
+- Resolves the real client IP via the shared ``get_client_ip``
+  helper and binds it onto structlog contextvars as ``client_ip``.
+  Done HERE (not in ``deps.get_current_user``) so it lands on EVERY
+  access-log line, including anonymous routes like
+  ``/api/v1/auth/register`` and ``/api/v1/auth/login`` that never
+  resolve the auth dependency. The helper applies the same DO ingress
+  precedence (``do-connecting-ip``) and trusted-proxy XFF walk that
+  authed routes use for audit logging, so anonymous bot-signup waves
+  can be IP-clustered the same way.
 
 User / org / role context is bound LATER, inside
 ``deps.get_current_user``. With pure-ASGI semantics here, that
@@ -36,7 +45,10 @@ import re
 import uuid
 
 import structlog
+from starlette.requests import Request
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from app.rate_limit import get_client_ip
 
 
 # Bounded length on the inbound side. Past this we generate a fresh
@@ -103,6 +115,15 @@ class RequestContextMiddleware:
 
         request_id = _coerce_request_id(inbound)
         structlog.contextvars.bind_contextvars(request_id=request_id)
+
+        # Resolve the real client IP and bind it for every request,
+        # authed or not. ``get_client_ip`` only reads ``request.headers``
+        # and ``request.client``, both derivable from the ASGI scope
+        # without consuming ``receive`` — so a header-only ``Request``
+        # is sufficient and keeps the body stream untouched.
+        structlog.contextvars.bind_contextvars(
+            client_ip=get_client_ip(Request(scope))
+        )
 
         # Make request.state.request_id available without re-deriving.
         # ``scope.setdefault`` keeps any state dict Starlette already

--- a/backend/tests/test_request_context.py
+++ b/backend/tests/test_request_context.py
@@ -132,7 +132,7 @@ def test_middleware_clears_contextvars_between_requests():
 
 def test_middleware_binds_client_ip_for_every_request():
     """``client_ip`` is bound onto contextvars for ANY request — no
-    auth dependency required. Anonymous routes like ``/auth/register``
+    auth dependency required. Anonymous routes like ``/api/v1/auth/register``
     resolve no ``get_current_user`` dep, so binding here (not in the
     dep) is what makes bot-signup waves IP-clusterable.
     """
@@ -153,7 +153,7 @@ def test_middleware_binds_do_connecting_ip_on_anonymous_route(monkeypatch):
     honours ``do-connecting-ip`` unconditionally. An anonymous request
     carrying that header must surface the real client IP in
     ``client_ip`` — identical precedence to the authed audit path —
-    so the access-log line for ``/auth/register`` is IP-clusterable.
+    so the access-log line for ``/api/v1/auth/register`` is IP-clusterable.
     """
     monkeypatch.setenv("PFV_RUNTIME", "app_platform")
     captured: list[dict] = []

--- a/backend/tests/test_request_context.py
+++ b/backend/tests/test_request_context.py
@@ -127,6 +127,44 @@ def test_middleware_clears_contextvars_between_requests():
     assert "first.req" not in captured[1].values()
 
 
+# ── client_ip is bound unconditionally, incl. anonymous routes ───────────
+
+
+def test_middleware_binds_client_ip_for_every_request():
+    """``client_ip`` is bound onto contextvars for ANY request — no
+    auth dependency required. Anonymous routes like ``/auth/register``
+    resolve no ``get_current_user`` dep, so binding here (not in the
+    dep) is what makes bot-signup waves IP-clusterable.
+    """
+    captured: list[dict] = []
+    with TestClient(_build_app(captured)) as client:
+        res = client.get("/echo")
+    assert res.status_code == 200
+    # TestClient's default peer is the loopback address; the resolver
+    # returns it as the client IP when no trusted-proxy/DO context
+    # applies. The point of this assertion is that the KEY is present
+    # on an unauthenticated request.
+    assert "client_ip" in captured[-1]
+    assert captured[-1]["client_ip"]
+
+
+def test_middleware_binds_do_connecting_ip_on_anonymous_route(monkeypatch):
+    """On DO App Platform (``PFV_RUNTIME=app_platform``) the resolver
+    honours ``do-connecting-ip`` unconditionally. An anonymous request
+    carrying that header must surface the real client IP in
+    ``client_ip`` — identical precedence to the authed audit path —
+    so the access-log line for ``/auth/register`` is IP-clusterable.
+    """
+    monkeypatch.setenv("PFV_RUNTIME", "app_platform")
+    captured: list[dict] = []
+    with TestClient(_build_app(captured)) as client:
+        res = client.get(
+            "/echo", headers={"do-connecting-ip": "203.0.113.7"}
+        )
+    assert res.status_code == 200
+    assert captured[-1].get("client_ip") == "203.0.113.7"
+
+
 # ── Critical regression: handler-bound contextvars survive ────────────────
 
 


### PR DESCRIPTION
## Problem

Anonymous-route access logs (e.g. `POST /api/v1/auth/register`, `/auth/login`, `/auth/check-username`) emit `remote_addr` (the DO ingress internal IP) but **no** `client_ip` field. On authed routes `client_ip` is effectively available via the audit path's `get_client_ip` helper, but anonymous routes never resolve the auth dependency, so bot-signup waves can't be IP-clustered from their access logs.

## Fix

Bind `client_ip` onto structlog contextvars inside `RequestContextMiddleware`, right alongside `request_id`. Because this middleware runs (pure-ASGI) for **every** request at the edge of the stack, `client_ip` now lands on every access-log line, authed or anonymous.

- Reuses the existing `get_client_ip` helper, no re-implemented IP parsing.
- Preserves identical DO ingress precedence (`do-connecting-ip` under `PFV_RUNTIME=app_platform`) and the trusted-proxy right-to-left XFF walk used by the authed audit path.
- `remote_addr` is unchanged.

The helper only reads `request.headers` / `request.client` (pure scope reads), so a header-only `Request(scope)` is sufficient and the request body stream is untouched.

## Tests

Extended `tests/test_request_context.py`:
- `client_ip` is bound for any (unauthenticated) request.
- An anonymous request carrying `do-connecting-ip` under `PFV_RUNTIME=app_platform` surfaces the real client IP in `client_ip`.