### PR TITLE
chore(infra): expire orphaned apex _next/static via S3 lifecycle

### DIFF
--- a/infra/terraform/apex/README.md
+++ b/infra/terraform/apex/README.md
@@ -41,8 +41,9 @@ Set in TFC (`FlamaCorp/pfv-apex` -> Variables); never committed.
 | `TFC_AWS_RUN_ROLE_ARN` | Env | no | After bootstrap, the `tfc_role_arn` output. Tells TFC to assume that role via workload identity. |
 
 Defaults for `aws_region`, `domain`, `github_repo`, `tfc_organization`,
-`tfc_workspace_pattern`, and `noncurrent_version_expiration_days` live in
-`variables.tf` and rarely need overriding.
+`tfc_workspace_pattern`, `noncurrent_version_expiration_days`, and
+`orphaned_static_expiration_days` live in `variables.tf` and rarely need
+overriding.
 
 ## Outputs (consumed by other PRs)
 

--- a/infra/terraform/apex/main.tf
+++ b/infra/terraform/apex/main.tf
@@ -142,6 +142,25 @@ resource "aws_s3_bucket_lifecycle_configuration" "apex" {
       days_after_initiation = 7
     }
   }
+
+  # Reap hashed _next/static/ chunks orphaned by a Next.js rename. The deploy
+  # uploads new hashed assets without --delete (PR #267, to avoid 404ing
+  # browser-cached HTML mid-deploy), so renamed chunks keep a distinct, current
+  # key forever and the noncurrent-version rule above never touches them. Every
+  # in-use chunk is re-uploaded on each deploy, refreshing its mtime, so this
+  # expiration only reaps chunks absent from recent build output.
+  rule {
+    id     = "expire-orphaned-next-static"
+    status = "Enabled"
+
+    filter {
+      prefix = "_next/static/"
+    }
+
+    expiration {
+      days = var.orphaned_static_expiration_days
+    }
+  }
 }
 
 ###############################################################################

--- a/infra/terraform/apex/variables.tf
+++ b/infra/terraform/apex/variables.tf
@@ -49,3 +49,9 @@ variable "noncurrent_version_expiration_days" {
   type        = number
   default     = 90
 }
+
+variable "orphaned_static_expiration_days" {
+  description = "Days after which current _next/static/ objects expire. Hashed chunks orphaned by a Next.js rename never become noncurrent versions (the key changes entirely), so the noncurrent-version rule never prunes them. The apex deploy re-uploads every in-use chunk, refreshing its mtime, so a window this wide only reaps chunks no recent build referenced. Matches noncurrent_version_expiration_days for a generous safety margin."
+  type        = number
+  default     = 90
+}


### PR DESCRIPTION
Implements `specs/apex-orphaned-static-cleanup.md` (Option A, the recommended path).

## What

Adds a second rule to `aws_s3_bucket_lifecycle_configuration.apex` that expires current objects under the `_next/static/` prefix after 90 days, driven by a new `orphaned_static_expiration_days` variable (default 90).

## Why

PR #267 stopped using `--delete` on the hashed-asset sync to avoid 404ing browser-cached HTML mid-deploy. As a result, hashed chunks orphaned by a Next.js rename keep a distinct, current key forever, and the existing noncurrent-version rule never prunes them (the key changes entirely, so they never become noncurrent versions). This rule reaps them.

Every in-use chunk is re-uploaded on each deploy, refreshing its mtime, so a 90-day window only reaps chunks absent from recent build output. 90 matches the existing noncurrent-version expiry for a generous safety margin.

Files touched: `infra/terraform/apex/main.tf`, `infra/terraform/apex/variables.tf`, `infra/terraform/apex/README.md`.

Terraform applies via TFC Confirm & Apply on merge; not applied from CLI. `terraform fmt -recursive` is clean.