### PR TITLE
feat(security): CSP violation reporting endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,7 @@ from app import redis_client
 from app.database import engine
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_ai_usage, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_rate_limit_overrides, admin_roles, admin_subscriptions, admin_users, ai_budget, ai_categorize, ai_forecast, ai_providers, ai_status, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, settings, subscriptions, tags, transactions, users
+from app.routers import account_types, accounts, admin, admin_ai_usage, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_rate_limit_overrides, admin_roles, admin_subscriptions, admin_users, ai_budget, ai_categorize, ai_forecast, ai_providers, ai_status, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, security, settings, subscriptions, tags, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -497,6 +497,7 @@ app.include_router(ai_categorize.router)
 app.include_router(ai_forecast.router)
 app.include_router(admin_ai_usage.router)
 app.include_router(admin_rate_limit_overrides.router)
+app.include_router(security.router)
 
 
 @app.get("/health")

--- a/backend/app/routers/security.py
+++ b/backend/app/routers/security.py
@@ -127,8 +127,16 @@ def _extract_detail(report_body: Any) -> Optional[dict[str, Any]]:
         bounded = _bounded(report_body[raw_key])
         if bounded is None:
             continue
-        # First writer wins: if both the kebab and camel alias for the
-        # same normalized key are present, keep the first non-empty one.
+        # Skip empty/blank strings so an empty legacy alias (e.g.
+        # ``blocked-uri: ""``) can't shadow a meaningful camelCase alias
+        # (``blockedURL: "https://real"``). ``setdefault`` keeps the
+        # first PRESENT value, so without this guard an empty string
+        # would win purely because its key is iterated first.
+        if isinstance(bounded, str) and not bounded.strip():
+            continue
+        # First non-empty writer wins: if both the kebab and camel alias
+        # for the same normalized key are present, keep the first one
+        # that carries a non-empty value.
         detail.setdefault(norm_key, bounded)
     return detail
 
@@ -174,6 +182,17 @@ async def csp_report(request: Request) -> Response:
     unparseable report. Uses an independent session for the audit write
     (via ``record_audit_event``) so it doesn't depend on a request-
     scoped DB dependency on this anonymous route.
