### PR TITLE
fix(reports): label single-series bar chart tooltip

### DIFF
--- a/frontend/components/reports/ConfigRail.tsx
+++ b/frontend/components/reports/ConfigRail.tsx
@@ -49,6 +49,7 @@ import type {
   WidgetFilters,
 } from "@/lib/reports/types";
 import { isFieldOverridden } from "@/lib/reports/resolve";
+import { MEASURE_FIELD_LABELS } from "@/lib/reports/series";
 
 interface Props {
   widget: Widget;
@@ -72,12 +73,11 @@ const AGG_HELP_KEY: Record<Aggregation, HelpTooltipKey> = {
   distinct: "reports.agg.distinct",
 };
 
-const FIELD_OPTIONS: Array<{ value: MeasureField; label: string }> = [
-  { value: "amount", label: "Amount" },
-  { value: "id", label: "Row count (id)" },
-  { value: "category_id", label: "Category" },
-  { value: "account_id", label: "Account" },
-];
+// Derived from the shared measure-field label map so the editor picker,
+// chart tooltips, and CSV headers can never drift apart.
+const FIELD_OPTIONS: Array<{ value: MeasureField; label: string }> = (
+  Object.keys(MEASURE_FIELD_LABELS) as MeasureField[]
+).map((value) => ({ value, label: MEASURE_FIELD_LABELS[value] }));
 
 const DIMENSION_OPTIONS: Array<{ value: Dimension; label: string }> = [
   { value: "category", label: "Category" },

--- a/frontend/components/reports/widgets/BarWidget.tsx
+++ b/frontend/components/reports/widgets/BarWidget.tsx
@@ -164,6 +164,7 @@ export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
             sliced={sliced}
             secondaryValues={secondaryValues}
             seriesKeys={seriesKeys}
+            valueName={measureLabel}
           />
         )}
       </div>

--- a/frontend/components/reports/widgets/BarWidget.tsx
+++ b/frontend/components/reports/widgets/BarWidget.tsx
@@ -25,7 +25,11 @@ import dynamic from "next/dynamic";
 import { useMemo } from "react";
 
 import { useReportQuery } from "@/lib/reports/useReportQuery";
