### PR TITLE
chore(infra): apex CloudFront CSP + access logging

### DIFF
--- a/infra/terraform/apex/README.md
+++ b/infra/terraform/apex/README.md
@@ -17,10 +17,11 @@ plus the ACM-emitted validation CNAMEs).
 | Resource | Purpose |
 |---|---|
 | `aws_s3_bucket` (+ public-access-block, versioning, SSE, lifecycle, ownership) | Private origin bucket for the static export |
-| `aws_cloudfront_distribution` | Edge distribution with HTTPS, HSTS, www -> apex redirect |
+| `aws_s3_bucket.apex_logs` (+ ownership, public-access-block, ACL, SSE, lifecycle) | Dedicated private bucket for CloudFront standard (legacy) access logs. ACLs enabled (`BucketOwnerPreferred`) with an explicit ACL granting the bucket owner and the CloudFront log-delivery account `FULL_CONTROL`; public access still blocked. |
+| `aws_cloudfront_distribution` | Edge distribution with HTTPS, HSTS, www -> apex redirect, standard access logging to `apex_logs` |
 | `aws_cloudfront_origin_access_control` | OAC (NOT legacy OAI) so only this distribution can read the bucket |
 | `aws_cloudfront_function` | Viewer-request function: (1) `www` -> apex 301 redirect, then (2) S3 directory-index rewrite (`/privacy/` -> `/privacy/index.html`) |
-| `aws_cloudfront_response_headers_policy` | Security headers: HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy |
+| `aws_cloudfront_response_headers_policy` | Security headers: Content-Security-Policy, HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy |
 | `aws_acm_certificate` + `_validation` | DNS-validated cert in `us-east-1` (CloudFront requirement) for apex + www |
 | `aws_route53_record.apex_acm_validation` | ACM `_<token>.<domain>` validation CNAMEs in the existing zone. **Does NOT touch the apex A record.** |
 | `aws_iam_openid_connect_provider.github` | Trust for GitHub Actions OIDC tokens |
@@ -41,9 +42,9 @@ Set in TFC (`FlamaCorp/pfv-apex` -> Variables); never committed.
 | `TFC_AWS_RUN_ROLE_ARN` | Env | no | After bootstrap, the `tfc_role_arn` output. Tells TFC to assume that role via workload identity. |
 
 Defaults for `aws_region`, `domain`, `github_repo`, `tfc_organization`,
-`tfc_workspace_pattern`, `noncurrent_version_expiration_days`, and
-`orphaned_static_expiration_days` live in `variables.tf` and rarely need
-overriding.
+`tfc_workspace_pattern`, `noncurrent_version_expiration_days`,
+`orphaned_static_expiration_days`, and `access_log_expiration_days` live
+in `variables.tf` and rarely need overriding.
 
 ## Outputs (consumed by other PRs)
 
@@ -245,10 +246,27 @@ documented OAC as the long-term path.
 - `X-Frame-Options: DENY`
 - `Referrer-Policy: strict-origin-when-cross-origin`
 - `Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()`
+- `Content-Security-Policy` (see `local.apex_csp` in `main.tf`)
 
-CSP is intentionally **not** set in this module. PR-C will author the
-CSP alongside the static-export's actual asset graph and add it via a
-follow-up to the response-headers policy.
+CSP **is** set in this module, in `local.apex_csp`. It is authored against
+what `build-apex.sh`'s static export actually loads and is intentionally
+distinct from the Next.js app's nonce-based CSP: the apex is an
+`output: 'export'` static build with no request-time runtime, so it cannot
+mint per-request nonces and `script-src`/`style-src` allow `'unsafe-inline'`.
+The only external origins permitted are Google Fonts (`fonts.googleapis.com`
+for `style-src`, `fonts.gstatic.com` for `font-src`); everything else is
+same-origin.
+
+### Access logging
+
+CloudFront standard (legacy) access logging is enabled and delivers to the
+dedicated `apex_logs` bucket under the `apex/` prefix. Standard logging
+delivers via an ACL grant to the AWS-owned log-delivery canonical user, so the
+logs bucket keeps ACLs enabled (`BucketOwnerPreferred`) and grants the owner
+plus the log-delivery account `FULL_CONTROL` through an explicit
+`aws_s3_bucket_acl`; public access stays blocked
+(`block_public_policy`/`restrict_public_buckets` on). Log objects expire after
+`access_log_expiration_days` (default 90).
 
 ## Rollback
 