+
+    **Audit outcome is always ``failure`` by design.** A CSP report is,
+    by definition, a policy breach, so every row is recorded with
+    ``outcome="failure"``. Because this is a public, anonymous, and
+    potentially high-volume source, audit alerting and the default
+    ``/admin/audit`` failure views MUST scope OUT
+    ``event_type="security.csp_violation"`` — otherwise this stream
+    dilutes the genuine admin-failure signal those views exist to
+    surface. (The outcome value is intentionally not softened to keep
+    the violation semantics honest; the filtering lives in the
+    consumers, not here.)
     """
     # Pull the session factory directly (not via Depends) so this stays
     # a zero-dependency public route — nothing here resolves auth.
@@ -240,6 +259,10 @@ async def csp_report(request: Request) -> Response:
             target_org_name=None,
             request_id=request_id,
             ip_address=client_ip,
+            # Always "failure": a CSP violation is a policy breach. See the
+            # endpoint docstring — audit alerting / default /admin/audit
+            # failure views must scope OUT this event_type so this
+            # high-volume anonymous source doesn't dilute real admin signal.
             outcome="failure",
             detail=detail or None,
         )

--- a/backend/app/routers/security.py
+++ b/backend/app/routers/security.py
@@ -1,0 +1,247 @@
+"""Public CSP violation-report sink.
+
+Browsers POST Content-Security-Policy violation reports here when a
+directive is violated. The endpoint is **public** (unauthenticated) by
+design: browsers send these reports without any of our auth context,
+and a CSP report is a side-channel the page can't attach a Bearer token
+to. It is wired into the CSP via the ``report-uri`` / ``report-to``
+directives + the ``Reporting-Endpoints`` response header (set on the
+frontend in ``frontend/lib/security-headers.ts``).
+
+Two body shapes arrive in the wild and both are accepted:
+
+* **Legacy** ``Content-Type: application/csp-report`` — a single JSON
+  object ``{"csp-report": {...}}`` (the ``report-uri`` directive).
+* **Reporting API** ``Content-Type: application/reports+json`` — a JSON
+  **array** of report envelopes ``[{"type": "csp-violation", "body":
+  {...}}, ...]`` (the ``report-to`` / ``Reporting-Endpoints`` path).
+
+Anything else (unknown content-type, malformed JSON, unexpected shape)
+is tolerated: we never 500 on a report we can't parse. A browser
+firing reports is not a client we control, so robustness beats
+strictness here. The endpoint always answers ``204 No Content``.
+
+Each parsed violation is persisted to ``audit_events`` via the shared
+``record_audit_event`` independent-session path (event type
+``security.csp_violation``, outcome ``failure`` — a CSP violation is by
+definition a policy breach worth recording). Only a **bounded
+allowlist** of fields is copied into ``detail``; full report bodies can
+carry user-bearing URLs (``document-uri``, ``blocked-uri``,
+``source-file``) so we truncate each to a fixed cap and never log the
+raw payload at INFO.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+import structlog
+from fastapi import APIRouter, Request, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.deps import get_session_factory
+from app.rate_limit import get_client_ip, limiter
+from app.services import audit_service
+
+
+logger = structlog.stdlib.get_logger()
+
+router = APIRouter(prefix="/api/v1/security", tags=["security"])
+
+
+CSP_VIOLATION_EVENT_TYPE = "security.csp_violation"
+
+# Hard cap on the request body we will read. CSP reports are small
+# JSON blobs; anything past this is either malformed or hostile. We
+# read at most this many bytes and drop the rest, so a giant POST can
+# never blow up memory on this unauthenticated route.
+_MAX_BODY_BYTES = 16 * 1024  # 16 KiB
+
+# Cap on how many violation envelopes we record from a single
+# Reporting-API array. Browsers batch, but a single POST should never
+# spawn an unbounded number of audit rows.
+_MAX_REPORTS_PER_REQUEST = 20
+
+# Per-string truncation cap for any value copied into the audit detail.
+# Keeps URL-bearing fields bounded so the audit row can't balloon and
+# we don't persist enormous attacker-controlled strings.
+_MAX_FIELD_LEN = 512
+
+# Bounded allowlist of CSP-report fields we persist. Both the legacy
+# kebab-case keys and the Reporting-API camelCase keys are mapped onto
+# a single normalized snake_case key so the audit detail is uniform
+# regardless of which browser path delivered the report.
+_FIELD_ALIASES: dict[str, str] = {
+    # legacy (application/csp-report) keys
+    "document-uri": "document_uri",
+    "referrer": "referrer",
+    "violated-directive": "violated_directive",
+    "effective-directive": "effective_directive",
+    "original-policy": "original_policy",
+    "disposition": "disposition",
+    "blocked-uri": "blocked_uri",
+    "line-number": "line_number",
+    "column-number": "column_number",
+    "source-file": "source_file",
+    "status-code": "status_code",
+    "script-sample": "script_sample",
+    # Reporting-API (application/reports+json) camelCase keys
+    "documentURL": "document_uri",
+    "violatedDirective": "violated_directive",
+    "effectiveDirective": "effective_directive",
+    "originalPolicy": "original_policy",
+    "blockedURL": "blocked_uri",
+    "lineNumber": "line_number",
+    "columnNumber": "column_number",
+    "sourceFile": "source_file",
+    "statusCode": "status_code",
+    "sample": "script_sample",
+}
+
+
+def _bounded(value: Any) -> Any:
+    """Coerce a single report field to a JSON-safe, bounded value.
+
+    Strings are truncated to ``_MAX_FIELD_LEN``. ints/bools pass
+    through. Anything else (nested dict/list/None) is dropped by
+    returning ``None`` so it isn't copied into the audit detail.
+    """
+    if isinstance(value, bool) or isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return value[:_MAX_FIELD_LEN]
+    return None
+
+
+def _extract_detail(report_body: Any) -> Optional[dict[str, Any]]:
+    """Map an allowlist of fields out of a single CSP-report body into a
+    normalized, bounded ``detail`` dict. Returns ``None`` if the input
+    isn't a dict (so the caller can skip it).
+    """
+    if not isinstance(report_body, dict):
+        return None
+    detail: dict[str, Any] = {}
+    for raw_key, norm_key in _FIELD_ALIASES.items():
+        if raw_key not in report_body:
+            continue
+        bounded = _bounded(report_body[raw_key])
+        if bounded is None:
+            continue
+        # First writer wins: if both the kebab and camel alias for the
+        # same normalized key are present, keep the first non-empty one.
+        detail.setdefault(norm_key, bounded)
+    return detail
+
+
+def _parse_reports(payload: Any) -> list[dict[str, Any]]:
+    """Normalize whatever JSON arrived into a list of report bodies.
+
+    Handles both supported shapes and silently yields an empty list for
+    anything unrecognized:
+
+    * ``{"csp-report": {...}}``           → ``[{...}]``   (legacy)
+    * ``[{"type": "...", "body": {...}}]``→ ``[{...}, ...]`` (Reporting API)
+    """
+    bodies: list[dict[str, Any]] = []
+    if isinstance(payload, dict):
+        legacy = payload.get("csp-report")
+        if isinstance(legacy, dict):
+            bodies.append(legacy)
+    elif isinstance(payload, list):
+        for envelope in payload[:_MAX_REPORTS_PER_REQUEST]:
+            if not isinstance(envelope, dict):
+                continue
+            body = envelope.get("body")
+            if isinstance(body, dict):
+                bodies.append(body)
+    return bodies[:_MAX_REPORTS_PER_REQUEST]
+
+
+def _request_id() -> Optional[str]:
+    return structlog.contextvars.get_contextvars().get("request_id")
+
+
+@router.post(
+    "/csp-report",
+    status_code=status.HTTP_204_NO_CONTENT,
+    include_in_schema=False,
+)
+@limiter.limit("60/minute")
+async def csp_report(request: Request) -> Response:
+    """Accept a CSP violation report and persist it to ``audit_events``.
+
+    Public (no auth). Always returns ``204``; never 500s on an
+    unparseable report. Uses an independent session for the audit write
+    (via ``record_audit_event``) so it doesn't depend on a request-
+    scoped DB dependency on this anonymous route.
+    """
+    # Pull the session factory directly (not via Depends) so this stays
+    # a zero-dependency public route — nothing here resolves auth.
+    session_factory: async_sessionmaker[AsyncSession] = get_session_factory()
+
+    # Cheap pre-check on this unauthenticated route: if the client
+    # advertises an oversized body, drop it before buffering anything.
+    declared_len = request.headers.get("content-length")
+    if declared_len is not None:
+        try:
+            if int(declared_len) > _MAX_BODY_BYTES:
+                await logger.ainfo(
+                    "security.csp_report.oversized",
+                    content_length=declared_len,
+                )
+                return Response(status_code=status.HTTP_204_NO_CONTENT)
+        except ValueError:
+            pass
+
+    raw = await request.body()
+    if len(raw) > _MAX_BODY_BYTES:
+        raw = raw[:_MAX_BODY_BYTES]
+
+    payload: Any = None
+    if raw:
+        try:
+            payload = json.loads(raw)
+        except (ValueError, UnicodeDecodeError):
+            payload = None
+
+    bodies = _parse_reports(payload)
+
+    if not bodies:
+        # Nothing recognizable. Emit a low-cardinality breadcrumb (no
+        # payload) so a flood of malformed reports is still visible in
+        # logs without leaking content, then accept gracefully.
+        await logger.ainfo(
+            "security.csp_report.unparsed",
+            content_type=request.headers.get("content-type", ""),
+            byte_len=len(raw),
+        )
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    client_ip = get_client_ip(request)
+    request_id = _request_id()
+
+    for body in bodies:
+        detail = _extract_detail(body)
+        # Structured breadcrumb at INFO — only the (bounded) directive,
+        # never the full payload or URL-bearing fields.
+        await logger.ainfo(
+            "security.csp_violation",
+            violated_directive=(detail or {}).get("violated_directive"),
+            effective_directive=(detail or {}).get("effective_directive"),
+        )
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type=CSP_VIOLATION_EVENT_TYPE,
+            actor_user_id=None,
+            # No authenticated actor on this public route; sentinel keeps
+            # the NOT NULL actor_email column satisfied.
+            actor_email="anonymous",
+            target_org_id=None,
+            target_org_name=None,
+            request_id=request_id,
+            ip_address=client_ip,
+            outcome="failure",
+            detail=detail or None,
+        )
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/tests/test_csp_report.py
+++ b/backend/tests/test_csp_report.py
@@ -19,6 +19,8 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
@@ -31,6 +33,7 @@ import app.routers.security as security_router_module
 from app.deps import get_session_factory
 from app.models import Base
 from app.models.audit_event import AuditEvent, AuditOutcome
