### PR TITLE
test(backend): shared test-app factory

### DIFF
--- a/backend/tests/factories/__init__.py
+++ b/backend/tests/factories/__init__.py
@@ -1,0 +1,12 @@
+"""Shared test-infra factories.
+
+See :mod:`tests.factories.app` for ``make_test_app`` — the single place that
+builds a configured FastAPI test app with the ``get_db`` /
+``get_current_user`` / ``get_session_factory`` dependency overrides every
+router test was previously hand-rolling.
+"""
+
+from tests.factories.app import make_test_app
+
+
+__all__ = ["make_test_app"]

--- a/backend/tests/factories/app.py
+++ b/backend/tests/factories/app.py
@@ -1,0 +1,150 @@
+"""Shared FastAPI test-app factory.
+
+Almost every router test built its own ``_make_app``/``make_app`` helper that
+did the same four things:
+
+1. ``app = FastAPI()``
+2. override ``get_db`` to yield a session from a test ``session_factory``
+3. override ``get_current_user`` to return a seeded ``User``
+4. (sometimes) override ``get_session_factory`` to return the factory itself
+5. ``app.include_router(...)`` for the router(s) under test
+
+``make_test_app`` collapses that boilerplate into one place while preserving
+the *exact* override semantics each call site relied on. It deliberately makes
+no assumptions a caller didn't ask for: nothing is overridden unless a value
+was supplied.
+
+Override contracts (kept byte-for-byte equivalent to the hand-rolled helpers):
+
+- ``get_db`` →  ``async with session_factory() as session: yield session``
+- ``get_session_factory`` →  returns the factory object itself
+- ``get_current_user`` →  see the ``current_user`` parameter below
+
+Example::
+
+    from tests.factories import make_test_app
+    from app.routers.accounts import router as accounts_router
+
+    app = make_test_app(session_factory, routers=accounts_router,
+                        current_user=admin_resolver)
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
+from typing import Union
+
+from fastapi import APIRouter, FastAPI
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models.user import User
+
+
+# A current-user spec is one of:
+#   - a ``User`` instance (returned as-is)
+#   - a zero-arg callable returning a ``User`` (sync or async)
+#   - a one-arg callable taking the session_factory, returning a ``User``
+#     (sync or async) — the ``current_user_resolver(session_factory)`` shape
+#   - ``None`` → do not override get_current_user (anonymous app)
+CurrentUserSpec = Union[
+    User,
+    Callable[[], Union[User, Awaitable[User]]],
+    Callable[[async_sessionmaker[AsyncSession]], Union[User, Awaitable[User]]],
+    None,
+]
+
+
+def make_test_app(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    routers: Union[APIRouter, Iterable[APIRouter], None] = None,
+    current_user: CurrentUserSpec = None,
+    override_session_factory: bool = False,
+) -> FastAPI:
+    """Build a configured FastAPI app for a router test.
+
+    Parameters
+    ----------
+    session_factory:
+        The test ``async_sessionmaker`` (typically an in-memory aiosqlite
+        engine). ``get_db`` is always overridden to yield from it.
+    routers:
+        A single ``APIRouter`` or an iterable of them to mount on the app.
+        ``None`` mounts nothing (caller mounts later if needed).
+    current_user:
+        Controls the ``get_current_user`` override. See ``CurrentUserSpec``:
+
+        - ``None`` (default): leave ``get_current_user`` un-overridden, so the
+          app authenticates anonymously (the auth-route pattern).
+        - a ``User``: return that instance.
+        - a callable: invoked to resolve the user. If it accepts an argument
+          it is called with ``session_factory`` (the ``current_user_resolver``
+          /``current_user_factory`` shape); otherwise it is called with no
+          args. The result is awaited if it is a coroutine. This covers both
+          the "resolver closure" and "resolve inline from the factory" styles.
+    override_session_factory:
+        When True, also override ``get_session_factory`` to return the factory
+        object itself (the shape used by routers that depend on it directly).
+    """
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    if override_session_factory:
+        async def override_get_session_factory() -> async_sessionmaker[AsyncSession]:
+            return session_factory
+
+        app.dependency_overrides[get_session_factory] = override_get_session_factory
+
+    if current_user is not None:
+        resolver = _make_current_user_resolver(session_factory, current_user)
+        app.dependency_overrides[get_current_user] = resolver
+
+    if routers is not None:
+        if isinstance(routers, APIRouter):
+            routers = [routers]
+        for router in routers:
+            app.include_router(router)
+
+    return app
+
+
+def _make_current_user_resolver(
+    session_factory: async_sessionmaker[AsyncSession],
+    current_user: CurrentUserSpec,
+):
+    """Build the ``get_current_user`` override coroutine for ``current_user``.
+
+    Normalises the three accepted ``current_user`` shapes (instance, zero-arg
+    callable, one-arg ``(factory)`` callable — each sync or async) into a
+    single async override that returns a ``User``.
+    """
+    import inspect
+
+    if isinstance(current_user, User):
+
+        async def override_current_user() -> User:
+            return current_user
+
+        return override_current_user
+
+    # It's a callable. Decide whether it wants the session_factory argument.
+    try:
+        sig = inspect.signature(current_user)
+        wants_factory = len(sig.parameters) >= 1
+    except (TypeError, ValueError):  # builtins / un-introspectable callables
+        wants_factory = False
+
+    async def override_current_user() -> User:
+        result = current_user(session_factory) if wants_factory else current_user()
+        if inspect.isawaitable(result):
+            result = await result
+        return result
+
+    return override_current_user

--- a/backend/tests/factories/app.py
+++ b/backend/tests/factories/app.py
@@ -31,6 +31,7 @@ Example::
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from typing import Union
 
@@ -124,9 +125,14 @@ def _make_current_user_resolver(
     Normalises the three accepted ``current_user`` shapes (instance, zero-arg
     callable, one-arg ``(factory)`` callable — each sync or async) into a
     single async override that returns a ``User``.
-    """
-    import inspect
 