-import { dimensionHeader, pivotBySecondaryDimension } from "@/lib/reports/series";
+import {
+  dimensionHeader,
+  measureFieldLabel,
+  pivotBySecondaryDimension,
+} from "@/lib/reports/series";
 import type {
   BarWidget as BarWidgetType,
   CanvasFilters,
@@ -105,7 +109,7 @@ export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
   // CSV export. Single-series: [dimension, measure]. Sliced (break-down
   // by a secondary dimension): [primary dimension, ...one column per
   // secondary value], mirroring the stacked segments.
-  const measureLabel = widget.config.measure.field;
+  const measureLabel = measureFieldLabel(widget.config.measure.field);
   const csvDataset = sliced
     ? {
         headers: [dimensionHeader(primaryKey), ...secondaryValues],

--- a/frontend/components/reports/widgets/BarWidgetChart.tsx
+++ b/frontend/components/reports/widgets/BarWidgetChart.tsx
@@ -41,6 +41,13 @@ export interface BarWidgetChartProps {
   sliced: boolean;
   secondaryValues: string[];
   seriesKeys: string[];
+  /**
+   * Human label for the single-series measure, surfaced as the bar's
+   * tooltip ``name`` so hovering shows e.g. "Amount: 1234" instead of
+   * the bare "value" dataKey. Sliced bars already carry per-segment
+   * ``name`` from their secondary value.
+   */
+  valueName: string;
 }
 
 export default function BarWidgetChart({
@@ -48,6 +55,7 @@ export default function BarWidgetChart({
   sliced,
   secondaryValues,
   seriesKeys,
+  valueName,
 }: BarWidgetChartProps) {
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -75,6 +83,7 @@ export default function BarWidgetChart({
         ) : (
           <Bar
             dataKey="value"
+            name={valueName}
             fill={chartColor.spent}
             radius={[4, 4, 0, 0]}
             animationDuration={220}

--- a/frontend/lib/reports/series.ts
+++ b/frontend/lib/reports/series.ts
@@ -8,6 +8,7 @@
 import type {
   Dimension,
   Measure,
+  MeasureField,
   QueryRow,
   ReportsQueryResponse,
   SeriesConfig,
@@ -43,6 +44,26 @@ export function dimensionHeader(key: string): string {
 }
 
 /**
+ * Friendly display label for a measure field. ``measure.field`` is a raw
+ * DB key ("amount", "id", "category_id", "account_id"); surfaced bare it
+ * reads "amount: 1234" or "account_id: 3" in chart tooltips and CSV
+ * headers. Single source of truth for the human label — consumed by
+ * ``seriesLabel`` (multi-series chart names), the single-series bar
+ * tooltip + CSV header (``BarWidget``), and the ConfigRail field picker.
+ */
+export const MEASURE_FIELD_LABELS: Record<MeasureField, string> = {
+  amount: "Amount",
+  id: "Row count",
+  category_id: "Category",
+  account_id: "Account",
+};
+
+/** Display label for a measure field, falling back to the raw key. */
+export function measureFieldLabel(field: MeasureField): string {
+  return MEASURE_FIELD_LABELS[field] ?? field;
+}
+
+/**
  * Stable human label for a series. Uses the optional ``label`` if
  * present; otherwise falls back to "<Agg> of <field>". A single-
  * series widget shows just the field name to avoid the noisy
@@ -54,8 +75,9 @@ export function seriesLabel(
   total: number,
 ): string {
   if (s.label && s.label.trim()) return s.label.trim();
-  if (total === 1) return s.measure.field;
-  return `${HUMAN_AGG[s.measure.agg]} of ${s.measure.field}`;
+  const fieldLabel = measureFieldLabel(s.measure.field);
+  if (total === 1) return fieldLabel;
+  return `${HUMAN_AGG[s.measure.agg]} of ${fieldLabel}`;
 }
 
 /**

--- a/frontend/tests/components/reports/widgets/bar-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/bar-widget.test.tsx
@@ -172,7 +172,9 @@ describe("BarWidget", () => {
     expect(downloadMock).toHaveBeenCalledTimes(1);
     const [filename, csv] = downloadMock.mock.calls[0];
     expect(filename).toBe("spend-by-category.csv");
-    expect(csv).toBe("Category,amount\r\nFood,200\r\nTransport,80");
+    // Header uses the friendly measure label ("Amount"), not the raw
+    // "amount" field key — same humanized label the bar tooltip shows.
+    expect(csv).toBe("Category,Amount\r\nFood,200\r\nTransport,80");
   });
 
   it("exports one column per account when broken down by a secondary dimension", async () => {

--- a/frontend/tests/components/reports/widgets/table-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/table-widget.test.tsx
@@ -280,10 +280,10 @@ describe("TableWidget", () => {
     expect(downloadMock).toHaveBeenCalledTimes(1);
     const [filename, csv] = downloadMock.mock.calls[0];
     expect(filename).toBe("top-categories.csv");
-    // Header uses the human dimension label "Category" + the measure
-    // field "amount"; the Total row sums the additive column (280).
+    // Header uses the human dimension label "Category" + the friendly
+    // measure label "Amount"; the Total row sums the additive column (280).
     expect(csv).toBe(
-      "Category,amount\r\nFood,200\r\nTransport,80\r\nTotal,280",
+      "Category,Amount\r\nFood,200\r\nTransport,80\r\nTotal,280",
     );
   });
 

--- a/frontend/tests/lib/reports/series.test.ts
+++ b/frontend/tests/lib/reports/series.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  MEASURE_FIELD_LABELS,
+  measureFieldLabel,
+  seriesLabel,
+} from "@/lib/reports/series";
+import type { MeasureField, SeriesConfig } from "@/lib/reports/types";
+
+describe("measureFieldLabel", () => {
+  it("maps every raw measure field to a friendly label (no bare keys)", () => {
+    const fields: MeasureField[] = [
+      "amount",
+      "id",
+      "category_id",
+      "account_id",
+    ];
+    for (const f of fields) {
+      const label = measureFieldLabel(f);
+      // Never surface the raw key or an *_id suffix to the user.
+      expect(label).toBe(MEASURE_FIELD_LABELS[f]);
+      expect(label).not.toBe(f);
+      expect(label).not.toMatch(/_id$/);
+    }
+  });
+
+  it("uses the expected human labels", () => {
+    expect(measureFieldLabel("amount")).toBe("Amount");
+    expect(measureFieldLabel("id")).toBe("Row count");
+    expect(measureFieldLabel("category_id")).toBe("Category");
+    expect(measureFieldLabel("account_id")).toBe("Account");
+  });
+});
+
+describe("seriesLabel", () => {
+  const s = (over: Partial<SeriesConfig> = {}): SeriesConfig => ({
+    measure: { agg: "sum", field: "amount" },
+    ...over,
+  });
+
+  it("single-series shows the humanized field, not the raw key", () => {
+    expect(seriesLabel(s(), 0, 1)).toBe("Amount");
+    expect(seriesLabel(s({ measure: { agg: "count", field: "id" } }), 0, 1)).toBe(
+      "Row count",
+    );
+  });
+
+  it("multi-series shows '<Agg> of <FriendlyField>'", () => {
+    expect(seriesLabel(s(), 0, 2)).toBe("Sum of Amount");
+    expect(
+      seriesLabel(s({ measure: { agg: "avg", field: "account_id" } }), 1, 2),
+    ).toBe("Average of Account");
+  });
+
+  it("an explicit label override always wins", () => {
+    expect(seriesLabel(s({ label: "Total spend" }), 0, 1)).toBe("Total spend");
+    expect(seriesLabel(s({ label: "  Total spend  " }), 0, 2)).toBe(
+      "Total spend",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Hovering a bar in a single-series (non-broken-down) Reports bar widget showed a bare number with no legend, because the bar was rendered with `dataKey="value"` and no `name` — the tooltip fell back to the meaningless `value` key.

## Fix

Thread the widget's measure label through to `BarWidgetChart` and set it as the bar's `name`, so the tooltip reads e.g. `Amount: 1234`. Sliced/broken-down bars already carried per-segment names and are unchanged.

Follow-up (backlogged): currency-symbol formatting of the tooltip/axis numbers.