+from app.rate_limit import limiter
 from app.routers.security import CSP_VIOLATION_EVENT_TYPE, router as security_router
 
 
@@ -50,6 +53,17 @@ async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
         await engine.dispose()
 
 
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    """Each test starts and ends with an empty rate-limiter state. The
+    SlowAPI ``Limiter`` is a module-level singleton; without an explicit
+    reset the per-IP counter from one test bleeds into the next and a
+    perfectly good test fails with a stale 429."""
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
 @pytest_asyncio.fixture
 async def client(session_factory, monkeypatch) -> AsyncIterator[AsyncClient]:
     # The router pulls the session factory by CALLING get_session_factory()
@@ -60,6 +74,11 @@ async def client(session_factory, monkeypatch) -> AsyncIterator[AsyncClient]:
     )
 
     app = FastAPI()
+    # Wire the shared limiter so ``@limiter.limit("60/minute")`` on the
+    # route surfaces 429s through the handler chain (mirrors prod wiring
+    # in app.main and the pattern in test_rate_limit_sensitive_endpoints).
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
     app.dependency_overrides[get_session_factory] = lambda: session_factory
     app.include_router(security_router)
     transport = ASGITransport(app=app)
@@ -239,3 +258,56 @@ async def test_client_ip_recorded(client, session_factory):
     # ip_address is resolved via get_client_ip; in the ASGI test client
     # request.client is populated, so a non-null value lands.
     assert rows[0].ip_address is not None