+    Resolver contract: a ``current_user`` resolver must be a plain 0- or
+    1-positional-arg callable (sync or async); the 1-arg form receives the
+    ``session_factory``. We decide arity by counting only *required positional*
+    parameters (POSITIONAL_ONLY / POSITIONAL_OR_KEYWORD with no default), so
+    incidental shapes like ``def r(*args)`` or ``def r(factory=None)`` resolve
+    as zero-arg and are not mis-routed the session_factory.
+    """
     if isinstance(current_user, User):
 
         async def override_current_user() -> User:
@@ -134,10 +140,18 @@ def _make_current_user_resolver(
 
         return override_current_user
 
-    # It's a callable. Decide whether it wants the session_factory argument.
+    # It's a callable. Decide whether it wants the session_factory argument by
+    # counting only required positional params (no default). ``*args``,
+    # ``**kwargs``, keyword-only, and defaulted params do not count.
     try:
         sig = inspect.signature(current_user)
-        wants_factory = len(sig.parameters) >= 1
+        required_positional = [
+            p
+            for p in sig.parameters.values()
+            if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+            and p.default is p.empty
+        ]
+        wants_factory = len(required_positional) >= 1
     except (TypeError, ValueError):  # builtins / un-introspectable callables
         wants_factory = False
 

--- a/backend/tests/factories/test_app_factory.py
+++ b/backend/tests/factories/test_app_factory.py
@@ -1,0 +1,225 @@
+"""Direct contract tests for ``make_test_app`` (the shared test-app factory).
+
+These lock the ``current_user`` resolution contract documented in
+``tests.factories.app``: a resolver must be a plain 0- or 1-positional-arg
+callable (sync or async); the 1-arg form receives the ``session_factory``.
+
+Every accepted ``current_user`` *shape* is exercised end-to-end through a
+protected route:
+
+  (a) a ``User`` instance
+  (b) a zero-arg sync callable
+  (c) a zero-arg async callable
+  (d) a one-arg ``(factory)`` sync resolver
+  (e) a one-arg ``(factory)`` async resolver
+  (f) ``None`` → anonymous → protected route returns 401
+
+The 7 router files migrated onto the factory only exercise shape (d)/(e); the
+``User``-instance and anonymous paths are pinned here before the remaining
+files migrate.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import APIRouter, Depends, FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.deps import get_current_user
+from app.models import Organization
+from app.models.base import Base
+from app.models.user import Role, User
+from app.security import hash_password
+from tests.factories import make_test_app
+
+
+# A tiny protected router so the factory contract is tested in isolation,
+# independent of any production router's seed requirements.
+probe_router = APIRouter()
+
+
+@probe_router.get("/whoami")
+async def whoami(user: User = Depends(get_current_user)) -> dict:
+    return {"id": user.id, "username": user.username}
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with factory() as db:
+        org = Organization(name="Probe Org", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        db.add(
+            User(
+                org_id=org.id,
+                username="probe",
+                email="probe@example.com",
+                password_hash=hash_password("x"),
+                role=Role.OWNER,
+                is_superadmin=True,
+            )
+        )
+        await db.commit()
+
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _load_user(factory) -> User:
+    async with factory() as db:
+        return (
+            await db.execute(select(User).where(User.username == "probe"))
+        ).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_current_user_user_instance(session_factory):
+    """Shape (a): a bare ``User`` instance is returned as-is."""
+    user = await _load_user(session_factory)
+    app = make_test_app(session_factory, routers=probe_router, current_user=user)
+
+    with TestClient(app) as client:
+        resp = client.get("/whoami")
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "probe"
+
+
+@pytest.mark.asyncio
+async def test_current_user_zero_arg_sync(session_factory):
+    """Shape (b): a zero-arg sync callable returning a ``User``."""
+    user = await _load_user(session_factory)
+
+    def resolver() -> User:
+        return user
+
+    app = make_test_app(session_factory, routers=probe_router, current_user=resolver)
+
+    with TestClient(app) as client:
+        resp = client.get("/whoami")
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "probe"
+
+
+@pytest.mark.asyncio
+async def test_current_user_zero_arg_async(session_factory):
+    """Shape (c): a zero-arg async callable returning a ``User``."""
+    user = await _load_user(session_factory)
+
+    async def resolver() -> User:
+        return user
+
+    app = make_test_app(session_factory, routers=probe_router, current_user=resolver)
+
+    with TestClient(app) as client:
+        resp = client.get("/whoami")
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "probe"
+
+
+@pytest.mark.asyncio
+async def test_current_user_one_arg_sync(session_factory):
+    """Shape (d): a one-arg ``(factory)`` sync resolver receives the factory."""
+
+    def resolver(factory) -> User:
+        # Prove the factory argument is the one we passed in.
+        assert factory is session_factory
+        # Resolve synchronously via a throwaway connection isn't trivial, so
+        # just return a detached instance built off known seed data; the point
+        # of this shape is the factory hand-off, exercised above.
+        return User(
+            id=999,
+            org_id=1,
+            username="sync-one-arg",
+            email="s1@example.com",
+            password_hash="x",
+            role=Role.OWNER,
+        )
+
+    app = make_test_app(session_factory, routers=probe_router, current_user=resolver)
+
+    with TestClient(app) as client:
+        resp = client.get("/whoami")
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "sync-one-arg"
+
+
+@pytest.mark.asyncio
+async def test_current_user_one_arg_async(session_factory):
+    """Shape (e): a one-arg ``(factory)`` async resolver loads via the factory."""
+
+    async def resolver(factory) -> User:
+        assert factory is session_factory
+        async with factory() as db:
+            return (
+                await db.execute(select(User).where(User.username == "probe"))
+            ).scalar_one()
+
+    app = make_test_app(session_factory, routers=probe_router, current_user=resolver)
+
+    with TestClient(app) as client:
+        resp = client.get("/whoami")
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "probe"
+
+
+@pytest.mark.asyncio
+async def test_current_user_none_is_anonymous_401(session_factory):
+    """Shape (f): ``None`` leaves ``get_current_user`` un-overridden, so a
+    protected route rejects an invalid/absent token with 401."""
+    app = make_test_app(session_factory, routers=probe_router, current_user=None)
+    assert get_current_user not in app.dependency_overrides
+
+    with TestClient(app) as client:
+        # A malformed bearer token passes the HTTPBearer scheme and reaches the
+        # real get_current_user decode path, which returns 401.
+        resp = client.get("/whoami", headers={"Authorization": "Bearer not-a-token"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_defaulted_and_varargs_resolvers_route_as_zero_arg(session_factory):
+    """Hardened arity heuristic: ``def r(factory=None)`` and ``def r(*args)``
+    have no *required positional* param, so they are called with zero args
+    (not handed the session_factory)."""
+    user = await _load_user(session_factory)
+
+    def defaulted(factory=None) -> User:
+        # If the factory were (wrongly) passed, this would be non-None.
+        assert factory is None
+        return user
+
+    def varargs(*args) -> User:
+        assert args == ()
+        return user
+
+    for resolver in (defaulted, varargs):
+        app = make_test_app(
+            session_factory, routers=probe_router, current_user=resolver
+        )
+        with TestClient(app) as client:
+            resp = client.get("/whoami")
+        assert resp.status_code == 200
+        assert resp.json()["username"] == "probe"

--- a/backend/tests/routers/test_accounts_change_type.py
+++ b/backend/tests/routers/test_accounts_change_type.py
@@ -25,8 +25,6 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
-from app.database import get_db
-from app.deps import get_current_user, get_session_factory
 from app.models import Account, AccountType, Organization
 from app.models.audit_event import AuditEvent
 from app.models.base import Base
@@ -35,6 +33,7 @@ from app.models.transaction import Transaction, TransactionStatus, TransactionTy
 from app.models.user import Role, User
 from app.routers.accounts import router as accounts_router
 from app.security import hash_password
+from tests.factories import make_test_app
 
 
 @pytest_asyncio.fixture
@@ -167,17 +166,8 @@ async def seeded(session_factory) -> dict:
 
 
 def _make_app(session_factory, *, as_other_org: bool = False) -> FastAPI:
-    app = FastAPI()
-
-    async def override_get_db() -> AsyncIterator[AsyncSession]:
-        async with session_factory() as session:
-            yield session
-
-    async def override_session_factory():
-        return session_factory
-
-    async def override_current_user() -> User:
-        async with session_factory() as db:
+    async def resolve_admin(factory) -> User:
+        async with factory() as db:
             if as_other_org:
                 # No user exists for the second org; the cross-tenant
                 # tests use the admin user's org_id mismatched against
@@ -187,11 +177,12 @@ def _make_app(session_factory, *, as_other_org: bool = False) -> FastAPI:
                 await db.execute(select(User).where(User.role == Role.ADMIN))
             ).scalar_one()
 
-    app.dependency_overrides[get_db] = override_get_db
-    app.dependency_overrides[get_session_factory] = override_session_factory
-    app.dependency_overrides[get_current_user] = override_current_user
-    app.include_router(accounts_router)
-    return app
+    return make_test_app(
+        session_factory,
+        routers=accounts_router,
+        current_user=resolve_admin,
+        override_session_factory=True,
+    )
 
 
 async def _audit_rows_for_type_changed(session_factory, account_id: int):

--- a/backend/tests/routers/test_admin_audit.py
+++ b/backend/tests/routers/test_admin_audit.py
@@ -9,24 +9,20 @@ Pins:
 from __future__ import annotations
 
 import datetime
-from collections.abc import AsyncIterator
-
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
-from app.database import get_db
-from app.deps import get_current_user
 from app.models import Base
 from app.models.audit_event import AuditEvent, AuditOutcome
 from app.models.user import Organization, Role, User
 from app.routers.admin_audit import router as admin_audit_router
 from app.security import hash_password
+from tests.factories import make_test_app
 
 
 @pytest_asyncio.fixture
@@ -53,19 +49,11 @@ async def session_factory():
 
 
 def make_app(session_factory, current_user_resolver):
-    app = FastAPI()
-
-    async def override_get_db() -> AsyncIterator[AsyncSession]:
-        async with session_factory() as session:
-            yield session
-
-    async def override_current_user() -> User:
-        return await current_user_resolver(session_factory)
-
-    app.dependency_overrides[get_db] = override_get_db
-    app.dependency_overrides[get_current_user] = override_current_user
-    app.include_router(admin_audit_router)
-    return app
+    return make_test_app(
+        session_factory,
+        routers=admin_audit_router,
+        current_user=current_user_resolver,
+    )
 
 
 async def _seed(factory) -> dict:

--- a/backend/tests/routers/test_announcements.py
+++ b/backend/tests/routers/test_announcements.py
@@ -20,7 +20,6 @@ from datetime import datetime, timedelta
 
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import event, select
 from sqlalchemy.engine import Engine
@@ -32,8 +31,6 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.pool import StaticPool
 
 from app._time import utcnow_naive
-from app.database import get_db
-from app.deps import get_current_user, get_session_factory
 from app.models import Base
 from app.models.announcement import (
     Announcement,
@@ -45,6 +42,7 @@ from app.models.user import Organization, Role, User
 from app.routers.admin_announcements import router as admin_router
 from app.routers.announcements import router as user_router
 from app.security import hash_password
+from tests.factories import make_test_app
 
 
 @pytest_asyncio.fixture
@@ -71,24 +69,12 @@ async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
 
 
 def _make_app(session_factory, current_user_resolver):
-    app = FastAPI()
-
-    async def override_get_db() -> AsyncIterator[AsyncSession]:
-        async with session_factory() as session:
-            yield session
-
-    async def override_current_user() -> User:
-        return await current_user_resolver(session_factory)
-
-    def override_session_factory():
-        return session_factory
-
-    app.dependency_overrides[get_db] = override_get_db
-    app.dependency_overrides[get_current_user] = override_current_user
-    app.dependency_overrides[get_session_factory] = override_session_factory
-    app.include_router(user_router)
-    app.include_router(admin_router)
-    return app
+    return make_test_app(
+        session_factory,
+        routers=[user_router, admin_router],
+        current_user=current_user_resolver,
+        override_session_factory=True,
+    )
 
 
 async def _seed_users(factory) -> dict:

--- a/backend/tests/routers/test_categories_c0.py
+++ b/backend/tests/routers/test_categories_c0.py
@@ -30,8 +30,6 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
-from app.database import get_db
-from app.deps import get_current_user
 from app.models import Account, AccountType, Category, Organization
 from app.models.audit_event import AuditEvent
 from app.models.base import Base
@@ -50,6 +48,7 @@ from app.models.transaction import Transaction, TransactionStatus, TransactionTy
 from app.models.user import Role, User
 from app.routers.categories import router as categories_router
 from app.security import hash_password
+from tests.factories import make_test_app
 
 
 @pytest_asyncio.fixture
@@ -77,25 +76,19 @@ async def session_factory():
         await engine.dispose()
 
 
+async def _resolve_superadmin(factory) -> User:
+    async with factory() as db:
+        return (
+            await db.execute(select(User).where(User.is_superadmin.is_(True)))
+        ).scalar_one()
+
+
 def make_app(session_factory) -> FastAPI:
-    app = FastAPI()
-
-    async def override_get_db() -> AsyncIterator[AsyncSession]:
-        async with session_factory() as session:
-            yield session
-
-    async def override_current_user() -> User:
-        async with session_factory() as db:
-            return (
-                await db.execute(
-                    select(User).where(User.is_superadmin.is_(True))
-                )
-            ).scalar_one()
-
-    app.dependency_overrides[get_db] = override_get_db
-    app.dependency_overrides[get_current_user] = override_current_user
-    app.include_router(categories_router)
-    return app
+    return make_test_app(
+        session_factory,
+        routers=categories_router,
+        current_user=_resolve_superadmin,
+    )
 
 
 async def _seed_basic(factory) -> dict:

--- a/backend/tests/routers/test_recurring_generate_route.py
+++ b/backend/tests/routers/test_recurring_generate_route.py
@@ -26,8 +26,6 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
-from app.database import get_db
-from app.deps import get_current_user
 from app.models import Account, AccountType, Category, Organization
 from app.models.base import Base
 from app.models.category import CategoryType
@@ -35,6 +33,7 @@ from app.models.recurring import Frequency, RecurringTransaction
 from app.models.user import Role, User
 from app.routers.recurring import router as recurring_router
 from app.security import hash_password
+from tests.factories import make_test_app
 
 
 # ── fixtures ───────────────────────────────────────────────────────────────
@@ -63,25 +62,20 @@ async def session_factory():
         await engine.dispose()
 
 
+async def _resolve_superadmin(factory) -> User:
+    from sqlalchemy import select as _select
+    async with factory() as db:
+        return (
+            await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+        ).scalar_one()
+
+
 def make_app(session_factory) -> FastAPI:
-    app = FastAPI()
-
-    async def override_get_db() -> AsyncIterator[AsyncSession]:
-        async with session_factory() as session:
-            yield session
-
-    async def override_current_user() -> User:
-        from sqlalchemy import select as _select
-        async with session_factory() as db:
-            return (
-                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
-            ).scalar_one()
-
-    app.dependency_overrides[get_db] = override_get_db
-    app.dependency_overrides[get_current_user] = override_current_user
-
-    app.include_router(recurring_router)
-    return app
+    return make_test_app(
+        session_factory,
+        routers=recurring_router,
+        current_user=_resolve_superadmin,
+    )
 
 
 async def _seed(factory) -> dict:

--- a/backend/tests/routers/test_tags.py
+++ b/backend/tests/routers/test_tags.py
@@ -6,22 +6,18 @@ in-memory SQLite + dependency-override pattern matches
 """
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
 from decimal import Decimal
 
 import datetime
 
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import event, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
-from app.database import get_db
-from app.deps import get_current_user, get_session_factory
 from app.models import Base
 from app.models.account import Account, AccountType
 from app.models.audit_event import AuditEvent
@@ -37,6 +33,7 @@ from app.models.transaction import Transaction, TransactionStatus, TransactionTy
 from app.models.user import Organization, Role, User
 from app.routers.tags import router as tags_router, transaction_tags_router
 from app.security import hash_password
+from tests.factories import make_test_app
 
 
 @pytest_asyncio.fixture
@@ -111,8 +108,22 @@ def make_app(factory, user_id: int):
     from fastapi.responses import JSONResponse
     from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
-    app = FastAPI()
+    async def resolve_user(session_factory) -> User:
+        async with session_factory() as db:
+            return (
+                await db.execute(select(User).where(User.id == user_id))
+            ).scalar_one()
 
+    app = make_test_app(
+        factory,
+        routers=[tags_router, transaction_tags_router],
+        current_user=resolve_user,
+        override_session_factory=True,
+    )
+
+    # These routers raise domain exceptions that the production app maps to
+    # HTTP status codes via app-level handlers; register the same handlers
+    # here so the status-code assertions hold against the isolated app.
     @app.exception_handler(NotFoundError)
     async def _nf(request, exc):
         return JSONResponse(status_code=404, content={"detail": str(exc)})
@@ -125,24 +136,6 @@ def make_app(factory, user_id: int):
     async def _ce(request, exc):
         return JSONResponse(status_code=409, content={"detail": exc.detail})
 
-    async def override_get_db() -> AsyncIterator[AsyncSession]:
-        async with factory() as session:
-            yield session
-
-    async def override_current_user() -> User:
-        async with factory() as db:
-            return (
-                await db.execute(select(User).where(User.id == user_id))
-            ).scalar_one()
-
-    def override_session_factory():
-        return factory
-
-    app.dependency_overrides[get_db] = override_get_db
-    app.dependency_overrides[get_current_user] = override_current_user
-    app.dependency_overrides[get_session_factory] = override_session_factory
-    app.include_router(tags_router)
-    app.include_router(transaction_tags_router)
     return app
 
 

--- a/backend/tests/routers/test_transactions_list_route.py
+++ b/backend/tests/routers/test_transactions_list_route.py
@@ -25,8 +25,6 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
-from app.database import get_db
-from app.deps import get_current_user
 from app.models import Account, AccountType, Category, Organization
 from app.models.base import Base
 from app.models.category import CategoryType
@@ -34,6 +32,7 @@ from app.models.transaction import Transaction, TransactionStatus, TransactionTy
 from app.models.user import Role, User
 from app.routers.transactions import router as transactions_router
 from app.security import hash_password
+from tests.factories import make_test_app
 
 
 # ── fixtures ───────────────────────────────────────────────────────────────
@@ -62,25 +61,20 @@ async def session_factory():
         await engine.dispose()
 
 
+async def _resolve_superadmin(factory) -> User:
+    from sqlalchemy import select as _select
+    async with factory() as db:
+        return (
+            await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+        ).scalar_one()
+
+
 def make_app(session_factory) -> FastAPI:
-    app = FastAPI()
-
-    async def override_get_db() -> AsyncIterator[AsyncSession]:
-        async with session_factory() as session:
-            yield session
-
-    async def override_current_user() -> User:
-        from sqlalchemy import select as _select
-        async with session_factory() as db:
-            return (
-                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
-            ).scalar_one()
-
-    app.dependency_overrides[get_db] = override_get_db
-    app.dependency_overrides[get_current_user] = override_current_user
-
-    app.include_router(transactions_router)
-    return app
+    return make_test_app(
+        session_factory,
+        routers=transactions_router,
+        current_user=_resolve_superadmin,
+    )
 
 
 async def _seed(factory) -> dict:


### PR DESCRIPTION
## What

Introduce a single shared test-app factory and migrate the duplicated
ad-hoc construction across router tests to it.

Almost every router test defined its own `_make_app`/`make_app` that did
the same four things: create `FastAPI()`, override `get_db` to yield from
a test `session_factory`, override `get_current_user` to return a seeded
`User`, sometimes override `get_session_factory`, and `include_router(...)`.

`tests/factories/app.py::make_test_app` collapses that into one place,
preserving the exact override semantics:

- `get_db` → `async with session_factory() as session: yield session`
- `get_session_factory` → returns the factory object itself (opt-in)
- `get_current_user` → resolves from a `User` instance, a zero-arg
  callable, or a `(factory) -> User` resolver (sync or async). `None`
  leaves it un-overridden for anonymous apps.

Nothing is overridden unless a value is supplied.

## Scope

Pure test-infra refactor. No `backend/app/` production code changes.

Migrated 7 representative call sites covering every variation found
(resolver-callback, inline-resolve, `session_factory` override,
multi-router, custom exception handlers):

- `test_accounts_change_type.py`
- `test_admin_audit.py`
- `test_announcements.py`
- `test_categories_c0.py`
- `test_recurring_generate_route.py`
- `test_transactions_list_route.py`
- `test_tags.py`

The remaining `_make_app` call sites are left for touch-when-adjacent
follow-up; the factory leaves a clean pattern to follow.

## Verification

Full backend suite green in an isolated compose project: 2254 passed,
9 skipped. The 7 migrated files: 142 passed, 1 skipped, identical to
pre-change.
