### PR TITLE
fix(ai): raise ai_dispatch wall-clock timeout 5s to 30s

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -146,10 +146,11 @@ services:
       - key: AI_NATIVE_ENABLED
         scope: RUN_AND_BUILD_TIME
         value: "false"
-      # Wall-clock ceiling on a single AI dispatch adapter call. The 5 s
-      # code default was too tight for real structured-output completions
-      # (every call timed out); 30 s restores AI features while still
-      # bounding a hung provider.
+      # Wall-clock ceiling on a single AI dispatch adapter ATTEMPT (the
+      # structured path retries up to 3x, so worst case ~90 s, still under
+      # DO/Cloudflare's 100 s origin ceiling). The 5 s code default was too
+      # tight for a real structured-output completion (every attempt timed
+      # out); 30 s restores AI features while still bounding a hung provider.
       - key: AI_DISPATCH_TIMEOUT_S
         scope: RUN_AND_BUILD_TIME
         value: "30"

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -146,6 +146,13 @@ services:
       - key: AI_NATIVE_ENABLED
         scope: RUN_AND_BUILD_TIME
         value: "false"
+      # Wall-clock ceiling on a single AI dispatch adapter call. The 5 s
+      # code default was too tight for real structured-output completions
+      # (every call timed out); 30 s restores AI features while still
+      # bounding a hung provider.
+      - key: AI_DISPATCH_TIMEOUT_S
+        scope: RUN_AND_BUILD_TIME
+        value: "30"
       # Pinned ToS version. Bump to force every org to re-consent on
       # the next admin-UI mount. Existing rows are never auto-upgraded.
       - key: AI_NATIVE_CURRENT_CONSENT_VERSION

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -123,7 +123,15 @@ class Settings(BaseSettings):
     # On timeout the dispatcher records a system-failure ledger row and
     # raises ``AIDispatchFailed("provider_timeout")`` (5xx). Architect-
     # mandated reliability bound (AI tier decision, 2026-05-22).
-    ai_dispatch_timeout_s: float = 5.0
+    #
+    # The original 5 s ceiling proved too tight in production: a full
+    # structured-output completion (plus up to two schema retries) for a
+    # real provider routinely exceeds it, so every dispatch flat-lined at
+    # ~5000 ms and all AI features returned the "temporarily unavailable"
+    # empty state. 30 s covers a real round-trip while still bounding a
+    # hung provider well under the adapter's coarse read budget. Tunable
+    # via ``AI_DISPATCH_TIMEOUT_S``.
+    ai_dispatch_timeout_s: float = 30.0
 
     # Google SSO
     google_client_id: str = ""

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -124,13 +124,20 @@ class Settings(BaseSettings):
     # raises ``AIDispatchFailed("provider_timeout")`` (5xx). Architect-
     # mandated reliability bound (AI tier decision, 2026-05-22).
     #
-    # The original 5 s ceiling proved too tight in production: a full
-    # structured-output completion (plus up to two schema retries) for a
-    # real provider routinely exceeds it, so every dispatch flat-lined at
-    # ~5000 ms and all AI features returned the "temporarily unavailable"
-    # empty state. 30 s covers a real round-trip while still bounding a
-    # hung provider well under the adapter's coarse read budget. Tunable
-    # via ``AI_DISPATCH_TIMEOUT_S``.
+    # NOTE: this bounds a SINGLE provider attempt, not the whole dispatch.
+    # ``call_llm_structured`` wraps each attempt in ``_with_dispatch_timeout``
+    # *inside* the retry loop (``STRUCTURED_OUTPUT_MAX_RETRIES`` + 1 = up to
+    # 3 attempts), so the worst-case wall clock for a structured dispatch is
+    # ~3x this value (~90 s at 30 s). That still sits under DO/Cloudflare's
+    # 100 s origin-response ceiling, so the request is not truncated upstream.
+    #
+    # The original 5 s ceiling proved too tight in production: a single
+    # structured-output completion for a real provider routinely exceeds
+    # 5 s, so every attempt flat-lined at ~5000 ms and all AI features
+    # returned the "temporarily unavailable" empty state. 30 s/attempt
+    # covers a real round-trip while still bounding a hung provider well
+    # under the adapter's coarse read budget. Tunable via
+    # ``AI_DISPATCH_TIMEOUT_S``.
     ai_dispatch_timeout_s: float = 30.0
 
     # Google SSO


### PR DESCRIPTION
## Problem

All AI features (rebalance, smart forecast, smart budget) are returning the *"AI is temporarily unavailable"* empty state in production.

Production logs show every dispatch flat-lining at the wall-clock ceiling:

```
"feature_key": "smart_budget", "error_class": "provider_timeout", "latency_ms": 5002, "event": "ai.dispatch.structured.failed"
"error_class": "AIDispatchFailed", "event": "ai.budget.rebalance.unavailable"
```

Zero successful dispatches in the recent window. The flat ~5000ms (not a fast auth/connection error) confirms the provider *is* responding but is being cut off by the 5s `ai_dispatch_timeout_s` ceiling added as a DoS stopgap. A full structured-output completion plus up to two schema retries routinely exceeds 5s.

## Fix

- Raise the `ai_dispatch_timeout_s` default `5.0` → `30.0` (`backend/app/config.py`).
- Pin `AI_DISPATCH_TIMEOUT_S=30` in `.do/app.yaml` so it's explicit and tunable without a code change.

30s covers a real provider round-trip while still bounding a hung provider well under the adapter's coarse read budget.