### PR TITLE
fix(import): cap OFX parse at 2000 rows as DoS stopgap

### DIFF
--- a/backend/app/services/import_ofx_service.py
+++ b/backend/app/services/import_ofx_service.py
@@ -8,7 +8,8 @@ L3.2 import contracts (see spec
   1. Hard 5 MB upload cap, enforced *before* parsing begins.
   2. 10-second parse timeout via ``asyncio.wait_for`` so a pathological
      file can't pin an ASGI worker.
-  3. 10 000-row hard cap on the parsed transaction list (413 on excess).
+  3. 2 000-row hard cap on the parsed transaction list (413 on excess).
+     Lowered from 10 000 as a DoS stopgap (see ``MAX_ROWS``).
 
 Isolation rationale: in-process bounded, NOT subprocess. ``ofxtools``
 is pure-Python with no native dependencies, uses ``defusedxml`` for
@@ -45,7 +46,7 @@ logger = structlog.get_logger()
 # ── Spec-locked bounds (L3.2 §1.2 + §1.4) ──
 MAX_UPLOAD_BYTES = 5 * 1024 * 1024  # 5 MB
 DEFAULT_TIMEOUT_S = 10.0
-MAX_ROWS = 10_000
+MAX_ROWS = 2_000  # DoS stopgap: lowered from 10k to shrink concurrent-parse blast radius
 
 
 def _coerce_account_type(value: object) -> str | None:

--- a/backend/tests/routers/test_import_ofx.py
+++ b/backend/tests/routers/test_import_ofx.py
@@ -339,7 +339,10 @@ class _FakeOFX:
 
 @pytest.mark.asyncio
 async def test_ofx_preview_too_many_rows_returns_413(session_factory):
-    """Post-parse row cap (>10 000) → 413 (spec §1.5).
+    """Post-parse row cap (> MAX_ROWS) → 413 (spec §1.5).
+
+    The cap is the DoS stopgap at ``import_ofx_service.MAX_ROWS`` (2 000).
+    One row over the cap must be rejected with 413.
 
     We stub ``_parse_in_executor`` so the test does not depend on
     ofxtools' wall-clock parse speed. Slow CI runners would otherwise
@@ -349,8 +352,10 @@ async def test_ofx_preview_too_many_rows_returns_413(session_factory):
     seed = await _seed(session_factory)
     app = _make_app(session_factory)
 
+    over = import_ofx_service.MAX_ROWS + 1  # 2 001
+
     def fake_parse(_raw: bytes):
-        return _FakeOFX(10_001)
+        return _FakeOFX(over)
 
     with patch.object(import_ofx_service, "_parse_in_executor", fake_parse):
         with TestClient(app) as client:
@@ -361,8 +366,33 @@ async def test_ofx_preview_too_many_rows_returns_413(session_factory):
             )
     assert resp.status_code == 413
     detail = resp.json()["detail"]
-    assert "10001" in detail or "10000" in detail
+    assert str(over) in detail or str(import_ofx_service.MAX_ROWS) in detail
     assert "transactions" in detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_ofx_preview_at_row_cap_is_accepted(session_factory):
+    """Exactly MAX_ROWS rows (2 000) is at the boundary and must NOT 413.
+
+    Pairs with ``test_ofx_preview_too_many_rows_returns_413`` to pin the
+    DoS-stopgap cap at exactly ``import_ofx_service.MAX_ROWS``.
+    """
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory)
+
+    at_cap = import_ofx_service.MAX_ROWS  # 2 000
+
+    def fake_parse(_raw: bytes):
+        return _FakeOFX(at_cap)
+
+    with patch.object(import_ofx_service, "_parse_in_executor", fake_parse):
+        with TestClient(app) as client:
+            resp = client.post(
+                "/api/v1/import/ofx/preview",
+                files={"file": ("ok.ofx", io.BytesIO(b"<OFX>stub</OFX>"), "application/x-ofx")},
+                data={"account_id": str(seed["account_id"])},
+            )
+    assert resp.status_code != 413
 
 
 # ── Auth gate ──

--- a/backend/tests/routers/test_import_ofx.py
+++ b/backend/tests/routers/test_import_ofx.py
@@ -372,10 +372,12 @@ async def test_ofx_preview_too_many_rows_returns_413(session_factory):
 
 @pytest.mark.asyncio
 async def test_ofx_preview_at_row_cap_is_accepted(session_factory):
-    """Exactly MAX_ROWS rows (2 000) is at the boundary and must NOT 413.
+    """Exactly MAX_ROWS rows (2 000) is at the boundary and must not return 413.
 
     Pairs with ``test_ofx_preview_too_many_rows_returns_413`` to pin the
-    DoS-stopgap cap at exactly ``import_ofx_service.MAX_ROWS``.
+    DoS-stopgap cap at exactly ``import_ofx_service.MAX_ROWS``. Asserting
+    the real 200 success (not merely "not 413") proves the at-cap file is
+    genuinely accepted, and that all MAX_ROWS rows survive to the preview.
     """
     seed = await _seed(session_factory)
     app = _make_app(session_factory)
@@ -392,7 +394,8 @@ async def test_ofx_preview_at_row_cap_is_accepted(session_factory):
                 files={"file": ("ok.ofx", io.BytesIO(b"<OFX>stub</OFX>"), "application/x-ofx")},
                 data={"account_id": str(seed["account_id"])},
             )
-    assert resp.status_code != 413
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["total_rows"] == import_ofx_service.MAX_ROWS
 
 
 # ── Auth gate ──


### PR DESCRIPTION
Lowers the OFX preview parser's post-parse row cap (`MAX_ROWS`) from 10,000 to 2,000. Because the OFX parse runs in a non-killable executor thread, N concurrent large uploads can pin CPU on single-replica DO; a lower cap shrinks that blast radius until the full killable-parse-boundary fix lands. The 413 error copy interpolates the cap, so it now reads "max 2000" with no wording changes needed. A new boundary test asserts exactly 2,000 rows is accepted while 2,001 is rejected (413).