### PR TITLE
feat(transactions): clarify transfer category picker UX

### DIFF
--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1129,9 +1129,9 @@ function TransactionsPageContent() {
                             </div>
                             <div>
                               <label htmlFor={`edit-cat-${tx.id}`} className={label}>{isTransfer ? "Transfer category" : "Category"}</label>
-                              <CategorySelect aria-label={isTransfer ? "Transfer category" : "Category"} id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={isTransfer ? undefined : editType} typeFilter={isTransfer ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
+                              <CategorySelect aria-label={isTransfer ? "Transfer category" : "Category"} aria-describedby={isTransfer ? `edit-cat-${tx.id}-help` : undefined} id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={isTransfer ? undefined : editType} typeFilter={isTransfer ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
                               {isTransfer && (
-                                <p className="mt-1 text-xs text-text-secondary">Transfers only accept categories that work for both income and expense (for example, Transfer).</p>
+                                <p id={`edit-cat-${tx.id}-help`} className="mt-1 text-xs text-text-secondary">Transfers only accept categories that work for both income and expense (for example, Transfer).</p>
                               )}
                               {categorizeAi?.entitled && !editPartner ? (
                                 <div className="mt-1">
@@ -1447,9 +1447,9 @@ function TransactionsPageContent() {
                               </div>
                               <div>
                                 <label htmlFor={`edit-cat-mobile-${tx.id}`} className={label}>{isTransfer ? "Transfer category" : "Category"}</label>
-                                <CategorySelect aria-label={isTransfer ? "Transfer category" : "Category"} id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={isTransfer ? undefined : editType} typeFilter={isTransfer ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
+                                <CategorySelect aria-label={isTransfer ? "Transfer category" : "Category"} aria-describedby={isTransfer ? `edit-cat-mobile-${tx.id}-help` : undefined} id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={isTransfer ? undefined : editType} typeFilter={isTransfer ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
                                 {isTransfer && (
-                                  <p className="mt-1 text-xs text-text-secondary">Transfers only accept categories that work for both income and expense (for example, Transfer).</p>
+                                  <p id={`edit-cat-mobile-${tx.id}-help`} className="mt-1 text-xs text-text-secondary">Transfers only accept categories that work for both income and expense (for example, Transfer).</p>
                                 )}
                                 {categorizeAi?.entitled && !editPartner ? (
                                   <div className="mt-1">

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1128,8 +1128,11 @@ function TransactionsPageContent() {
                               </select>
                             </div>
                             <div>
-                              <label htmlFor={`edit-cat-${tx.id}`} className={label}>Category</label>
-                              <CategorySelect aria-label="Category" id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={isTransfer ? undefined : editType} typeFilter={isTransfer ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
+                              <label htmlFor={`edit-cat-${tx.id}`} className={label}>{isTransfer ? "Transfer category" : "Category"}</label>
+                              <CategorySelect aria-label={isTransfer ? "Transfer category" : "Category"} id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={isTransfer ? undefined : editType} typeFilter={isTransfer ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
+                              {isTransfer && (
+                                <p className="mt-1 text-xs text-text-secondary">Transfers only accept categories that work for both income and expense (for example, Transfer).</p>
+                              )}
                               {categorizeAi?.entitled && !editPartner ? (
                                 <div className="mt-1">
                                   {categorizeAi.configured ? (
@@ -1443,8 +1446,11 @@ function TransactionsPageContent() {
                                 </select>
                               </div>
                               <div>
-                                <label htmlFor={`edit-cat-mobile-${tx.id}`} className={label}>Category</label>
-                                <CategorySelect aria-label="Category" id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={isTransfer ? undefined : editType} typeFilter={isTransfer ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
+                                <label htmlFor={`edit-cat-mobile-${tx.id}`} className={label}>{isTransfer ? "Transfer category" : "Category"}</label>
+                                <CategorySelect aria-label={isTransfer ? "Transfer category" : "Category"} id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={isTransfer ? undefined : editType} typeFilter={isTransfer ? "BOTH" : undefined} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
+                                {isTransfer && (
+                                  <p className="mt-1 text-xs text-text-secondary">Transfers only accept categories that work for both income and expense (for example, Transfer).</p>
+                                )}
                                 {categorizeAi?.entitled && !editPartner ? (
                                   <div className="mt-1">
                                     {categorizeAi.configured ? (

--- a/frontend/components/ui/CategorySelect.tsx
+++ b/frontend/components/ui/CategorySelect.tsx
@@ -37,6 +37,7 @@ interface Props {
   typeFilter?: "INCOME" | "EXPENSE" | "BOTH";
   className?: string;
   "aria-label"?: string;
+  "aria-describedby"?: string;
   onCategoryCreated?: (cat: Category) => void;
   /**
    * Category IDs that should still appear in the dropdown but render as
@@ -57,7 +58,7 @@ interface Props {
   masterOnly?: boolean;
 }
 
-export default function CategorySelect({ id, categories, value, onChange, filterType, typeFilter, className = "", "aria-label": ariaLabel, onCategoryCreated, disabledIds, masterOnly = false }: Props) {
+export default function CategorySelect({ id, categories, value, onChange, filterType, typeFilter, className = "", "aria-label": ariaLabel, "aria-describedby": ariaDescribedBy, onCategoryCreated, disabledIds, masterOnly = false }: Props) {
   const disabledSet = useMemo(() => {
     if (!disabledIds) return null;
     return disabledIds instanceof Set ? disabledIds : new Set(disabledIds);
@@ -231,6 +232,7 @@ export default function CategorySelect({ id, categories, value, onChange, filter
         aria-controls={`${id}-listbox`}
         aria-activedescendant={activeDescendant}
         aria-label={ariaLabel}
+        aria-describedby={ariaDescribedBy}
       />
       <input type="hidden" name={`${id}-value`} value={value} required />
 

--- a/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
+++ b/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
@@ -219,8 +219,11 @@ describe("TransactionsPage - edit row layout (Punch-list Item 7)", () => {
 
     // Open the desktop transfer-row category combobox by focusing its input.
     // Both desktop + mobile CategorySelects render in jsdom; target the
-    // desktop one by its id.
-    const combos = await screen.findAllByRole("combobox", { name: "Category" });
+    // desktop one by its id. On a transfer leg the control's accessible
+    // name is "Transfer category" (it is plain "Category" on regular rows).
+    const combos = await screen.findAllByRole("combobox", {
+      name: "Transfer category",
+    });
     const combo = combos.find((c) => c.id === "edit-cat-200") as HTMLInputElement;
     expect(combo).toBeTruthy();
     fireEvent.focus(combo);
@@ -291,7 +294,10 @@ describe("TransactionsPage - edit row layout (Punch-list Item 7)", () => {
     await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
-    const combos = await screen.findAllByRole("combobox", { name: "Category" });
+    // Transfer legs label the control "Transfer category" (see sibling test).
+    const combos = await screen.findAllByRole("combobox", {
+      name: "Transfer category",
+    });
     const combo = combos.find((c) => c.id === "edit-cat-200") as HTMLInputElement;
     expect(combo).toBeTruthy();
     fireEvent.focus(combo);

--- a/frontend/tests/app/transactions-page.test.tsx
+++ b/frontend/tests/app/transactions-page.test.tsx
@@ -216,6 +216,18 @@ describe("TransactionsPage — transfer wiring (Task D7)", () => {
       expect(typeNodes.some((el) => el.tagName === "SELECT")).toBe(false);
       expect(typeNodes[0].getAttribute("title")).toMatch(/transfer leg/i);
     });
+
+    // Editing a transfer leg renames the category control to "Transfer category"
+    // and surfaces helper text clarifying the both-type constraint that the
+    // picker (typeFilter="BOTH") enforces.
+    const catControls = await screen.findAllByLabelText("Transfer category");
+    expect(catControls.length).toBeGreaterThan(0);
+    const helperNotes = screen.getAllByText(
+      /only accept categories that work for both income and expense/i
+    );
+    expect(helperNotes.length).toBeGreaterThan(0);
+    // The plain "Category" label must not be used while editing a transfer leg.
+    expect(screen.queryByLabelText("Category")).toBeNull();
   });
 
   it("Saving an edit on a linked row omits 'type' from the PUT body", async () => {
@@ -275,6 +287,32 @@ describe("TransactionsPage — transfer wiring (Task D7)", () => {
     const body = JSON.parse((putCall[1] as RequestInit).body as string);
     expect(body).not.toHaveProperty("type");
     expect(body.description).toBe("Linked out edited");
+  });
+
+  it("Editing a regular row keeps the plain Category label and no transfer helper text", async () => {
+    const tx = makeTx({
+      id: 60, account_id: ACCT_A.id, account_name: ACCT_A.name,
+      type: "expense", amount: 40, description: "Groceries run",
+      linked_transaction_id: null,
+    });
+    setupApiFetch([tx]);
+
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Groceries run");
+
+    const editButtons = await screen.findAllByRole("button", { name: /^Edit: Groceries run$/i });
+    expect(editButtons.length).toBeGreaterThan(0);
+    fireEvent.click(editButtons[0]);
+
+    // A regular row uses the plain "Category" label.
+    const catControls = await screen.findAllByLabelText("Category");
+    expect(catControls.length).toBeGreaterThan(0);
+    // The transfer-only label and helper text must not appear.
+    expect(screen.queryByLabelText("Transfer category")).toBeNull();
+    expect(
+      screen.queryByText(/only accept categories that work for both income and expense/i)
+    ).toBeNull();
   });
 
   it("Per-row action column renders all actions on a single un-linked row (responsive layout)", async () => {

--- a/frontend/tests/app/transactions-page.test.tsx
+++ b/frontend/tests/app/transactions-page.test.tsx
@@ -228,6 +228,20 @@ describe("TransactionsPage — transfer wiring (Task D7)", () => {
     expect(helperNotes.length).toBeGreaterThan(0);
     // The plain "Category" label must not be used while editing a transfer leg.
     expect(screen.queryByLabelText("Category")).toBeNull();
+
+    // a11y: the picker combobox must be programmatically associated with the
+    // helper text via aria-describedby so screen-reader users hear the
+    // both-type constraint when the field is focused. Each rendered control
+    // points at its own helper paragraph (which carries the matching id).
+    catControls.forEach((control) => {
+      const describedBy = control.getAttribute("aria-describedby");
+      expect(describedBy).toBeTruthy();
+      const helper = document.getElementById(describedBy as string);
+      expect(helper).not.toBeNull();
+      expect(helper?.textContent).toMatch(
+        /only accept categories that work for both income and expense/i
+      );
+    });
   });
 
   it("Saving an edit on a linked row omits 'type' from the PUT body", async () => {
@@ -313,6 +327,10 @@ describe("TransactionsPage — transfer wiring (Task D7)", () => {
     expect(
       screen.queryByText(/only accept categories that work for both income and expense/i)
     ).toBeNull();
+    // Regular rows have no helper text, so the picker must not be wired to one.
+    catControls.forEach((control) => {
+      expect(control.getAttribute("aria-describedby")).toBeNull();
+    });
   });
 
   it("Per-row action column renders all actions on a single un-linked row (responsive layout)", async () => {


### PR DESCRIPTION
## What

When editing a transfer leg on the Transactions page, the category control now:

- Renames its label and aria-label from "Category" to "Transfer category".
- Shows helper text: "Transfers only accept categories that work for both income and expense (for example, Transfer)."

Applied to both the desktop and mobile edit rows. Regular (non-transfer) rows are unchanged: plain "Category" label, no helper text.

## Why

The `type=both` constraint on the transfer category picker (`typeFilter="BOTH"`) and the partner-leg cascade already shipped in #398. Without explanatory copy, the constrained list reads like a bug. This is the remaining "Transfer Category UX" delta from `specs/transactions-transfer-category-and-batch-edit.md`: the label rename and helper text. The batch-edit modal already carries its own transfer-category note, and the picker constraint itself was already in place, so neither was touched.

The optional "seed default Transfer category" item is left as a follow-up (out of scope for a frontend-only polish; it touches backend seeding).

## Tests

Extended `tests/app/transactions-page.test.tsx`: the linked-row edit test now asserts the "Transfer category" label and helper text appear (and the plain "Category" label does not); a new test confirms a regular row keeps the plain "Category" label with no helper text.