--- a/infra/terraform/apex/main.tf
+++ b/infra/terraform/apex/main.tf
@@ -32,6 +32,13 @@ locals {
   # config; the format matches the AWS console convention.
   s3_origin_id = "S3-${local.bucket_name}"
 
+  # Dedicated bucket for CloudFront standard (access) logs. Kept separate
+  # from the origin bucket so log writes never collide with the static
+  # export surface and so the two have independent lifecycle + ownership
+  # settings (the origin enforces BucketOwnerEnforced; the logs bucket must
+  # allow ACLs for CloudFront's log-delivery principal — see below).
+  logs_bucket_name = "${replace(var.domain, ".", "-")}-apex-logs"
+
   # GitHub Actions OIDC subject claim: ONLY push-to-main can assume the
   # deploy role. PR-context tokens have a different sub (`pull_request`)
   # and are rejected by the trust policy's StringEquals match. PR previews,
@@ -43,6 +50,42 @@ locals {
   # suffix; we accept plan + apply so PR speculative plans and merge applies
   # both work. Workspace pattern uses TFC's glob support.
   tfc_sub_pattern = "organization:${var.tfc_organization}:project:*:workspace:${var.tfc_workspace_pattern}:run_phase:*"
+
+  # Content-Security-Policy for the apex static export. Derived directly from
+  # what build-apex.sh's output actually loads (frontend/scripts/build-apex.sh
+  # + frontend/app/layout.tsx + frontend/app/page.tsx). It is INTENTIONALLY
+  # distinct from the Next.js app's nonce-based CSP
+  # (frontend/lib/security-headers.ts): the apex is a `output: 'export'` static
+  # build with NO request-time runtime, so it cannot mint per-request nonces.
+  # layout.tsx's theme-bootstrap inline <script> and page.tsx's JSON-LD
+  # <script type="application/ld+json"> blocks ship WITHOUT a nonce attribute on
+  # the static export (readNonce() returns ""), and Next.js itself injects
+  # un-nonced inline hydration bootstrap scripts. So script-src/style-src MUST
+  # allow 'unsafe-inline' here (and NOT 'strict-dynamic', which would void
+  # 'unsafe-inline').
+  #
+  # External origins the apex genuinely loads, and nothing more:
+  #   * https://fonts.googleapis.com -> Google Fonts <link rel=stylesheet> (style-src)
+  #   * https://fonts.gstatic.com    -> the font files that stylesheet pulls (font-src)
+  # og:image (/og.png) and every other asset are same-origin ('self'). There is
+  # NO analytics, CDN, Cloudflare Turnstile, or backend connect on the apex
+  # surface: build-apex.sh's post-build guard hard-fails on any /api/v1
+  # reference, and the auth pages that load Turnstile are staged out of the
+  # apex build by the default-deny route allowlist.
+  apex_csp = join("; ", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "style-src-attr 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self' data: https://fonts.gstatic.com",
+    "connect-src 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+    "upgrade-insecure-requests",
+  ])
 }
 
 # Existing hosted zone for the apex domain. We do not create the zone here;
