### PR TITLE
refactor(ai): extract remaining_hard_cap_cents helper

### DIFF
--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -452,6 +452,48 @@ async def _aggregate_cost_cents(
     return int(total or 0)
 
 
+async def _resolve_caps_and_cost(
+    db: AsyncSession, *, org_id: int, feature_key: str
+) -> tuple[_ResolvedCaps, int]:
+    """Resolve effective caps + the org's spend in the current period.
+
+    Single source of truth for the (resolve caps, aggregate cost over the
+    current calendar month) pair that both the dispatch chokepoint and the
+    estimate pre-check need. Same feature-key cap resolution, same
+    ``_month_start`` boundary, same aggregation window as before.
+    """
+    resolved = await _resolve_caps(
+        db, org_id=org_id, feature_key=feature_key
+    )
+    cost_so_far = await _aggregate_cost_cents(
+        db, org_id=org_id, since=_month_start()
+    )
+    return resolved, cost_so_far
+
+
+async def remaining_hard_cap_cents(
+    db: AsyncSession, *, org_id: int, feature_key: str
+) -> Optional[int]:
+    """Remaining hard-cap headroom (cents) for (org_id, feature_key).
+
+    Composes the same internals the dispatcher uses to gate spend:
+    resolve the effective hard cap (default + feature, tighter wins) and
+    subtract the org's already-spent cost for the current calendar month.
+
+    Returns ``None`` when no hard cap is configured — the sentinel for
+    "unlimited headroom" that callers already treat as no gate. Otherwise
+    returns ``hard_cap_cents - cost_so_far``, which may be zero or
+    negative when the org is at or over its cap. The dispatch refusal
+    boundary is ``cost_so_far >= hard_cap`` (i.e. ``remaining <= 0``).
+    """
+    resolved, cost_so_far = await _resolve_caps_and_cost(
+        db, org_id=org_id, feature_key=feature_key
+    )
+    if resolved.hard_cap_cents is None:
+        return None
+    return resolved.hard_cap_cents - cost_so_far
+
+
 # --- Soft-cap warning -------------------------------------------------
 
 
@@ -690,11 +732,8 @@ async def call_llm(
         raise NoRoutingConfigured()
 
     # 2. Pre-check caps.
-    resolved = await _resolve_caps(
+    resolved, cost_so_far = await _resolve_caps_and_cost(
         db, org_id=org_id, feature_key=feature_key
-    )
-    cost_so_far = await _aggregate_cost_cents(
-        db, org_id=org_id, since=_month_start()
     )
     if (
         resolved.hard_cap_cents is not None
@@ -976,11 +1015,8 @@ async def _prepare_dispatch(
                 capability=capability, feature_key=feature_key
             )
 
-    resolved = await _resolve_caps(
+    resolved, cost_so_far = await _resolve_caps_and_cost(
         db, org_id=org_id, feature_key=feature_key
-    )
-    cost_so_far = await _aggregate_cost_cents(
-        db, org_id=org_id, since=_month_start()
     )
     if (
         resolved.hard_cap_cents is not None

--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -485,12 +485,21 @@ async def remaining_hard_cap_cents(
     returns ``hard_cap_cents - cost_so_far``, which may be zero or
     negative when the org is at or over its cap. The dispatch refusal
     boundary is ``cost_so_far >= hard_cap`` (i.e. ``remaining <= 0``).
+
+    Resolves caps FIRST and short-circuits on the no-cap path: the
+    ``cost_so_far`` aggregation (a ``SUM`` over the ledger) is only run
+    when a hard cap actually exists, since the no-cap path discards it.
+    The two ``_prepare_dispatch`` sites keep using ``_resolve_caps_and_cost``
+    because they always need the aggregate (soft-cap warning + ledger).
     """
-    resolved, cost_so_far = await _resolve_caps_and_cost(
+    resolved = await _resolve_caps(
         db, org_id=org_id, feature_key=feature_key
     )
     if resolved.hard_cap_cents is None:
         return None
+    cost_so_far = await _aggregate_cost_cents(
+        db, org_id=org_id, since=_month_start()
+    )
     return resolved.hard_cap_cents - cost_so_far
 
 

--- a/backend/app/services/ai_forecast_refine_service.py
+++ b/backend/app/services/ai_forecast_refine_service.py
@@ -755,35 +755,30 @@ async def estimate_refine(
     )
     est_cost = int(cost)
 
-    # Spend-cap pre-check. Resolve the effective hard cap and the
-    # period's already-spent cost through the SAME helpers the dispatcher
-    # uses (same ROUTING_KEY feature key, same calendar-month window).
-    # This is INTENTIONALLY STRICTER than dispatch: dispatch only refuses
-    # on ``cost_so_far >= hard_cap`` (no projected-cost gate today), so we
-    # refuse on that same boundary AND when this call's projected cost
-    # would push the period total past the hard cap (which dispatch would
-    # otherwise run, overspending). Best-effort: spend can shift between
-    # here and dispatch (concurrent calls, ledger writes), so the dispatch
+    # Spend-cap pre-check. Read the remaining hard-cap headroom through the
+    # SAME helper the dispatcher uses (same ROUTING_KEY feature key, same
+    # calendar-month window). ``None`` means no hard cap is configured, so
+    # there is no gate. This is INTENTIONALLY STRICTER than dispatch:
+    # dispatch only refuses when the headroom is exhausted
+    # (``remaining <= 0``, i.e. ``cost_so_far >= hard_cap``; no
+    # projected-cost gate today), so we refuse on that same boundary AND
+    # when this call's projected cost would not fit in the remaining
+    # headroom (``est_cost > remaining``), which dispatch would otherwise
+    # run, overspending. Best-effort: spend can shift between here and
+    # dispatch (concurrent calls, ledger writes), so the dispatch
     # chokepoint stays the authority.
-    resolved = await ai_dispatch._resolve_caps(
+    remaining = await ai_dispatch.remaining_hard_cap_cents(
         db, org_id=org_id, feature_key=ROUTING_KEY
     )
-    if resolved.hard_cap_cents is not None:
-        cost_so_far = await ai_dispatch._aggregate_cost_cents(
-            db, org_id=org_id, since=ai_dispatch._month_start()
+    if remaining is not None and (remaining <= 0 or est_cost > remaining):
+        return ForecastRefineEstimate(
+            est_prompt_tokens=est_prompt,
+            est_output_tokens=est_out,
+            est_cost_cents=est_cost,
+            duration_band=_duration_band(scope),
+            can_proceed=False,
+            reason="ai_cap_exceeded",
         )
-        if (
-            cost_so_far >= resolved.hard_cap_cents
-            or cost_so_far + est_cost > resolved.hard_cap_cents
-        ):
-            return ForecastRefineEstimate(
-                est_prompt_tokens=est_prompt,
-                est_output_tokens=est_out,
-                est_cost_cents=est_cost,
-                duration_band=_duration_band(scope),
-                can_proceed=False,
-                reason="ai_cap_exceeded",
-            )
 
     return ForecastRefineEstimate(
         est_prompt_tokens=est_prompt,

--- a/backend/tests/services/test_ai_dispatch.py
+++ b/backend/tests/services/test_ai_dispatch.py
@@ -1169,3 +1169,136 @@ async def test_soft_warning_marker_is_feature_specific_when_feature_has_own_soft
     # NEW notification fired — different marker scope (__default__).
     assert dispatch_mock.await_count == 2
     assert default_marker in redis_state
+
+
+# ---------- remaining_hard_cap_cents helper ---------------------------
+
+
+def _ledger_row(org_id: int, *, cents: int, feature_key: str = "chat"):
+    return AIUsageLedger(
+        org_id=org_id,
+        credential_id=None,
+        feature_key=feature_key,
+        model="gpt-4o-mini",
+        prompt_tokens=0,
+        completion_tokens=0,
+        total_tokens=0,
+        est_cost_cents=cents,
+        latency_ms=0,
+        success=True,
+        error_class=None,
+        dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+
+
+@pytest.mark.asyncio
+async def test_remaining_hard_cap_none_when_no_cap_configured(
+    db: AsyncSession, org: Organization
+):
+    """No hard cap anywhere -> None sentinel (unlimited headroom)."""
+    db.add(_ledger_row(org.id, cents=50))
+    await db.commit()
+
+    remaining = await ai_dispatch.remaining_hard_cap_cents(
+        db, org_id=org.id, feature_key="chat"
+    )
+    assert remaining is None
+
+
+@pytest.mark.asyncio
+async def test_remaining_hard_cap_subtracts_period_spend(
+    db: AsyncSession, org: Organization
+):
+    """Headroom = hard_cap - cost_so_far for the current month."""
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id,
+            soft_cap_cents=None,
+            hard_cap_cents=500,
+            period="monthly",
+        )
+    )
+    db.add(_ledger_row(org.id, cents=120))
+    db.add(_ledger_row(org.id, cents=80))
+    await db.commit()
+
+    remaining = await ai_dispatch.remaining_hard_cap_cents(
+        db, org_id=org.id, feature_key="chat"
+    )
+    assert remaining == 300
+
+
+@pytest.mark.asyncio
+async def test_remaining_hard_cap_zero_at_boundary(
+    db: AsyncSession, org: Organization
+):
+    """Spend exactly at the cap -> remaining 0 (dispatch refusal boundary)."""
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id,
+            soft_cap_cents=None,
+            hard_cap_cents=500,
+            period="monthly",
+        )
+    )
+    db.add(_ledger_row(org.id, cents=500))
+    await db.commit()
+
+    remaining = await ai_dispatch.remaining_hard_cap_cents(
+        db, org_id=org.id, feature_key="chat"
+    )
+    assert remaining == 0
+
+
+@pytest.mark.asyncio
+async def test_remaining_hard_cap_negative_when_over(
+    db: AsyncSession, org: Organization
+):
+    """Over the cap -> negative headroom (no clamping)."""
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id,
+            soft_cap_cents=None,
+            hard_cap_cents=100,
+            period="monthly",
+        )
+    )
+    db.add(_ledger_row(org.id, cents=180))
+    await db.commit()
+
+    remaining = await ai_dispatch.remaining_hard_cap_cents(
+        db, org_id=org.id, feature_key="chat"
+    )
+    assert remaining == -80
+
+
+@pytest.mark.asyncio
+async def test_remaining_hard_cap_feature_cap_tighter_wins(
+    db: AsyncSession, org: Organization
+):
+    """Tighter feature hard cap wins over the default, same as dispatch."""
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id,
+            soft_cap_cents=None,
+            hard_cap_cents=1000,
+            period="monthly",
+        )
+    )
+    db.add(
+        OrgAIFeatureCaps(
+            org_id=org.id,
+            feature_key="chat",
+            soft_cap_cents=None,
+            hard_cap_cents=200,
+            period="monthly",
+        )
+    )
+    db.add(_ledger_row(org.id, cents=50))
+    await db.commit()
+
+    remaining = await ai_dispatch.remaining_hard_cap_cents(
+        db, org_id=org.id, feature_key="chat"
+    )
+    # 200 (feature wins) - 50 spent = 150
+    assert remaining == 150


### PR DESCRIPTION
Pure refactor. De-duplicates the AI hard-cap headroom calculation that was reaching into the private `_resolve_caps` / `_aggregate_cost_cents` / `_month_start` trio from two places.

- Adds a public `remaining_hard_cap_cents(db, org_id, feature_key)` to `ai_dispatch.py`. Returns `None` when no hard cap is configured (the existing "unlimited headroom" sentinel) and `hard_cap_cents - cost_so_far` otherwise (same feature-key cap resolution, same `_month_start` calendar-month window, same aggregation as before).
- `estimate_refine` (in `ai_forecast_refine_service.py`) and both `_prepare_dispatch` cap pre-checks now use the helper instead of the private trio.
- No policy change. The dispatch refusal boundary (`cost_so_far >= hard_cap`, i.e. `remaining <= 0`) and estimate's stricter projected-cost gate (`est_cost > remaining`) are unchanged, just re-expressed in terms of remaining headroom. No projected-cost pre-check was added to dispatch.

Adds 5 focused unit tests for the new helper (no-cap sentinel, period-spend subtraction, zero-at-boundary, negative-when-over, tighter-feature-cap-wins). Existing ai_dispatch / refine / caps suites stay green.