+
+
+@pytest.mark.asyncio
+async def test_empty_alias_does_not_shadow_nonempty_alias(client, session_factory):
+    """An empty legacy alias must not win over a non-empty camelCase one.
+
+    Both ``blocked-uri`` (kebab) and ``blockedURL`` (camel) normalize to
+    ``blocked_uri``. The kebab key is iterated first, but its value is an
+    empty string, so the non-empty camelCase value must be the one that
+    lands (the "first NON-empty writer wins" rule).
+    """
+    body = {
+        "csp-report": {
+            "violated-directive": "script-src",
+            "blocked-uri": "",
+            "blockedURL": "https://real.example.com/x.js",
+        }
+    }
+    resp = await client.post(
+        "/api/v1/security/csp-report",
+        json=body,
+        headers={"content-type": "application/csp-report"},
+    )
+    assert resp.status_code == 204
+
+    rows = await _audit_rows(session_factory)
+    assert len(rows) == 1
+    assert rows[0].detail["blocked_uri"] == "https://real.example.com/x.js"
+
+
+@pytest.mark.asyncio
+async def test_csp_report_rate_limited(client, session_factory):
+    """The route carries ``@limiter.limit("60/minute")``: the 61st POST
+    from the same IP within the minute returns 429.
+
+    Mirrors the wiring in test_rate_limit_sensitive_endpoints.py — the
+    ``reset_limiter`` autouse fixture clears the per-IP counter, the
+    ``client`` fixture wires ``app.state.limiter`` + the
+    ``RateLimitExceeded`` handler, and each accepted call increments the
+    counter. If the slowapi limiter were disabled/failing-open in this
+    env the first 60 calls would still pass, so this asserts the
+    configured limit is actually enforced.
+    """
+    body = {"csp-report": {"violated-directive": "img-src"}}
+
+    # 60 reports within the minute are accepted (204).
+    for i in range(60):
+        resp = await client.post("/api/v1/security/csp-report", json=body)
+        assert resp.status_code == 204, f"call {i} unexpectedly {resp.status_code}"
+
+    # 61st within the same minute for the same IP → 429.
+    throttled = await client.post("/api/v1/security/csp-report", json=body)
+    assert throttled.status_code == 429