@@ -159,6 +202,87 @@ resource "aws_s3_bucket_lifecycle_configuration" "apex" {
 
     expiration {
       days = var.orphaned_static_expiration_days
+    }
+  }
+}
+
+###############################################################################
+# CLOUDFRONT ACCESS LOGS BUCKET
+# Dedicated, private bucket for CloudFront standard (legacy) access logs.
+#
+# CloudFront standard logging delivers log files using an ACL grant to the
+# `awslogsdelivery` AWS-owned account (the canonical-user-id path), NOT a
+# service-principal bucket policy. That means this bucket MUST have ACLs
+# enabled — object_ownership = "BucketOwnerPreferred", and the account-level
+# Block Public Access must leave `block_public_acls` / `ignore_public_acls`
+# OFF so the delivery ACL grant lands. (The origin bucket uses the stricter
+# BucketOwnerEnforced + full BPA; these two buckets intentionally differ.)
+# `aws_cloudfront_distribution.logging_config` wires the grant automatically.
+###############################################################################
+
+resource "aws_s3_bucket" "apex_logs" {
+  bucket = local.logs_bucket_name
+
+  tags = {
+    Name = local.logs_bucket_name
+    role = "apex-cloudfront-logs"
+  }
+}
+
+# ACLs enabled. CloudFront standard log delivery writes via an ACL grant to
+# the log-delivery account; BucketOwnerEnforced (which disables ACLs) would
+# reject the grant and break log delivery. BucketOwnerPreferred keeps the
+# bucket owner as the owner of delivered objects while still permitting ACLs.
+resource "aws_s3_bucket_ownership_controls" "apex_logs" {
+  bucket = aws_s3_bucket.apex_logs.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+# Block PUBLIC access while still permitting the CloudFront log-delivery ACL
+# grant. The two *_acls flags are left false because disabling them entirely
+# (as the origin bucket does) would also block the non-public delivery grant.
+# block_public_policy + restrict_public_buckets stay on, so no public policy
+# or public bucket exposure is possible regardless of the ACL grant.
+resource "aws_s3_bucket_public_access_block" "apex_logs" {
+  bucket = aws_s3_bucket.apex_logs.id
+
+  block_public_acls       = false
+  block_public_policy     = true
+  ignore_public_acls      = false
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "apex_logs" {
+  bucket = aws_s3_bucket.apex_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "apex_logs" {
+  bucket = aws_s3_bucket.apex_logs.id
+
+  rule {
+    id     = "expire-access-logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "apex/"
+    }
+
+    expiration {
+      days = var.access_log_expiration_days
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
     }
   }
 }
@@ -319,15 +443,21 @@ resource "aws_cloudfront_origin_access_control" "apex" {
   signing_protocol                  = "sigv4"
 }
 
-# Response headers policy: HSTS, X-Content-Type-Options, X-Frame-Options,
-# Referrer-Policy, Permissions-Policy. These are baseline web security
-# headers; CSP is intentionally omitted from this PR because the static
-# export's CSP needs to be authored alongside PR-C's build output.
+# Response headers policy: CSP, HSTS, X-Content-Type-Options, X-Frame-Options,
+# Referrer-Policy, Permissions-Policy. Baseline web security headers for the
+# apex static landing distribution. The CSP value is assembled in the locals
+# block at the top of this file (local.apex_csp); see the rationale there for
+# why it is intentionally distinct from the Next.js app's nonce-based CSP.
 resource "aws_cloudfront_response_headers_policy" "apex" {
   name    = "${local.bucket_name}-security-headers"
   comment = "Baseline security headers for the apex landing distribution."
 
   security_headers_config {
+    content_security_policy {
+      content_security_policy = local.apex_csp
+      override                = true
+    }
+
     strict_transport_security {
       access_control_max_age_sec = 63072000 # 2 years
       include_subdomains         = true
@@ -422,6 +552,18 @@ resource "aws_cloudfront_distribution" "apex" {
 
   aliases = [local.apex_fqdn, local.www_fqdn]
 
+  # CloudFront standard (access) logging to the dedicated logs bucket. The
+  # `bucket` argument expects the S3 bucket DOMAIN name (not the bare id or
+  # ARN). Logs land under the apex/ prefix so the bucket can host other
+  # CloudFront log streams later without key collisions, and so the lifecycle
+  # rule (which filters on prefix = "apex/") matches. include_cookies is left
+  # at its default (false): the apex is a cookieless static site, so logging
+  # cookies would only add noise.
+  logging_config {
+    bucket = aws_s3_bucket.apex_logs.bucket_domain_name
+    prefix = "apex/"
+  }
+
   origin {
     domain_name              = aws_s3_bucket.apex.bucket_regional_domain_name
     origin_id                = local.s3_origin_id
@@ -477,6 +619,16 @@ resource "aws_cloudfront_distribution" "apex" {
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"
   }
+
+  # The logs bucket's ownership controls (ACLs enabled) and BPA settings must
+  # be in place before CloudFront attempts its first log delivery; otherwise
+  # the log-delivery ACL grant CloudFront writes on enable is rejected and the
+  # distribution create/update errors. Sequencing here makes that explicit
+  # instead of relying on the implicit bucket_domain_name reference alone.
+  depends_on = [
+    aws_s3_bucket_ownership_controls.apex_logs,
+    aws_s3_bucket_public_access_block.apex_logs,
+  ]
 
   tags = {
     Name = "${var.domain}-apex"
@@ -693,9 +845,10 @@ resource "aws_iam_role" "tfc_apex_provisioner" {
 }
 
 data "aws_iam_policy_document" "tfc_apex_provisioner" {
-  # S3 management on THIS bucket only.
+  # S3 management on THIS module's buckets only: the static-origin bucket and
+  # the dedicated CloudFront access-logs bucket.
   statement {
-    sid    = "ManageApexBucket"
+    sid    = "ManageApexBuckets"
     effect = "Allow"
     actions = [
       "s3:*",
@@ -703,6 +856,8 @@ data "aws_iam_policy_document" "tfc_apex_provisioner" {
     resources = [
       aws_s3_bucket.apex.arn,
       "${aws_s3_bucket.apex.arn}/*",
+      aws_s3_bucket.apex_logs.arn,
+      "${aws_s3_bucket.apex_logs.arn}/*",
     ]
   }
 

--- a/infra/terraform/apex/main.tf
+++ b/infra/terraform/apex/main.tf
@@ -217,7 +217,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "apex" {
 # Block Public Access must leave `block_public_acls` / `ignore_public_acls`
 # OFF so the delivery ACL grant lands. (The origin bucket uses the stricter
 # BucketOwnerEnforced + full BPA; these two buckets intentionally differ.)
-# `aws_cloudfront_distribution.logging_config` wires the grant automatically.
+# The delivery grant is set EXPLICITLY via `aws_s3_bucket_acl.apex_logs`
+# rather than relying on the deprecated implicit auto-grant, which can fail
+# at apply with InvalidArgument.
 ###############################################################################
 
 resource "aws_s3_bucket" "apex_logs" {
@@ -253,6 +255,58 @@ resource "aws_s3_bucket_public_access_block" "apex_logs" {
   block_public_policy     = true
   ignore_public_acls      = false
   restrict_public_buckets = true
+}
+
+# CloudFront standard logging delivers via an ACL grant to a fixed AWS-owned
+# canonical user (the log-delivery account), not a service principal. The
+# deprecated implicit behavior where enabling logging_config auto-grants this
+# can fail at apply with InvalidArgument, so we grant it explicitly here.
+# `aws_canonical_user_id` resolves the calling account's canonical id so the
+# bucket OWNER keeps FULL_CONTROL alongside the log-delivery grant.
+data "aws_canonical_user_id" "current" {}
+
+# CloudFront standard-logging delivery canonical user id (a fixed, global,
+# AWS-published value). FULL_CONTROL lets the log-delivery account write and
+# set ACLs on the log objects it delivers.
+locals {
+  cloudfront_log_delivery_canonical_id = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
+}
+
+# Explicit ACL granting the bucket owner FULL_CONTROL and the CloudFront
+# log-delivery account FULL_CONTROL. This replaces the deprecated implicit
+# auto-grant that logging_config used to perform on enable.
+resource "aws_s3_bucket_acl" "apex_logs" {
+  bucket = aws_s3_bucket.apex_logs.id
+
+  access_control_policy {
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+
+    grant {
+      grantee {
+        type = "CanonicalUser"
+        id   = data.aws_canonical_user_id.current.id
+      }
+      permission = "FULL_CONTROL"
+    }
+
+    grant {
+      grantee {
+        type = "CanonicalUser"
+        id   = local.cloudfront_log_delivery_canonical_id
+      }
+      permission = "FULL_CONTROL"
+    }
+  }
+
+  # Ownership controls (ACLs enabled) and the public-access-block must exist
+  # before the ACL is applied, and the ACL must exist before CloudFront's first
+  # log delivery (sequenced via the distribution's depends_on).
+  depends_on = [
+    aws_s3_bucket_ownership_controls.apex_logs,
+    aws_s3_bucket_public_access_block.apex_logs,
+  ]
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "apex_logs" {
@@ -560,7 +614,7 @@ resource "aws_cloudfront_distribution" "apex" {
   # at its default (false): the apex is a cookieless static site, so logging
   # cookies would only add noise.
   logging_config {
-    bucket = aws_s3_bucket.apex_logs.bucket_domain_name
+    bucket = aws_s3_bucket.apex_logs.bucket_regional_domain_name
     prefix = "apex/"
   }
 
@@ -620,14 +674,15 @@ resource "aws_cloudfront_distribution" "apex" {
     minimum_protocol_version = "TLSv1.2_2021"
   }
 
-  # The logs bucket's ownership controls (ACLs enabled) and BPA settings must
-  # be in place before CloudFront attempts its first log delivery; otherwise
-  # the log-delivery ACL grant CloudFront writes on enable is rejected and the
-  # distribution create/update errors. Sequencing here makes that explicit
-  # instead of relying on the implicit bucket_domain_name reference alone.
+  # The logs bucket's ownership controls (ACLs enabled), BPA settings, and the
+  # explicit log-delivery ACL grant must all be in place before CloudFront
+  # attempts its first log delivery; otherwise the delivery write is rejected
+  # and the distribution create/update errors. Sequencing here makes that
+  # explicit instead of relying on the implicit domain-name reference alone.
   depends_on = [
     aws_s3_bucket_ownership_controls.apex_logs,
     aws_s3_bucket_public_access_block.apex_logs,
+    aws_s3_bucket_acl.apex_logs,
   ]
 
   tags = {

--- a/infra/terraform/apex/variables.tf
+++ b/infra/terraform/apex/variables.tf
@@ -55,3 +55,9 @@ variable "orphaned_static_expiration_days" {
   type        = number
   default     = 90
 }
+
+variable "access_log_expiration_days" {
+  description = "Days after which CloudFront access log objects expire from the dedicated logs bucket. Standard CloudFront logs are operational telemetry (not records of intent), so a 90-day window is enough for incident forensics and traffic analysis while capping storage growth."
+  type        = number
+  default     = 90
+}

--- a/infra/terraform/apex/variables.tf
+++ b/infra/terraform/apex/variables.tf
@@ -60,4 +60,9 @@ variable "access_log_expiration_days" {
   description = "Days after which CloudFront access log objects expire from the dedicated logs bucket. Standard CloudFront logs are operational telemetry (not records of intent), so a 90-day window is enough for incident forensics and traffic analysis while capping storage growth."
   type        = number
   default     = 90
+
+  validation {
+    condition     = var.access_log_expiration_days >= 1
+    error_message = "access_log_expiration_days must be at least 1."
+  }
 }


### PR DESCRIPTION
Two small CloudFront security-hardening additions to the apex marketing module (`infra/terraform/apex/`). Terraform only; applied via TFC Confirm & Apply on merge.

## 1. Content-Security-Policy on the apex distribution
Adds a `content_security_policy` block to `aws_cloudfront_response_headers_policy.apex` (which previously stamped HSTS / frame-options / content-type-options / referrer / permissions but no CSP).

The value is derived from what the static export actually loads (`scripts/build-apex.sh` + `app/layout.tsx` + `app/page.tsx`), and is intentionally distinct from the Next.js app's nonce-based CSP: the apex is an `output: 'export'` static build with no request-time runtime, so it cannot mint nonces. The theme-bootstrap inline `<script>` and the JSON-LD blocks ship un-nonced, and Next injects its own un-nonced inline hydration bootstrap, so `script-src`/`style-src` allow `'unsafe-inline'` (no `'strict-dynamic'`, which would void it). Only external origins are Google Fonts (`fonts.googleapis.com` stylesheet + `fonts.gstatic.com` fonts); og:image (`/og.png`) and all other assets are same-origin. No analytics / CDN / Turnstile / backend connect on the apex surface.

CSP value:

```
default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-attr 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
```

## 2. CloudFront access logging
No logging bucket existed in the module, so this adds a dedicated private `aws_s3_bucket.apex_logs` with the ACL/ownership settings CloudFront standard logging requires (`BucketOwnerPreferred` + the two `*_acls` BPA flags off so the log-delivery ACL grant lands; `block_public_policy` + `restrict_public_buckets` stay on), AES256 SSE, and a lifecycle expiration (new `access_log_expiration_days`, default 90). Wired via `logging_config { bucket = ..., prefix = "apex/" }`, with a `depends_on` so the bucket ACL/BPA settings apply before first log delivery. TFC provisioner IAM extended to manage the new bucket.

## Files
- `infra/terraform/apex/main.tf`
- `infra/terraform/apex/variables.tf`