### PR TITLE
fix(dev): mount vitest config + setup so edits aren't stale

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,13 @@ services:
       # this explicit mount, edits require `docker compose up --build`
       # to take effect.
       - ./frontend/next.config.ts:/app/next.config.ts
+      # Same trap for the vitest config + setup: they are COPYed at build
+      # time, so without these mounts an edit to either silently runs the
+      # stale baked copy until a rebuild. (A pre-#422 image missing the
+      # Blob.text polyfill made the import-page sniff test fail locally
+      # while CI — which always builds fresh — stayed green.)
+      - ./frontend/vitest.config.ts:/app/vitest.config.ts
+      - ./frontend/vitest.setup.ts:/app/vitest.setup.ts
 
   nginx:
     image: nginx:alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,13 +87,20 @@ services:
       # this explicit mount, edits require `docker compose up --build`
       # to take effect.
       - ./frontend/next.config.ts:/app/next.config.ts
-      # Same trap for the vitest config + setup: they are COPYed at build
-      # time, so without these mounts an edit to either silently runs the
-      # stale baked copy until a rebuild. (A pre-#422 image missing the
+      # Same trap for the vitest config + setup and tsconfig: all three are
+      # COPYed at build time, so without these mounts an edit silently runs
+      # the stale baked copy until a rebuild. (A pre-#422 image missing the
       # Blob.text polyfill made the import-page sniff test fail locally
-      # while CI — which always builds fresh — stayed green.)
+      # while CI — which always builds fresh — stayed green.) tsconfig is
+      # read live by `docker compose exec frontend npx tsc --noEmit`, where
+      # a stale copy could silently mask or invent type errors.
+      # eslint.config.mjs shares the trap but is deliberately left out — it
+      # changes ~never and isn't part of the local edit/test/typecheck loop.
+      # package.json / package-lock.json are intentionally NOT mounted: they
+      # require a rebuild (npm install bakes node_modules before the COPY).
       - ./frontend/vitest.config.ts:/app/vitest.config.ts
       - ./frontend/vitest.setup.ts:/app/vitest.setup.ts
+      - ./frontend/tsconfig.json:/app/tsconfig.json
 
   nginx:
     image: nginx:alpine


### PR DESCRIPTION
## Problem

`tests/app/import-page.test.tsx` failed deterministically on a local stack while CI stayed green. Root cause was **not a code bug** — it was a stale local frontend image.

`vitest.config.ts` and `vitest.setup.ts` are `COPY`d into the dev image at build time and were **not** in the compose volume mounts (unlike `next.config.ts`, which has an explicit mount for exactly this reason). A frontend image built before #422 — which added the jsdom `Blob.text` polyfill the import sniff relies on — kept running the pre-polyfill baked `vitest.setup.ts`, so `file.slice(...).text()` was undefined and the sniff fell back to the CSV endpoint. A fresh build (CI, or `docker compose build frontend`) has the polyfill and passes 1663/1663.

## Fix

Mount `vitest.config.ts` and `vitest.setup.ts` into the frontend container, mirroring the existing `next.config.ts` mount, so edits to either take effect without a rebuild and a stale baked copy can't silently diverge from the repo.