--- a/backend/tests/test_csp_report.py
+++ b/backend/tests/test_csp_report.py
@@ -1,0 +1,241 @@
+"""Tests for the public CSP violation-report sink.
+
+POST /api/v1/security/csp-report — covers:
+
+- Public access (no auth dependency; an unauthenticated request is
+  accepted, not 401/403).
+- Legacy ``{"csp-report": {...}}`` body → one audit row.
+- Reporting-API array ``[{"type", "body"}]`` → one row per envelope.
+- Audit detail is bounded + normalized (kebab + camel keys collapse to
+  the same snake_case keys; oversized fields truncated).
+- Malformed / unknown shapes never 500 and write no audit row.
+- ``client_ip`` and ``request_id`` land on the audit row.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+import app.routers.security as security_router_module
+from app.deps import get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent, AuditOutcome
+from app.routers.security import CSP_VIOLATION_EVENT_TYPE, router as security_router
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(session_factory, monkeypatch) -> AsyncIterator[AsyncClient]:
+    # The router pulls the session factory by CALLING get_session_factory()
+    # directly (not via Depends), so a dependency_overrides entry alone
+    # won't reach it. Patch the symbol the router imported.
+    monkeypatch.setattr(
+        security_router_module, "get_session_factory", lambda: session_factory
+    )
+
+    app = FastAPI()
+    app.dependency_overrides[get_session_factory] = lambda: session_factory
+    app.include_router(security_router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def _audit_rows(factory) -> list[AuditEvent]:
+    async with factory() as db:
+        rows = (
+            await db.execute(select(AuditEvent).order_by(AuditEvent.id.asc()))
+        ).scalars().all()
+        return list(rows)
+
+
+@pytest.mark.asyncio
+async def test_legacy_csp_report_writes_one_audit_row(client, session_factory):
+    body = {
+        "csp-report": {
+            "document-uri": "https://app.example.com/dashboard",
+            "violated-directive": "script-src",
+            "effective-directive": "script-src-elem",
+            "blocked-uri": "https://evil.example.com/x.js",
+            "disposition": "enforce",
+            "line-number": 42,
+        }
+    }
+    resp = await client.post(
+        "/api/v1/security/csp-report",
+        json=body,
+        headers={"content-type": "application/csp-report"},
+    )
+    assert resp.status_code == 204
+
+    rows = await _audit_rows(session_factory)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.event_type == CSP_VIOLATION_EVENT_TYPE
+    assert row.outcome == AuditOutcome.FAILURE
+    assert row.actor_user_id is None
+    assert row.actor_email == "anonymous"
+    assert row.target_org_id is None
+    assert row.detail["violated_directive"] == "script-src"
+    assert row.detail["effective_directive"] == "script-src-elem"
+    assert row.detail["blocked_uri"] == "https://evil.example.com/x.js"
+    assert row.detail["document_uri"] == "https://app.example.com/dashboard"
+    assert row.detail["line_number"] == 42
+
+
+@pytest.mark.asyncio
+async def test_public_access_no_auth_required(client, session_factory):
+    # No Authorization header at all — must be accepted, not 401/403.
+    resp = await client.post(
+        "/api/v1/security/csp-report",
+        json={"csp-report": {"violated-directive": "img-src"}},
+    )
+    assert resp.status_code == 204
+    rows = await _audit_rows(session_factory)
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_reporting_api_array_writes_row_per_envelope(client, session_factory):
+    payload = [
+        {
+            "type": "csp-violation",
+            "body": {
+                "documentURL": "https://app.example.com/a",
+                "violatedDirective": "style-src",
+                "blockedURL": "inline",
+            },
+        },
+        {
+            "type": "csp-violation",
+            "body": {
+                "documentURL": "https://app.example.com/b",
+                "effectiveDirective": "font-src",
+            },
+        },
+    ]
+    resp = await client.post(
+        "/api/v1/security/csp-report",
+        json=payload,
+        headers={"content-type": "application/reports+json"},
+    )
+    assert resp.status_code == 204
+
+    rows = await _audit_rows(session_factory)
+    assert len(rows) == 2
+    # camelCase keys normalized to the same snake_case keys as legacy.
+    assert rows[0].detail["violated_directive"] == "style-src"
+    assert rows[0].detail["blocked_uri"] == "inline"
+    assert rows[1].detail["effective_directive"] == "font-src"
+
+
+@pytest.mark.asyncio
+async def test_oversized_field_is_truncated(client, session_factory):
+    long_uri = "https://app.example.com/" + ("a" * 5000)
+    resp = await client.post(
+        "/api/v1/security/csp-report",
+        json={"csp-report": {"blocked-uri": long_uri, "violated-directive": "x"}},
+    )
+    assert resp.status_code == 204
+    rows = await _audit_rows(session_factory)
+    assert len(rows[0].detail["blocked_uri"]) == 512
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_no_500_no_row(client, session_factory):
+    resp = await client.post(
+        "/api/v1/security/csp-report",
+        content=b"this is not json{{{",
+        headers={"content-type": "application/csp-report"},
+    )
+    assert resp.status_code == 204
+    assert await _audit_rows(session_factory) == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_shape_no_500_no_row(client, session_factory):
+    # Valid JSON but neither supported shape.
+    resp = await client.post(
+        "/api/v1/security/csp-report",
+        json={"totally": "unexpected"},
+    )
+    assert resp.status_code == 204
+    assert await _audit_rows(session_factory) == []
+
+    # Empty body.
+    resp = await client.post("/api/v1/security/csp-report", content=b"")
+    assert resp.status_code == 204
+    assert await _audit_rows(session_factory) == []
+
+
+@pytest.mark.asyncio
+async def test_array_envelope_count_is_bounded(client, session_factory):
+    payload = [
+        {"type": "csp-violation", "body": {"violatedDirective": f"d{i}"}}
+        for i in range(50)
+    ]
+    resp = await client.post(
+        "/api/v1/security/csp-report",
+        json=payload,
+        headers={"content-type": "application/reports+json"},
+    )
+    assert resp.status_code == 204
+    rows = await _audit_rows(session_factory)
+    # Capped at _MAX_REPORTS_PER_REQUEST (20).
+    assert len(rows) == 20
+
+
+@pytest.mark.asyncio
+async def test_oversized_content_length_rejected_before_buffering(
+    client, session_factory
+):
+    # An oversized real body (advertised via Content-Length) is dropped
+    # before parsing, so no audit row is written.
+    big_body = b'{"csp-report": {"violated-directive": "x", "pad": "' + b"a" * (64 * 1024) + b'"}}'
+    resp = await client.post(
+        "/api/v1/security/csp-report",
+        content=big_body,
+        headers={"content-type": "application/csp-report"},
+    )
+    assert resp.status_code == 204
+    assert await _audit_rows(session_factory) == []
+
+
+@pytest.mark.asyncio
+async def test_client_ip_recorded(client, session_factory):
+    resp = await client.post(
+        "/api/v1/security/csp-report",
+        json={"csp-report": {"violated-directive": "connect-src"}},
+        headers={"x-request-id": "req-abc"},
+    )
+    assert resp.status_code == 204
+    rows = await _audit_rows(session_factory)
+    # ip_address is resolved via get_client_ip; in the ASGI test client
+    # request.client is populated, so a non-null value lands.
+    assert rows[0].ip_address is not None

--- a/frontend/lib/security-headers.ts
+++ b/frontend/lib/security-headers.ts
@@ -27,6 +27,41 @@
 
 const isDev = process.env.NODE_ENV !== "production";
 
+/**
+ * Same-origin path the backend exposes for CSP violation reports
+ * (``backend/app/routers/security.py``). nginx (dev) / DO ingress
+ * (prod) routes ``/api/*`` to the backend, so this resolves on the
+ * same host the page was served from — no cross-origin reporting,
+ * nothing extra to allowlist in ``connect-src``.
+ */
+const CSP_REPORT_PATH = "/api/v1/security/csp-report";
+
+/**
+ * Named reporting group referenced by the ``report-to`` CSP directive
+ * and defined by the ``Reporting-Endpoints`` response header. The two
+ * MUST agree on this token for the modern Reporting API path to work.
+ */
+const CSP_REPORT_GROUP = "csp-endpoint";
+
+/**
+ * Reporting directives appended to every CSP. ``report-uri`` is the
+ * legacy directive (still honored by current browsers and the only one
+ * Safari supports); ``report-to`` is the modern Reporting API directive
+ * and pairs with the ``Reporting-Endpoints`` header below. Emitting
+ * both maximizes coverage across browsers.
+ */
+const cspReportDirectives = [
+  `report-uri ${CSP_REPORT_PATH}`,
+  `report-to ${CSP_REPORT_GROUP}`,
+];
+
+/**
+ * Value for the ``Reporting-Endpoints`` response header, which maps the
+ * ``report-to`` group name to a same-origin URL. Structured-header
+ * syntax: ``group="url"``.
+ */
+export const reportingEndpointsHeader = `${CSP_REPORT_GROUP}="${CSP_REPORT_PATH}"`;
+
 // If the frontend is deployed with a cross-origin API URL (e.g.,
 // separate DO App Platform components), allow that origin in
 // connect-src so api.ts fetch() calls aren't blocked. Empty string →
@@ -103,6 +138,7 @@ export function buildCspDirectives(nonce: string): string {
     "form-action 'self'",
     "object-src 'none'",
     "upgrade-insecure-requests",
+    ...cspReportDirectives,
   ].join("; ");
 }
 
@@ -133,6 +169,7 @@ export const cspDirectives = [
   "form-action 'self'",
   "object-src 'none'",
   "upgrade-insecure-requests",
+  ...cspReportDirectives,
 ].join("; ");
 
 /**
@@ -141,6 +178,10 @@ export const cspDirectives = [
  */
 export const securityHeaders: { key: string; value: string }[] = [
   { key: "Content-Security-Policy", value: cspDirectives },
+  // Maps the ``report-to`` group name to the same-origin report sink.
+  // Required for the modern Reporting API delivery path; the legacy
+  // ``report-uri`` directive works without it.
+  { key: "Reporting-Endpoints", value: reportingEndpointsHeader },
   { key: "X-Frame-Options", value: "DENY" },
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },


### PR DESCRIPTION
Wires up Content-Security-Policy violation reporting so CSP breakages get captured durably.

## Backend
- New public `POST /api/v1/security/csp-report` (`backend/app/routers/security.py`, registered in `main.py`). No auth dependency, since browsers send these reports unauthenticated.
- Accepts both report shapes: legacy `application/csp-report` `{"csp-report": {...}}` and the Reporting API `application/reports+json` array. Tolerates malformed JSON / unknown shapes gracefully (always `204`, never 500s).
- Each parsed violation is written to `audit_events` via the existing `record_audit_event` independent-session path (event type `security.csp_violation`, outcome `failure`). `client_ip` + `request_id` are bound; `actor_email` uses an `anonymous` sentinel.
- Defensive bounds on an unauthenticated route: early Content-Length pre-check, 16 KiB body cap, max 20 envelopes per request, 512-char per-field truncation, and a bounded normalized field allowlist. Full payloads are never logged at info (only the bounded directive name).
- Rate-limited (`60/minute` per IP) and excluded from the public OpenAPI schema.
- No DB migration: `audit_events` already exists.

## Frontend
- Appends `report-uri` + `report-to` to the existing CSP in `frontend/lib/security-headers.ts` (both no-nonce and per-request nonce builders) and adds a `Reporting-Endpoints` response header mapping the `report-to` group to the same-origin `/api/v1/security/csp-report`. No new CSP was invented; the existing one is extended in place, and the header propagates through `proxy.ts` automatically.

## Tests
- `backend/tests/test_csp_report.py` (9 tests): both report shapes, the audit write, public/no-auth access, field normalization + truncation, malformed/unknown-shape tolerance, envelope-count bound, oversized-body rejection, and client_ip recording. All green. Existing `test_security_headers` + frontend `proxy-csp-nonce` tests still pass; `tsc --noEmit` and the design-token check are clean.