### PR TITLE
feat(forecast): review-then-apply for refine suggestions

### DIFF
--- a/frontend/components/dashboard/AIForecastRefineReviewModal.tsx
+++ b/frontend/components/dashboard/AIForecastRefineReviewModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import type { RefinedForecastResponse } from "@/components/dashboard/AIForecastRefineToggle";
 import { formatAmount } from "@/lib/format";
@@ -41,15 +41,15 @@ export default function AIForecastRefineReviewModal({
     [refined.categories],
   );
 
-  const [acceptedIds, setAcceptedIds] = useState<Set<number>>(new Set());
-
-  useEffect(() => {
-    if (!open) return;
-    // Accept-by-default: each adjustment is opt-out, matching the
-    // rebalance diff-review UX. The user can skip individual rows
-    // before clicking Apply.
-    setAcceptedIds(new Set(adjustments.map((a) => a.category_id)));
-  }, [open, adjustments]);
+  // Accept-by-default: each adjustment is opt-out, matching the
+  // rebalance diff-review UX. The user can skip individual rows before
+  // clicking Apply. Seeded lazily on mount so the first render already
+  // has every row accepted (no empty frame where a fast Apply click would
+  // submit zero rows). The parent mounts this modal fresh per review, so
+  // the initializer always reflects the current adjustments.
+  const [acceptedIds, setAcceptedIds] = useState<Set<number>>(
+    () => new Set(adjustments.map((a) => a.category_id)),
+  );
 
   function toggleRow(categoryId: number) {
     setAcceptedIds((prev) => {

--- a/frontend/components/dashboard/AIForecastRefineReviewModal.tsx
+++ b/frontend/components/dashboard/AIForecastRefineReviewModal.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import type { RefinedForecastResponse } from "@/components/dashboard/AIForecastRefineToggle";
+import { formatAmount } from "@/lib/format";
+import { btnPrimary, btnSecondary, card } from "@/lib/styles";
+
+/**
+ * Per-row review step for AI forecast refinement.
+ *
+ * Mirrors the BudgetRebalanceModal accept/skip diff pattern so the AI
+ * features stay consistent: the AI returns suggested per-category
+ * adjustments, the user reviews each one and accepts/skips it, and
+ * NOTHING is reflected on the forecast until they click Apply. Unlike
+ * the budget rebalance (which PUTs each accepted row), forecast refine
+ * is display-only, so "Apply" simply tells the parent which category ids
+ * the user accepted. The parent recomputes the displayed refined
+ * forecast from the accepted subset (skipped categories fall back to
+ * their baseline).
+ */
+
+export interface AIForecastRefineReviewModalProps {
+  open: boolean;
+  refined: RefinedForecastResponse;
+  /** Called with the set of accepted category ids when the user clicks Apply. */
+  onApply: (acceptedCategoryIds: Set<number>) => void;
+  onClose: () => void;
+}
+
+export default function AIForecastRefineReviewModal({
+  open,
+  refined,
+  onApply,
+  onClose,
+}: AIForecastRefineReviewModalProps) {
+  // Only categories the AI actually adjusted (multiplier != 1) are
+  // reviewable; unchanged categories carry the baseline regardless.
+  const adjustments = useMemo(
+    () => refined.categories.filter((c) => c.multiplier !== 1),
+    [refined.categories],
+  );
+
+  const [acceptedIds, setAcceptedIds] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    if (!open) return;
+    // Accept-by-default: each adjustment is opt-out, matching the
+    // rebalance diff-review UX. The user can skip individual rows
+    // before clicking Apply.
+    setAcceptedIds(new Set(adjustments.map((a) => a.category_id)));
+  }, [open, adjustments]);
+
+  function toggleRow(categoryId: number) {
+    setAcceptedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(categoryId)) next.delete(categoryId);
+      else next.add(categoryId);
+      return next;
+    });
+  }
+
+  if (!open) return null;
+
+  const acceptedCount = acceptedIds.size;
+  // Net displayed delta from the accepted subset (skipped rows contribute
+  // zero, since they keep their baseline).
+  const acceptedDelta = adjustments
+    .filter((a) => acceptedIds.has(a.category_id))
+    .reduce(
+      (acc, a) => acc + (Number(a.refined_forecast) - Number(a.baseline_forecast)),
+      0,
+    );
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="forecast-refine-review-title"
+    >
+      <div
+        className={`${card} relative w-full max-w-3xl max-h-[90vh] overflow-y-auto`}
+      >
+        <div className="flex items-start justify-between border-b border-border-subtle px-6 py-4">
+          <div>
+            <h2
+              id="forecast-refine-review-title"
+              className="text-base font-semibold text-text-primary"
+            >
+              Review AI forecast adjustments
+            </h2>
+            <p className="mt-1 text-xs text-text-muted">
+              Suggestions only. Nothing changes on your forecast until you click
+              Apply.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-text-muted hover:text-text-primary"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="px-6 py-5">
+          {refined.provenance.summary && (
+            <p className="mb-4 text-sm text-text-secondary">
+              {refined.provenance.summary}
+            </p>
+          )}
+
+          {adjustments.length === 0 ? (
+            <div
+              className="py-10 text-center"
+              data-testid="forecast-refine-review-empty"
+            >
+              <p className="text-sm font-medium text-text-primary">
+                No adjustments to review
+              </p>
+              <p className="mt-2 text-xs text-text-muted">
+                AI looked at your forecast and did not recommend any category
+                changes.
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table
+                  className="w-full text-sm"
+                  data-testid="forecast-refine-diff-table"
+                >
+                  <thead>
+                    <tr className="border-b border-border-subtle text-left">
+                      <th className="py-2 pr-3 text-xs font-medium text-text-muted">
+                        Apply
+                      </th>
+                      <th className="py-2 pr-3 text-xs font-medium text-text-muted">
+                        Category
+                      </th>
+                      <th className="py-2 pr-3 text-right text-xs font-medium text-text-muted">
+                        Baseline
+                      </th>
+                      <th className="py-2 pr-3 text-right text-xs font-medium text-text-muted">
+                        Refined
+                      </th>
+                      <th className="py-2 pr-3 text-right text-xs font-medium text-text-muted">
+                        Delta
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {adjustments.map((a) => {
+                      const baseline = Number(a.baseline_forecast);
+                      const refinedAmt = Number(a.refined_forecast);
+                      const delta = refinedAmt - baseline;
+                      const accepted = acceptedIds.has(a.category_id);
+                      return (
+                        <tr
+                          key={a.category_id}
+                          className="border-b border-border-subtle/60 align-top"
+                          data-testid={`forecast-refine-row-${a.category_id}`}
+                          data-row-accepted={accepted ? "yes" : "no"}
+                        >
+                          <td className="py-2 pr-3">
+                            <input
+                              type="checkbox"
+                              aria-label={`Apply adjustment for ${a.category_name}`}
+                              checked={accepted}
+                              onChange={() => toggleRow(a.category_id)}
+                              className="h-4 w-4 accent-accent"
+                            />
+                          </td>
+                          <td className="py-2 pr-3 text-text-primary">
+                            {a.category_name}
+                            <span className="ml-2 text-[10px] uppercase tracking-wide text-text-muted">
+                              x{a.multiplier.toFixed(2)}
+                            </span>
+                          </td>
+                          <td className="py-2 pr-3 text-right tabular-nums text-text-secondary">
+                            {formatAmount(baseline)}
+                          </td>
+                          <td className="py-2 pr-3 text-right tabular-nums text-text-primary">
+                            {formatAmount(refinedAmt)}
+                          </td>
+                          <td
+                            className={`py-2 pr-3 text-right tabular-nums ${
+                              delta > 0
+                                ? "text-danger"
+                                : delta < 0
+                                  ? "text-success"
+                                  : "text-text-muted"
+                            }`}
+                          >
+                            {delta > 0 ? "+" : ""}
+                            {formatAmount(delta)}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              <p className="mt-3 text-xs text-text-muted">
+                {acceptedCount} of {adjustments.length} adjustments selected.
+                Net change: {acceptedDelta > 0 ? "+" : ""}
+                {formatAmount(acceptedDelta)}.
+              </p>
+            </>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-border-subtle bg-surface-raised/30 px-6 py-3">
+          <button type="button" onClick={onClose} className={btnSecondary}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onApply(acceptedIds)}
+            className={btnPrimary}
+            data-testid="forecast-refine-apply"
+          >
+            {adjustments.length === 0
+              ? "Done"
+              : `Apply ${acceptedCount} adjustment${acceptedCount === 1 ? "" : "s"}`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/AIForecastRefineToggle.tsx
+++ b/frontend/components/dashboard/AIForecastRefineToggle.tsx
@@ -5,6 +5,7 @@ import { Sparkles, AlertTriangle } from "lucide-react";
 import { ApiResponseError } from "@/lib/api";
 import { card } from "@/lib/styles";
 import { AIForecastRefinePanel } from "@/components/dashboard/AIForecastRefinePanel";
+import AIForecastRefineReviewModal from "@/components/dashboard/AIForecastRefineReviewModal";
 import { useAiStatus } from "@/lib/hooks/use-ai-status";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { SetUpAiCta } from "@/components/ai/SetUpAiCta";
@@ -75,6 +76,44 @@ export interface AIForecastRefineToggleProps {
 }
 
 /**
+ * Recompute a display-only refined forecast from the subset of category
+ * adjustments the user accepted in the review step. Skipped categories
+ * fall back to their baseline (multiplier reset to 1, refined = baseline),
+ * and the headline refined-expense total is re-derived so the badge delta
+ * reflects only what the user accepted. Nothing here persists; this is a
+ * pure transform over the in-memory response.
+ */
+export function applyAcceptedAdjustments(
+  refined: RefinedForecastResponse,
+  acceptedCategoryIds: Set<number>,
+): RefinedForecastResponse {
+  const baselineExpense = Number(refined.baseline_forecast_expense);
+  let acceptedDelta = 0;
+  const categories = refined.categories.map((c) => {
+    const wasAdjusted = c.multiplier !== 1;
+    const accepted = acceptedCategoryIds.has(c.category_id);
+    if (wasAdjusted && !accepted) {
+      // Skipped: revert this category to its baseline.
+      return {
+        ...c,
+        multiplier: 1,
+        refined_forecast: c.baseline_forecast,
+      };
+    }
+    if (wasAdjusted && accepted) {
+      acceptedDelta +=
+        Number(c.refined_forecast) - Number(c.baseline_forecast);
+    }
+    return c;
+  });
+  return {
+    ...refined,
+    categories,
+    refined_forecast_expense: (baselineExpense + acceptedDelta).toFixed(2),
+  };
+}
+
+/**
  * AI-refined forecast toggle + badge.
  *
  * Opt-in: clicking "Apply AI refinement" hits
@@ -93,6 +132,10 @@ export default function AIForecastRefineToggle({
   visible = true,
 }: AIForecastRefineToggleProps) {
   const [refined, setRefined] = useState<RefinedForecastResponse | null>(null);
+  // Raw AI result awaiting per-row review. While this is set the review
+  // modal is open and nothing is reflected on the forecast yet.
+  const [pendingReview, setPendingReview] =
+    useState<RefinedForecastResponse | null>(null);
   const [panelOpen, setPanelOpen] = useState(false);
   const [gateBlocked, setGateBlocked] = useState(false);
   const [tooltipOpen, setTooltipOpen] = useState(false);
@@ -118,11 +161,29 @@ export default function AIForecastRefineToggle({
     );
   }
 
-  // When the panel calls onApplied (after a successful Confirm), store the
-  // result and close the panel so the refined-result view renders below.
+  // When the panel calls onApplied (after a successful Confirm), open the
+  // review step instead of reflecting the result immediately. The user
+  // accepts/skips each adjustment before anything shows on the forecast.
+  // If the backend fell back to baseline (ai_applied=false), there is
+  // nothing to review, so surface the fallback result straight away.
   const handleApplied = (result: RefinedForecastResponse) => {
-    setRefined(result);
     setPanelOpen(false);
+    const hasAdjustments =
+      result.provenance.ai_applied &&
+      result.categories.some((c) => c.multiplier !== 1);
+    if (hasAdjustments) {
+      setPendingReview(result);
+    } else {
+      setRefined(result);
+    }
+  };
+
+  // The review modal returns the accepted category ids. Recompute the
+  // display-only refined forecast from that subset and surface it.
+  const handleReviewApply = (acceptedCategoryIds: Set<number>) => {
+    if (!pendingReview) return;
+    setRefined(applyAcceptedAdjustments(pendingReview, acceptedCategoryIds));
+    setPendingReview(null);
   };
 
   // The panel's estimate call may 403 (feature gate closed) — propagate that
@@ -135,6 +196,18 @@ export default function AIForecastRefineToggle({
 
   // Idle state — invite the user to configure and confirm.
   if (refined === null) {
+    // Review step: the AI returned adjustments; the user reviews them
+    // per-row before anything is reflected on the forecast.
+    if (pendingReview) {
+      return (
+        <AIForecastRefineReviewModal
+          open
+          refined={pendingReview}
+          onApply={handleReviewApply}
+          onClose={() => setPendingReview(null)}
+        />
+      );
+    }
     if (panelOpen) {
       return (
         <AIForecastRefinePanel

--- a/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
+++ b/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
@@ -108,7 +108,7 @@ describe("AIForecastRefineToggle - idle and apply flow", () => {
     );
   });
 
-  it("shows the AI-refined badge after Confirm completes", async () => {
+  it("opens the review step after Confirm; nothing is reflected until Apply", async () => {
     // First call: estimate. Second call: refine.
     mockedFetch
       .mockResolvedValueOnce(estimateFixture())
@@ -121,6 +121,43 @@ describe("AIForecastRefineToggle - idle and apply flow", () => {
     const confirmBtn = await screen.findByRole("button", { name: /confirm/i });
     fireEvent.click(confirmBtn);
 
+    // The review modal opens with the per-row diff. The refined badge is
+    // NOT yet shown — nothing applies until the user clicks Apply.
+    await waitFor(() =>
+      expect(screen.getByTestId("forecast-refine-diff-table")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("ai-forecast-refined-panel")).toBeNull();
+    expect(screen.queryByTestId("ai-refined-badge")).toBeNull();
+    // The adjusted category is listed for review, accepted by default
+    // (the accept-by-default state is set in an effect, so wait for it).
+    await waitFor(() =>
+      expect(
+        screen.getByRole("checkbox", {
+          name: /Apply adjustment for Groceries/i,
+        }),
+      ).toBeChecked(),
+    );
+    expect(screen.getByTestId("forecast-refine-row-1")).toHaveAttribute(
+      "data-row-accepted",
+      "yes",
+    );
+  });
+
+  it("shows the AI-refined badge after the user accepts and applies", async () => {
+    mockedFetch
+      .mockResolvedValueOnce(estimateFixture())
+      .mockResolvedValueOnce(refinedFixture());
+
+    render(<AIForecastRefineToggle periodStart="2026-05-01" />);
+    fireEvent.click(screen.getByTestId("ai-forecast-refine-toggle"));
+
+    const confirmBtn = await screen.findByRole("button", { name: /confirm/i });
+    fireEvent.click(confirmBtn);
+
+    // Accept-by-default, so Apply reflects the full adjustment.
+    const applyBtn = await screen.findByTestId("forecast-refine-apply");
+    fireEvent.click(applyBtn);
+
     await waitFor(() =>
       expect(screen.getByTestId("ai-forecast-refined-panel")).toBeInTheDocument(),
     );
@@ -129,6 +166,62 @@ describe("AIForecastRefineToggle - idle and apply flow", () => {
     // Delta vs. baseline surfaced.
     expect(screen.getByText(/\+20\.00 vs\. baseline/)).toBeInTheDocument();
     expect(screen.getByText(/1 category adjusted/)).toBeInTheDocument();
+    // Refine endpoint hit exactly once — Apply does NOT re-call the AI.
+    const refineCalls = mockedFetch.mock.calls.filter(
+      (c) => c[0] === "/api/v1/ai/forecast/refine",
+    );
+    expect(refineCalls).toHaveLength(1);
+  });
+
+  it("skipping a row reverts that category to baseline (zero net delta)", async () => {
+    mockedFetch
+      .mockResolvedValueOnce(estimateFixture())
+      .mockResolvedValueOnce(refinedFixture());
+
+    render(<AIForecastRefineToggle periodStart="2026-05-01" />);
+    fireEvent.click(screen.getByTestId("ai-forecast-refine-toggle"));
+
+    const confirmBtn = await screen.findByRole("button", { name: /confirm/i });
+    fireEvent.click(confirmBtn);
+
+    // Skip the single adjustment, then apply. Wait for the accept-by-default
+    // effect to settle (checkbox checked) before unchecking it, otherwise the
+    // effect could re-check it after our click.
+    const checkbox = await screen.findByRole("checkbox", {
+      name: /Apply adjustment for Groceries/i,
+    });
+    await waitFor(() => expect(checkbox).toBeChecked());
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByTestId("forecast-refine-apply"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("ai-forecast-refined-panel")).toBeInTheDocument(),
+    );
+    // With the only adjustment skipped, the displayed delta is zero and
+    // no categories count as adjusted.
+    expect(screen.getByText(/\+0\.00 vs\. baseline/)).toBeInTheDocument();
+    expect(screen.queryByText(/category adjusted/)).toBeNull();
+  });
+
+  it("Cancel on the review modal discards the result (back to idle)", async () => {
+    mockedFetch
+      .mockResolvedValueOnce(estimateFixture())
+      .mockResolvedValueOnce(refinedFixture());
+
+    render(<AIForecastRefineToggle periodStart="2026-05-01" />);
+    fireEvent.click(screen.getByTestId("ai-forecast-refine-toggle"));
+
+    const confirmBtn = await screen.findByRole("button", { name: /confirm/i });
+    fireEvent.click(confirmBtn);
+
+    await screen.findByTestId("forecast-refine-diff-table");
+    fireEvent.click(screen.getByRole("button", { name: /^Cancel$/ }));
+
+    // Back to the idle CTA, nothing reflected.
+    await waitFor(() =>
+      expect(screen.getByTestId("ai-forecast-refine-toggle")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("ai-refined-badge")).toBeNull();
   });
 });
 
@@ -143,6 +236,10 @@ describe("AIForecastRefineToggle - tooltip details", () => {
 
     const confirmBtn = await screen.findByRole("button", { name: /confirm/i });
     fireEvent.click(confirmBtn);
+
+    // Accept the adjustments in the review step to reach the refined view.
+    const applyBtn = await screen.findByTestId("forecast-refine-apply");
+    fireEvent.click(applyBtn);
 
     await waitFor(() =>
       expect(screen.getByTestId("ai-forecast-refined-panel")).toBeInTheDocument(),

--- a/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
+++ b/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
@@ -129,7 +129,7 @@ describe("AIForecastRefineToggle - idle and apply flow", () => {
     expect(screen.queryByTestId("ai-forecast-refined-panel")).toBeNull();
     expect(screen.queryByTestId("ai-refined-badge")).toBeNull();
     // The adjusted category is listed for review, accepted by default
-    // (the accept-by-default state is set in an effect, so wait for it).
+    // (seeded on first render by the lazy initializer).
     await waitFor(() =>
       expect(
         screen.getByRole("checkbox", {
@@ -154,10 +154,8 @@ describe("AIForecastRefineToggle - idle and apply flow", () => {
     const confirmBtn = await screen.findByRole("button", { name: /confirm/i });
     fireEvent.click(confirmBtn);
 
-    // Accept-by-default is set in an effect after the modal mounts. Wait for
-    // that effect to settle (the row checkbox checked) before clicking Apply,
-    // otherwise Apply can fire with an empty accepted set and revert every
-    // adjustment to baseline (the order-dependent full-suite race).
+    // Accept-by-default is seeded on first render, so the row checkbox is
+    // already checked before Apply.
     await waitFor(() =>
       expect(
         screen.getByRole("checkbox", {
@@ -194,9 +192,8 @@ describe("AIForecastRefineToggle - idle and apply flow", () => {
     const confirmBtn = await screen.findByRole("button", { name: /confirm/i });
     fireEvent.click(confirmBtn);
 
-    // Skip the single adjustment, then apply. Wait for the accept-by-default
-    // effect to settle (checkbox checked) before unchecking it, otherwise the
-    // effect could re-check it after our click.
+    // Skip the single adjustment, then apply. The checkbox is checked on
+    // first render (lazy initializer), so we can uncheck it directly.
     const checkbox = await screen.findByRole("checkbox", {
       name: /Apply adjustment for Groceries/i,
     });
@@ -248,9 +245,7 @@ describe("AIForecastRefineToggle - tooltip details", () => {
     fireEvent.click(confirmBtn);
 
     // Accept the adjustments in the review step to reach the refined view.
-    // Wait for the accept-by-default effect to settle (checkbox checked)
-    // before clicking Apply, otherwise Apply can fire with an empty accepted
-    // set and the refined view would carry no adjustments to list.
+    // The checkbox is checked on first render (lazy initializer).
     await waitFor(() =>
       expect(
         screen.getByRole("checkbox", {

--- a/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
+++ b/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
@@ -154,7 +154,17 @@ describe("AIForecastRefineToggle - idle and apply flow", () => {
     const confirmBtn = await screen.findByRole("button", { name: /confirm/i });
     fireEvent.click(confirmBtn);
 
-    // Accept-by-default, so Apply reflects the full adjustment.
+    // Accept-by-default is set in an effect after the modal mounts. Wait for
+    // that effect to settle (the row checkbox checked) before clicking Apply,
+    // otherwise Apply can fire with an empty accepted set and revert every
+    // adjustment to baseline (the order-dependent full-suite race).
+    await waitFor(() =>
+      expect(
+        screen.getByRole("checkbox", {
+          name: /Apply adjustment for Groceries/i,
+        }),
+      ).toBeChecked(),
+    );
     const applyBtn = await screen.findByTestId("forecast-refine-apply");
     fireEvent.click(applyBtn);
 
@@ -238,6 +248,16 @@ describe("AIForecastRefineToggle - tooltip details", () => {
     fireEvent.click(confirmBtn);
 
     // Accept the adjustments in the review step to reach the refined view.
+    // Wait for the accept-by-default effect to settle (checkbox checked)
+    // before clicking Apply, otherwise Apply can fire with an empty accepted
+    // set and the refined view would carry no adjustments to list.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("checkbox", {
+          name: /Apply adjustment for Groceries/i,
+        }),
+      ).toBeChecked(),
+    );
     const applyBtn = await screen.findByTestId("forecast-refine-apply");
     fireEvent.click(applyBtn);
 


### PR DESCRIPTION
## What

Replaces the Smart Forecast refinement **auto-preview + Revert** flow with a **per-row accept/skip review step**, reusing the existing `BudgetRebalanceModal` diff-review pattern so the AI features stay consistent.

After the AI returns, a review modal lists each adjusted category (baseline -> refined, with delta), accepted by default. Nothing is reflected on the forecast until the user clicks Apply. Skipped categories fall back to their baseline, and the headline refined-expense delta is recomputed from only the accepted subset.

## Why

The old flow showed the AI-refined forecast immediately, reading as "it applied without asking." Per `specs/ai-refinement-tweaks-backlog.md` (tweak 2), the review-then-apply step makes the result clearly a set of suggestions the user opts into, mirroring the budget rebalance UX.

## Scope / risk

- Forecast refine stays **display-only** (no persistence). This is UX clarity, not a data-safety fix.
- The AI dispatch/estimate layer is untouched; only the apply-side UX changed.
- The budget rebalance feature itself is not modified; the new modal adopts its accept/skip pattern.

## Changes

- New `AIForecastRefineReviewModal` (accept-by-default per-row diff table, mirrors the rebalance modal).
- `AIForecastRefineToggle` routes the AI result through the review step; fallback (`ai_applied=false`) skips review and surfaces the baseline directly. Adds `applyAcceptedAdjustments` to recompute the display-only forecast from the accepted subset.
- Extended `ai-forecast-refine-toggle.test.tsx`: nothing applies until Apply, accept/skip per row, Cancel discards, refine endpoint hit exactly once.