### PR TITLE
chore(legal): name FJ Cloud & AI Consulting as service operator

### DIFF
--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -46,7 +46,7 @@ export default function PrivacyPolicyPage() {
           <section>
             <p>
               The Better Decision (&ldquo;we&rdquo;, &ldquo;us&rdquo;) is a personal finance
-              application operated by Flamarion Jorge. We care about your
+              application operated by FJ Cloud &amp; AI Consulting. We care about your
               privacy and keep what we collect to the minimum needed to run
               the service. This policy explains what we collect, why, how
               long we keep it, and your rights.

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -45,7 +45,7 @@ export default function TermsOfServicePage() {
             <p>
               Welcome to The Better Decision. These Terms of Service (&ldquo;Terms&rdquo;)
               govern your use of The Better Decision personal finance application
-              operated by Flamarion Jorge. By creating an account or using
+              operated by FJ Cloud &amp; AI Consulting. By creating an account or using
               the service you agree to these Terms.
             </p>
           </section>


### PR DESCRIPTION
Replaces the personal name ("Flamarion Jorge") with the company name **FJ Cloud & AI Consulting** as the stated operator on the Privacy Policy and Terms of Service pages. These pages are part of the apex static export, so the change is also visible on the landing site.