### PR TITLE
feat(notifications): notification preferences settings page

### DIFF
--- a/frontend/app/settings/notifications/page.tsx
+++ b/frontend/app/settings/notifications/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import SettingsLayout from "@/components/SettingsLayout";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import {
+  card,
+  cardTitle,
+  btnPrimary,
+  error as errorCls,
+  success as successCls,
+} from "@/lib/styles";
+import type { NotificationPreferences } from "@/lib/types";
+
+/**
+ * The four notification categories, in display order. `security` is
+ * listed first and is locked on: the backend rejects
+ * `email_security=false` with code=security_emails_required, so the
+ * toggle renders disabled+on with explanatory copy rather than letting
+ * the user attempt a change the API will refuse.
+ *
+ * `key` is the email-channel field on NotificationPreferences. The
+ * in-app channel fields are preserved verbatim on save (the PUT
+ * replaces every toggle), so this page only ever mutates the email
+ * side.
+ */
+const CATEGORIES: ReadonlyArray<{
+  key: keyof Pick<
+    NotificationPreferences,
+    "email_security" | "email_account" | "email_org_admin" | "email_org_activity"
+  >;
+  title: string;
+  description: string;
+  locked?: boolean;
+}> = [
+  {
+    key: "email_security",
+    title: "Security",
+    description:
+      "Sign-in alerts, password changes, and other account-protection events. Always on so you never miss a security warning.",
+    locked: true,
+  },
+  {
+    key: "email_account",
+    title: "Account",
+    description:
+      "Updates about your own account, like email verification and profile changes.",
+  },
+  {
+    key: "email_org_admin",
+    title: "Organization (admin)",
+    description:
+      "Administrative events for your organization, such as member invites and role changes.",
+  },
+  {
+    key: "email_org_activity",
+    title: "Organization activity",
+    description:
+      "Day-to-day activity within your organization. Quiet by default, turn it on to follow along.",
+  },
+];
+
+export default function NotificationsPage() {
+  const [prefs, setPrefs] = useState<NotificationPreferences | null>(null);
+  const [loadErr, setLoadErr] = useState("");
+  const [saveErr, setSaveErr] = useState("");
+  const [saveMsg, setSaveMsg] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadErr("");
+    apiFetch<NotificationPreferences>("/api/v1/notifications/preferences")
+      .then((data) => {
+        if (!cancelled) setPrefs(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setLoadErr(extractErrorMessage(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function toggle(key: (typeof CATEGORIES)[number]["key"]) {
+    setSaveMsg("");
+    setPrefs((current) =>
+      current ? { ...current, [key]: !current[key] } : current,
+    );
+  }
+
+  async function handleSave() {
+    if (!prefs) return;
+    setSaving(true);
+    setSaveErr("");
+    setSaveMsg("");
+    try {
+      // PUT replaces every toggle, so we send the whole shape. The
+      // in-app fields ride along untouched; this page only edits email.
+      const updated = await apiFetch<NotificationPreferences>(
+        "/api/v1/notifications/preferences",
+        { method: "PUT", body: JSON.stringify(prefs) },
+      );
+      setPrefs(updated);
+      setSaveMsg("Notification preferences saved.");
+    } catch (err) {
+      setSaveErr(extractErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <SettingsLayout activeTab="/settings/notifications">
+      <div className="max-w-lg space-y-6">
+        <div className={`${card} p-6`}>
+          <h2 className={`mb-2 ${cardTitle}`}>Email notifications</h2>
+          <p className="mb-5 text-sm text-text-muted">
+            Choose which emails we send you. These settings only affect
+            email, your in-app notifications are unchanged.
+          </p>
+
+          {loadErr && (
+            <div role="alert" aria-live="polite" className={errorCls}>
+              {loadErr}
+            </div>
+          )}
+
+          {!loadErr && !prefs && (
+            <div className="flex justify-center py-8" aria-live="polite">
+              <Loader2
+                className="h-6 w-6 animate-spin text-text-muted motion-reduce:animate-none"
+                aria-label="Loading notification preferences"
+              />
+            </div>
+          )}
+
+          {prefs && (
+            <div className="space-y-5">
+              {saveMsg && (
+                <div role="status" aria-live="polite" className={successCls}>
+                  {saveMsg}
+                </div>
+              )}
+              {saveErr && (
+                <div role="alert" aria-live="polite" className={errorCls}>
+                  {saveErr}
+                </div>
+              )}
+
+              <ul className="divide-y divide-border">
+                {CATEGORIES.map((cat) => {
+                  const enabled = prefs[cat.key];
+                  return (
+                    <li
+                      key={cat.key}
+                      className="flex items-start justify-between gap-4 py-4 first:pt-0 last:pb-0"
+                    >
+                      <div>
+                        <p className="text-sm font-medium text-text-primary">
+                          {cat.title}
+                          {cat.locked && (
+                            <span className="ml-2 text-xs font-normal text-text-muted">
+                              (always on)
+                            </span>
+                          )}
+                        </p>
+                        <p className="mt-1 max-w-sm text-xs text-text-muted">
+                          {cat.description}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={enabled}
+                        aria-label={`${cat.title} email notifications`}
+                        disabled={cat.locked || saving}
+                        onClick={() => !cat.locked && toggle(cat.key)}
+                        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 disabled:cursor-not-allowed disabled:opacity-60 ${
+                          enabled ? "bg-success" : "bg-border"
+                        }`}
+                      >
+                        <span
+                          className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition ${
+                            enabled ? "translate-x-5" : "translate-x-0.5"
+                          }`}
+                        />
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving}
+                aria-busy={saving}
+                className={`${btnPrimary} w-full sm:w-auto sm:min-h-0 inline-flex items-center justify-center gap-2`}
+              >
+                {saving && (
+                  <Loader2
+                    className="h-4 w-4 animate-spin motion-reduce:animate-none"
+                    aria-hidden="true"
+                  />
+                )}
+                {saving ? "Saving..." : "Save changes"}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </SettingsLayout>
+  );
+}

--- a/frontend/components/SettingsLayout.tsx
+++ b/frontend/components/SettingsLayout.tsx
@@ -9,6 +9,7 @@ import { pageTitle } from "@/lib/styles";
 const tabs = [
   { href: "/settings", label: "Profile", minRole: "member" as const },
   { href: "/settings/security", label: "Security", minRole: "member" as const },
+  { href: "/settings/notifications", label: "Notifications", minRole: "member" as const },
   { href: "/settings/organization", label: "Organization", minRole: "admin" as const },
   { href: "/settings/ai-providers", label: "AI Providers", minRole: "admin" as const },
   { href: "/settings/billing", label: "Billing", minRole: "owner" as const },

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -397,6 +397,24 @@ export interface PlanFeatures {
   "ai.autocategorize": boolean;
 }
 
+// Notification preferences — mirrors the backend
+// `NotificationPreferencesResponse` / `NotificationPreferencesUpdate`
+// schemas (GET/PUT /api/v1/notifications/preferences). Two channels
+// (email + in-app) across the four categories. The PUT replaces every
+// toggle at once, so the settings page round-trips the full shape and
+// only mutates the email side. `email_security` cannot be turned off
+// (the API rejects it with code=security_emails_required).
+export interface NotificationPreferences {
+  email_security: boolean;
+  email_account: boolean;
+  email_org_admin: boolean;
+  email_org_activity: boolean;
+  in_app_security: boolean;
+  in_app_account: boolean;
+  in_app_org_admin: boolean;
+  in_app_org_activity: boolean;
+}
+
 export interface OrgFeatureOverride {
   feature_key: FeatureKey;
   value: boolean;

--- a/frontend/tests/app/settings-notifications-page.test.tsx
+++ b/frontend/tests/app/settings-notifications-page.test.tsx
@@ -91,6 +91,40 @@ describe("Notification preferences settings page", () => {
     expect(security).toBeDisabled();
   });
 
+  it("clicking the locked security toggle is a no-op and never PUTs email_security: false", async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce(makePrefs());
+    render(<NotificationsPage />);
+
+    const security = await screen.findByRole("switch", {
+      name: /security email notifications/i,
+    });
+    expect(security).toHaveAttribute("aria-checked", "true");
+
+    // The user tries to switch security off; the locked toggle must ignore it.
+    fireEvent.click(security);
+    expect(security).toHaveAttribute("aria-checked", "true");
+
+    // Saving afterwards keeps email_security on; no PUT ever carries false.
+    vi.mocked(apiFetch).mockResolvedValueOnce(makePrefs());
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenLastCalledWith(
+        "/api/v1/notifications/preferences",
+        expect.objectContaining({ method: "PUT" }),
+      ),
+    );
+    const [, opts] = vi.mocked(apiFetch).mock.calls.at(-1)!;
+    const sent = JSON.parse((opts as { body: string }).body);
+    expect(sent.email_security).toBe(true);
+
+    // Belt and suspenders: no PUT call anywhere carried email_security: false.
+    for (const [, callOpts] of vi.mocked(apiFetch).mock.calls) {
+      const body = (callOpts as { body?: string } | undefined)?.body;
+      if (body) expect(JSON.parse(body).email_security).not.toBe(false);
+    }
+  });
+
   it("toggles a category and PUTs the full preference shape", async () => {
     vi.mocked(apiFetch)
       .mockResolvedValueOnce(makePrefs())

--- a/frontend/tests/app/settings-notifications-page.test.tsx
+++ b/frontend/tests/app/settings-notifications-page.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import NotificationsPage from "@/app/settings/notifications/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+import type { NotificationPreferences } from "@/lib/types";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/auth/AuthProvider")
+  >("@/components/auth/AuthProvider");
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/settings/notifications",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+function makePrefs(
+  overrides: Partial<NotificationPreferences> = {},
+): NotificationPreferences {
+  return {
+    email_security: true,
+    email_account: true,
+    email_org_admin: true,
+    email_org_activity: false,
+    in_app_security: true,
+    in_app_account: true,
+    in_app_org_admin: true,
+    in_app_org_activity: false,
+    ...overrides,
+  };
+}
+
+function mockAuth() {
+  vi.mocked(useAuth).mockReturnValue({
+    user: {
+      id: 1,
+      username: "alice",
+      email: "alice@acme.io",
+      role: "member",
+      org_name: "Acme",
+      is_superadmin: false,
+    } as never,
+    loading: false,
+    billingUiEnabled: false,
+    refreshMe: vi.fn().mockResolvedValue(undefined),
+  } as never);
+}
+
+beforeEach(() => {
+  vi.mocked(apiFetch).mockReset();
+  mockAuth();
+});
+
+describe("Notification preferences settings page", () => {
+  it("renders the email toggles from the loaded preferences", async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce(makePrefs());
+    render(<NotificationsPage />);
+
+    expect(
+      await screen.findByRole("switch", { name: /account email notifications/i }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByRole("switch", {
+        name: /organization activity email notifications/i,
+      }),
+    ).toHaveAttribute("aria-checked", "false");
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/notifications/preferences");
+  });
+
+  it("keeps the security toggle on and disabled", async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce(makePrefs());
+    render(<NotificationsPage />);
+
+    const security = await screen.findByRole("switch", {
+      name: /security email notifications/i,
+    });
+    expect(security).toHaveAttribute("aria-checked", "true");
+    expect(security).toBeDisabled();
+  });
+
+  it("toggles a category and PUTs the full preference shape", async () => {
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce(makePrefs())
+      .mockResolvedValueOnce(makePrefs({ email_org_activity: true }));
+
+    render(<NotificationsPage />);
+
+    const orgActivity = await screen.findByRole("switch", {
+      name: /organization activity email notifications/i,
+    });
+    fireEvent.click(orgActivity);
+    expect(orgActivity).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenLastCalledWith(
+        "/api/v1/notifications/preferences",
+        expect.objectContaining({ method: "PUT" }),
+      ),
+    );
+    const [, opts] = vi.mocked(apiFetch).mock.calls.at(-1)!;
+    const sent = JSON.parse((opts as { body: string }).body);
+    // In-app channel fields ride along untouched; only the email side changed.
+    expect(sent).toMatchObject({
+      email_org_activity: true,
+      in_app_security: true,
+      in_app_org_activity: false,
+    });
+    expect(
+      await screen.findByText(/notification preferences saved/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an error when loading preferences fails", async () => {
+    vi.mocked(apiFetch).mockRejectedValueOnce(new Error("nope"));
+    render(<NotificationsPage />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/nope/i);
+  });
+});


### PR DESCRIPTION
Adds a `/settings/notifications` sub-page that consumes the existing `GET`/`PUT /api/v1/notifications/preferences` API.

- New Notifications tab registered in `SettingsLayout` (member-visible, between Security and Organization).
- Per-category email toggles (Security, Account, Organization admin, Organization activity) bound to the preferences API. Loads current prefs, mutates only the email side, and round-trips the full shape on `PUT` so the in-app channel fields are preserved.
- Security email is locked on (rendered disabled + on) because the API rejects `email_security=false` with `code=security_emails_required`.
- Loading, error, and success states mirror the sibling settings pages. Toggles use the existing `role="switch"` primitive with labelled `aria-checked`, focus rings, and token-only colors.

Reuses `lib/styles` primitives and theme tokens only (design-token check passes). New `NotificationPreferences` type in `lib/types.ts` mirrors the backend schema.