### PR TITLE
feat(reports): pluggable source registry + /sources catalog (Reports v3 phase 1)

### DIFF
--- a/backend/app/reports/sources/__init__.py
+++ b/backend/app/reports/sources/__init__.py
@@ -1,0 +1,28 @@
+"""Source registry. Concrete sources self-register on import."""
+from __future__ import annotations
+
+from app.reports.sources.base import ReportSource
+
+_REGISTRY: dict[str, ReportSource] = {}
+
+
+def register(source: ReportSource) -> None:
+    if source.key in _REGISTRY:
+        raise ValueError(f"duplicate report source key: {source.key!r}")
+    _REGISTRY[source.key] = source
+
+
+def get_source(key: str) -> ReportSource:
+    try:
+        return _REGISTRY[key]
+    except KeyError as exc:
+        raise KeyError(f"unknown report source: {key!r}") from exc
+
+
+def all_sources() -> list[ReportSource]:
+    return list(_REGISTRY.values())
+
+
+# Import concrete sources so they self-register. Kept at the bottom to
+# avoid a circular import (transactions.py imports from .base + __init__).
+from app.reports.sources import transactions as _transactions  # noqa: E402,F401

--- a/backend/app/reports/sources/base.py
+++ b/backend/app/reports/sources/base.py
@@ -1,0 +1,47 @@
+"""Reports v3 — pluggable source layer.
+
+A ``ReportSource`` answers three questions: which dimensions can you
+group/filter by, which measures can you plot, and how do you build the
+rows for a query. The registry dispatches the reports query AST on its
+``dataset`` discriminator to the registered source. Phase 1 ships one
+source (transactions) that delegates to the existing compiler; the
+interface is what makes accounts / recurring / net-worth additive later.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.reports_query import QueryMeta, ReportsQuery
+
+
+@dataclass(frozen=True)
+class SourceDimension:
+    key: str       # matches the AST Dimension value, e.g. "category"
+    label: str     # human label for the editor, e.g. "Category"
+    kind: str      # control hint: category|account|status|type|tag|time|account_type
+
+
+@dataclass(frozen=True)
+class SourceMeasure:
+    key: str       # stable id for the editor, e.g. "sum_amount"
+    label: str     # human label, e.g. "Total amount"
+    agg: str       # sum|count|avg|distinct
+    field: str     # amount|id|category_id|account_id (AST MeasureField value)
+    format: str    # currency|number|percent
+
+
+@runtime_checkable
+class ReportSource(Protocol):
+    key: str
+    label: str
+
+    def dimensions(self) -> list[SourceDimension]: ...
+
+    def measures(self) -> list[SourceMeasure]: ...
+
+    async def build_rows(
+        self, db: AsyncSession, org_id: int, query: ReportsQuery
+    ) -> tuple[list[dict], QueryMeta]: ...

--- a/backend/app/reports/sources/base.py
+++ b/backend/app/reports/sources/base.py
@@ -14,7 +14,7 @@ from typing import Protocol, runtime_checkable
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.schemas.reports_query import QueryMeta, ReportsQuery
+from app.schemas.reports_query import ReportsQuery
 
 
 @dataclass(frozen=True)
@@ -44,4 +44,4 @@ class ReportSource(Protocol):
 
     async def build_rows(
         self, db: AsyncSession, org_id: int, query: ReportsQuery
-    ) -> tuple[list[dict], QueryMeta]: ...
+    ) -> tuple[list[dict], dict]: ...  # meta dict carries row_count, truncated, query_ms — coerced to QueryMeta at the router

--- a/backend/app/reports/sources/transactions.py
+++ b/backend/app/reports/sources/transactions.py
@@ -1,0 +1,53 @@
+"""Transactions source — wraps the existing reports query compiler.
+
+build_rows delegates to ``execute_query`` verbatim, so the transactions
+query path is byte-for-byte identical to pre-registry behavior. The
+catalog (dimensions/measures) is derived from the closed AST enums so it
+cannot drift from what the compiler actually accepts.
+"""
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.reports.sources import register
+from app.reports.sources.base import ReportSource, SourceDimension, SourceMeasure
+from app.schemas.reports_query import QueryMeta, ReportsQuery
+from app.services.reports_query_service import execute_query
+
+_DIMENSIONS = [
+    SourceDimension("category", "Category", "category"),
+    SourceDimension("category_master", "Category group", "category"),
+    SourceDimension("account", "Account", "account"),
+    SourceDimension("tag", "Tag", "tag"),
+    SourceDimension("txn_type", "Type", "type"),
+    SourceDimension("status", "Status", "status"),
+    SourceDimension("month", "Month", "time"),
+    SourceDimension("week", "Week", "time"),
+    SourceDimension("day", "Day", "time"),
+]
+
+_MEASURES = [
+    SourceMeasure("sum_amount", "Total amount", "sum", "amount", "currency"),
+    SourceMeasure("avg_amount", "Average amount", "avg", "amount", "currency"),
+    SourceMeasure("count_rows", "Transaction count", "count", "id", "number"),
+]
+
+
+class TransactionsSource:
+    key = "transactions"
+    label = "Transactions"
+
+    def dimensions(self) -> list[SourceDimension]:
+        return list(_DIMENSIONS)
+
+    def measures(self) -> list[SourceMeasure]:
+        return list(_MEASURES)
+
+    async def build_rows(
+        self, db: AsyncSession, org_id: int, query: ReportsQuery
+    ) -> tuple[list[dict], QueryMeta]:
+        return await execute_query(db, query, org_id=org_id)
+
+
+_INSTANCE: ReportSource = TransactionsSource()
+register(_INSTANCE)

--- a/backend/app/reports/sources/transactions.py
+++ b/backend/app/reports/sources/transactions.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.reports.sources import register
 from app.reports.sources.base import ReportSource, SourceDimension, SourceMeasure
-from app.schemas.reports_query import QueryMeta, ReportsQuery
+from app.schemas.reports_query import ReportsQuery
 from app.services.reports_query_service import execute_query
 
 _DIMENSIONS = [
@@ -45,7 +45,7 @@ class TransactionsSource:
 
     async def build_rows(
         self, db: AsyncSession, org_id: int, query: ReportsQuery
-    ) -> tuple[list[dict], QueryMeta]:
+    ) -> tuple[list[dict], dict]:  # meta dict carries row_count, truncated, query_ms — coerced to QueryMeta at the router
         return await execute_query(db, query, org_id=org_id)
 
 

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -56,8 +56,8 @@ from app.schemas.report import (
     ReportUpdate,
     ReportVersionSummary,
 )
+from app.reports.sources import all_sources, get_source
 from app.schemas.reports_query import ReportsQuery, ReportsQueryResponse
-from app.services.reports_query_service import execute_query
 
 
 logger = structlog.stdlib.get_logger()
@@ -152,6 +152,17 @@ async def _snapshot_version(
         await db.delete(stale)
 
 
+async def _run_source_query(db, ast: ReportsQuery, *, org_id: int):
+    """Resolve the AST's dataset to a registered ReportSource and run it.
+
+    Unknown dataset is impossible from the wire (the Dataset enum is
+    closed and Pydantic-validated), so a KeyError here is a server bug,
+    not user input — let it surface as 500.
+    """
+    source = get_source(ast.dataset.value)
+    return await source.build_rows(db, org_id, ast)
+
+
 @router.post(
     "/query",
     response_model=ReportsQueryResponse,
@@ -166,9 +177,9 @@ async def run_query(
     """Execute a validated AST against the caller's org data.
 
     ``org_id`` is injected from ``current_user``; the AST has no way to
-    express it. See ``app/services/reports_query_service.py``.
+    express it. Dispatch is through the source registry on ``body.dataset``.
     """
-    rows, meta = await execute_query(db, body, org_id=current_user.org_id)
+    rows, meta = await _run_source_query(db, body, org_id=current_user.org_id)
     return ReportsQueryResponse(rows=rows, meta=meta)
 
 

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -28,6 +28,7 @@ private -> hard delete) is a follow-up PR. PR1 only ensures the FK is
 ``ON DELETE RESTRICT`` so a code path that bypasses the service layer
 fails loud instead of silently dropping reports.
 """
+import dataclasses
 from typing import Optional
 
 import structlog
@@ -57,6 +58,11 @@ from app.schemas.report import (
     ReportVersionSummary,
 )
 from app.reports.sources import all_sources, get_source
+from app.schemas.report_sources import (
+    SourceCatalogEntry,
+    SourceDimensionOut,
+    SourceMeasureOut,
+)
 from app.schemas.reports_query import ReportsQuery, ReportsQueryResponse
 
 
@@ -152,7 +158,7 @@ async def _snapshot_version(
         await db.delete(stale)
 
 
-async def _run_source_query(db, ast: ReportsQuery, *, org_id: int):
+async def _run_source_query(db: AsyncSession, ast: ReportsQuery, *, org_id: int):
     """Resolve the AST's dataset to a registered ReportSource and run it.
 
     Unknown dataset is impossible from the wire (the Dataset enum is
@@ -243,6 +249,28 @@ async def list_templates(current_user: User = Depends(get_current_user)):
     backend.
     """
     return [ReportTemplate(**t) for t in get_report_templates()]
+
+
+@router.get("/sources", response_model=list[SourceCatalogEntry])
+async def list_sources(current_user: User = Depends(get_current_user)):
+    """Catalog of reportable sources with their dimensions + measures.
+
+    Drives the widget editor's source/dimension/measure pickers so the
+    frontend hardcodes nothing about a source's shape. Auth-gated +
+    behind the reports-v2 flag like every route on this router.
+
+    Registered ABOVE ``GET /{report_id}`` so the literal ``/sources``
+    path is not captured by the ``{report_id}`` integer matcher.
+    """
+    return [
+        SourceCatalogEntry(
+            key=s.key,
+            label=s.label,
+            dimensions=[SourceDimensionOut(**dataclasses.asdict(d)) for d in s.dimensions()],
+            measures=[SourceMeasureOut(**dataclasses.asdict(m)) for m in s.measures()],
+        )
+        for s in all_sources()
+    ]
 
 
 @router.get("/{report_id}", response_model=ReportResponse)

--- a/backend/app/schemas/report_sources.py
+++ b/backend/app/schemas/report_sources.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+
+
+class SourceDimensionOut(BaseModel):
+    key: str
+    label: str
+    kind: str
+
+
+class SourceMeasureOut(BaseModel):
+    key: str
+    label: str
+    agg: str
+    field: str
+    format: str
+
+
+class SourceCatalogEntry(BaseModel):
+    key: str
+    label: str
+    dimensions: list[SourceDimensionOut]
+    measures: list[SourceMeasureOut]

--- a/backend/tests/routers/test_report_sources_endpoint.py
+++ b/backend/tests/routers/test_report_sources_endpoint.py
@@ -1,0 +1,162 @@
+"""Tests for GET /api/v1/reports/sources catalog endpoint (Reports v3 Phase 1, Task 5).
+
+Fixture wiring mirrors test_reports.py exactly: in-memory SQLite session factory,
+_make_app helper, _resolver helper, and the autouse _enable_flag monkeypatch.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings as app_settings
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.routers.reports import router as reports_router
+from app.security import hash_password
+
+
+# ─── fixtures (mirrors test_reports.py) ───────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _make_app(session_factory, user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_user() -> User:
+        return await user_resolver(session_factory)
+
+    def override_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_user
+    app.dependency_overrides[get_session_factory] = override_factory
+    app.include_router(reports_router)
+    return app
+
+
+async def _seed(factory) -> None:
+    """Minimal seed: one org + one user (owner). No transactions needed for catalog."""
+    async with factory() as db:
+        org = Organization(name="Test Org", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+
+        user = User(
+            org_id=org.id,
+            username="test_user",
+            email="test@example.com",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+
+
+def _resolver(username: str):
+    async def resolve(session_factory):
+        async with session_factory() as db:
+            from sqlalchemy import select as _s
+            return (
+                await db.execute(_s(User).where(User.username == username))
+            ).scalar_one()
+    return resolve
+
+
+@pytest.fixture(autouse=True)
+def _enable_flag(monkeypatch):
+    """Default every test in this file to FEATURE_REPORTS_V2 ON."""
+    monkeypatch.setattr(app_settings, "feature_reports_v2", True)
+
+
+# ─── tests ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sources_endpoint_lists_transactions_catalog(session_factory):
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("test_user"))
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/reports/sources")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    keys = {s["key"] for s in body}
+    assert "transactions" in keys
+
+    tx = next(s for s in body if s["key"] == "transactions")
+    assert tx["label"] == "Transactions"
+
+    # Dimensions: must include "category"
+    assert any(d["key"] == "category" for d in tx["dimensions"])
+
+    # Every dimension has all required fields
+    for d in tx["dimensions"]:
+        assert "key" in d
+        assert "label" in d
+        assert "kind" in d
+
+    # Measures: sum_amount with currency format must be present
+    assert any(
+        m["key"] == "sum_amount" and m["format"] == "currency"
+        for m in tx["measures"]
+    )
+
+    # Every measure has all required fields
+    for m in tx["measures"]:
+        assert "key" in m
+        assert "label" in m
+        assert "agg" in m
+        assert "field" in m
+        assert "format" in m
+
+
+@pytest.mark.asyncio
+async def test_sources_endpoint_404_when_flag_off(session_factory, monkeypatch):
+    monkeypatch.setattr(app_settings, "feature_reports_v2", False)
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("test_user"))
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/reports/sources")
+    assert resp.status_code == 404

--- a/backend/tests/routers/test_report_sources_endpoint.py
+++ b/backend/tests/routers/test_report_sources_endpoint.py
@@ -160,3 +160,30 @@ async def test_sources_endpoint_404_when_flag_off(session_factory, monkeypatch):
     with TestClient(app) as client:
         resp = client.get("/api/v1/reports/sources")
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_sources_anonymous_returns_401(session_factory):
+    """Flag ON, no Authorization header: the bearer scheme fires and
+    the request is rejected 401/403 (NOT 404) before any handler runs.
+
+    A bare FastAPI app with the router included — no
+    ``get_current_user`` override — exercises the production bearer
+    gate end-to-end. Mirrors test_reports.py::test_anonymous_request_returns_401.
+    """
+    await _seed(session_factory)
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.include_router(reports_router)
+    with TestClient(app) as client:
+        res = client.get("/api/v1/reports/sources")
+    # FastAPI's HTTPBearer with auto_error=True returns 403 when the
+    # Authorization header is missing; both 401 / 403 are acceptable
+    # auth-rejection codes here. The point is the route did NOT reach
+    # the handler.
+    assert res.status_code in (401, 403)

--- a/backend/tests/services/test_report_sources_registry.py
+++ b/backend/tests/services/test_report_sources_registry.py
@@ -38,3 +38,35 @@ def test_transactions_source_catalog_matches_ast_enums():
     for m in src.measures():
         assert m.agg in agg_values, f"bad agg: {m.agg}"
         assert m.field in field_values, f"bad field: {m.field}"
+
+
+@pytest.mark.asyncio
+async def test_run_query_dispatches_via_registry(monkeypatch):
+    """The route resolves the source from the AST dataset and calls its
+    build_rows — proving the indirection, not a direct execute_query call."""
+    from app.routers import reports as reports_router
+    from app.schemas.reports_query import (
+        Aggregation, Dataset, Dimension, Measure, MeasureField, ReportsQuery,
+    )
+
+    called = {}
+
+    async def fake_build_rows(self, db, org_id, query):
+        called["org_id"] = org_id
+        called["dataset"] = query.dataset.value
+        return ([{"category": "Food", "value": 12}], {"row_count": 1, "truncated": False, "query_ms": 1})
+
+    src = reports_router.get_source("transactions")
+    # TransactionsSource.build_rows is defined on the class, not the instance.
+    # Patching on the class means Python's descriptor protocol passes self as
+    # the first argument, so fake_build_rows takes (self, db, org_id, query).
+    monkeypatch.setattr(type(src), "build_rows", fake_build_rows)
+
+    ast = ReportsQuery(
+        dataset=Dataset.TRANSACTIONS,
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+        dimensions=[Dimension.CATEGORY],
+    )
+    rows, meta = await reports_router._run_source_query(object(), ast, org_id=42)
+    assert called == {"org_id": 42, "dataset": "transactions"}
+    assert rows[0]["category"] == "Food" and meta["row_count"] == 1

--- a/backend/tests/services/test_report_sources_registry.py
+++ b/backend/tests/services/test_report_sources_registry.py
@@ -1,0 +1,8 @@
+from app.reports.sources.base import ReportSource, SourceDimension, SourceMeasure
+
+
+def test_source_dimension_and_measure_are_simple_value_objects():
+    dim = SourceDimension(key="category", label="Category", kind="category")
+    meas = SourceMeasure(key="sum_amount", label="Total", agg="sum", field="amount", format="currency")
+    assert dim.key == "category" and dim.kind == "category"
+    assert meas.agg == "sum" and meas.format == "currency"

--- a/backend/tests/services/test_report_sources_registry.py
+++ b/backend/tests/services/test_report_sources_registry.py
@@ -6,3 +6,30 @@ def test_source_dimension_and_measure_are_simple_value_objects():
     meas = SourceMeasure(key="sum_amount", label="Total", agg="sum", field="amount", format="currency")
     assert dim.key == "category" and dim.kind == "category"
     assert meas.agg == "sum" and meas.format == "currency"
+
+
+import pytest
+from app.reports import sources as source_registry
+
+
+def test_registry_resolves_transactions_and_rejects_unknown():
+    src = source_registry.get_source("transactions")
+    assert src.key == "transactions"
+    assert "transactions" in {s.key for s in source_registry.all_sources()}
+    with pytest.raises(KeyError):
+        source_registry.get_source("nope")
+
+
+def test_transactions_source_catalog_matches_ast_enums():
+    from app.reports import sources as source_registry
+    from app.schemas.reports_query import Dimension as AstDimension
+
+    src = source_registry.get_source("transactions")
+    dim_keys = {d.key for d in src.dimensions()}
+    # Every catalog dimension is a real AST Dimension value (no typos).
+    assert dim_keys.issubset({d.value for d in AstDimension})
+    assert {"category", "account", "status", "txn_type", "month"}.issubset(dim_keys)
+    measure_keys = {m.key for m in src.measures()}
+    assert {"sum_amount", "count_rows"}.issubset(measure_keys)
+    sum_amount = next(m for m in src.measures() if m.key == "sum_amount")
+    assert sum_amount.format == "currency" and sum_amount.field == "amount"

--- a/backend/tests/services/test_report_sources_registry.py
+++ b/backend/tests/services/test_report_sources_registry.py
@@ -39,6 +39,25 @@ def test_transactions_source_catalog_matches_ast_enums():
         assert m.agg in agg_values, f"bad agg: {m.agg}"
         assert m.field in field_values, f"bad field: {m.field}"
 
+    # exact catalog contract (not just subset)
+    assert dim_keys == {"category", "category_master", "account", "tag",
+                        "txn_type", "status", "month", "week", "day"}
+    assert {m.key for m in src.measures()} == {"sum_amount", "avg_amount", "count_rows"}
+    by_key = {m.key: m for m in src.measures()}
+    assert (by_key["avg_amount"].agg, by_key["avg_amount"].field, by_key["avg_amount"].format) == ("avg", "amount", "currency")
+    assert (by_key["count_rows"].agg, by_key["count_rows"].field, by_key["count_rows"].format) == ("count", "id", "number")
+
+
+def test_every_dataset_enum_value_has_a_registered_source():
+    from app.reports import sources as source_registry
+    from app.schemas.reports_query import Dataset
+    registered = {s.key for s in source_registry.all_sources()}
+    enum_values = {d.value for d in Dataset}
+    assert enum_values == registered, (
+        f"Dataset enum and registry drifted: "
+        f"enum-only={enum_values - registered}, registry-only={registered - enum_values}"
+    )
+
 
 @pytest.mark.asyncio
 async def test_run_query_dispatches_via_registry(monkeypatch):

--- a/backend/tests/services/test_report_sources_registry.py
+++ b/backend/tests/services/test_report_sources_registry.py
@@ -1,4 +1,8 @@
+import pytest
+
+from app.reports import sources as source_registry
 from app.reports.sources.base import ReportSource, SourceDimension, SourceMeasure
+from app.schemas.reports_query import Aggregation, MeasureField
 
 
 def test_source_dimension_and_measure_are_simple_value_objects():
@@ -6,10 +10,6 @@ def test_source_dimension_and_measure_are_simple_value_objects():
     meas = SourceMeasure(key="sum_amount", label="Total", agg="sum", field="amount", format="currency")
     assert dim.key == "category" and dim.kind == "category"
     assert meas.agg == "sum" and meas.format == "currency"
-
-
-import pytest
-from app.reports import sources as source_registry
 
 
 def test_registry_resolves_transactions_and_rejects_unknown():
@@ -21,7 +21,6 @@ def test_registry_resolves_transactions_and_rejects_unknown():
 
 
 def test_transactions_source_catalog_matches_ast_enums():
-    from app.reports import sources as source_registry
     from app.schemas.reports_query import Dimension as AstDimension
 
     src = source_registry.get_source("transactions")
@@ -33,3 +32,9 @@ def test_transactions_source_catalog_matches_ast_enums():
     assert {"sum_amount", "count_rows"}.issubset(measure_keys)
     sum_amount = next(m for m in src.measures() if m.key == "sum_amount")
     assert sum_amount.format == "currency" and sum_amount.field == "amount"
+
+    agg_values = {a.value for a in Aggregation}
+    field_values = {f.value for f in MeasureField}
+    for m in src.measures():
+        assert m.agg in agg_values, f"bad agg: {m.agg}"
+        assert m.field in field_values, f"bad field: {m.field}"

--- a/specs/2026-06-11-reports-v3-flexible-canvas-design.md
+++ b/specs/2026-06-11-reports-v3-flexible-canvas-design.md
@@ -65,21 +65,24 @@ class ReportSource (Protocol)
 - `Row` is the existing row shape widgets already consume `{ [dimensionKey]: value, [measureKey]: number }`, so the chart layer is unchanged.
 
 **Implementations:**
-- `TransactionsSource` — wraps the existing `reports_query_service` AST verbatim. No behavior change; it just moves behind the interface. Dimensions: category, account, status, type, tag, payee, time(month/day). Measures: sum, count, avg.
+- `TransactionsSource` — wraps the existing `reports_query_service` AST compiler verbatim. No *behavior* change, but the request/validation schema does change (see Endpoints + Data model). Dimensions: category, account, status, type, tag, payee, time(month/day). Measures: sum, count, avg.
 - `AccountsSource` — balance by account / account_type; pending vs cleared balance; count. Read-only over `accounts` (+ pending tx for pending balance).
-- `NetWorthSource` — derived monthly time-series: assets − liabilities per month over the date range. Logic fully hidden behind `build_rows` (no single-table AST).
+- `NetWorthSource` — derived monthly time-series: assets − liabilities per month. **Materially harder than the other sources** and isolated into its own late phase (see Phasing + Open Decisions). The app has **no** asset/liability classification and **no** historical balance snapshots, so the series must be reconstructed from `opening_balance` + cumulative signed transaction deltas per account, bucketed by month, summed by an asset/liability sign that does not exist yet. Traps: transfer legs (use `reportable_transaction_filter()` or double-count), manual-adjustment rows, pending vs settled, and multi-currency accounts (net worth across EUR+USD is undefined without FX). Likely needs a migration (classification) — so the "no schema change" claim does **not** extend to NetWorth.
 - `RecurringSource` — committed/upcoming recurring amounts by category and due-month from recurring templates.
 
 Every `build_rows` is org-scoped; the registry never bypasses `org_id`.
 
 **Endpoints:**
 - `GET /api/v1/reports/sources` → catalog: each source with `dimensions[]` + `measures[]`. The editor reads this; the frontend hardcodes nothing about a source's shape.
-- `POST /api/v1/reports/query` → `{source, measures[], dimensions[], filters, date_range}` → dispatch to the source → rows. Replaces the implicit transactions-only query path.
+- `POST /api/v1/reports/query` → `{source, measure, dimensions[], filters, date_range, sort, limit}` → dispatch to the source → rows. Replaces the implicit transactions-only query path.
+  - **One measure per call (invariant).** The request carries a *single* `measure`, matching today's `ReportsQuery`. The frontend already fans out N parallel calls for multi-series widgets and merges them in `series.ts` (`mergeSeriesRows`/`pivotBySecondaryDimension`, keyed on dimension + `value`). Keeping one-measure-per-call leaves that merge layer untouched — do **not** move multi-measure aggregation server-side.
+  - **Response shape preserved verbatim:** `{rows: [{[dim]: …, value: number}], meta}` per call, so all chart/table widgets consume it unchanged.
+  - **Request schema is a superset of the legacy AST (Phase 1 change to `reports_query.py`):** the closed `Dataset` enum (single `transactions` member) becomes a `source` discriminator; `Measure._validate_agg_field`'s hardcoded "SUM/AVG require `field='amount'`" rule moves to **per-source** measure validation (Accounts `balance`, NetWorth series are not `amount`). The existing `test_reports_query_service.py` parity suite is **migrated** to the new body shape, not left unchanged.
 
 ### Frontend — Canvas, modes, editor
 
-- **Layout engine:** keep react-grid-layout but set `compactType={null}` + `preventCollision` (or `allowOverlap` off) so positions are literal. Persist `{x,y,w,h}` per widget in `layout_json`; load on mount; debounced save on drag/resize **stop** only. This fixes problems #1 and #4 of v2's behavior.
-- **No-reflow guarantee:** the editor is a **portaled popover** anchored to the selected widget (Popover/floating primitive), so it overlays and never alters the grid container width. Fixes #2.
+- **Layout engine:** keep react-grid-layout but set `compactType={null}` + `preventCollision` (no `allowOverlap`) so positions are literal and widgets never auto-move; collisions are simply rejected on drop, gaps are allowed. Persist `{x,y,w,h}` per widget in `layout_json`; load on mount; save on drag/resize **stop** only. `Canvas.tsx` today sets *neither* prop (defaults to vertical compaction) — that is the root of bug #1. **Guard `handleLayoutChange`** against react-grid-layout's mount-time/no-op normalization emissions so loading a report does not spuriously mark it `dirty`.
+- **No-reflow guarantee:** the editor is a **portaled popover** anchored to the selected widget, so it overlays and never alters the grid container width. Fixes #2. **This is net-new infrastructure** — the repo has no popover/floating/portal primitive and no `@floating-ui`/radix/headless dep. Phase 4 adds `@floating-ui/react` (anchor measurement, flip/shift at viewport edges, outside-click, focus handling) and repositions the popover when the underlying widget moves/resizes. Budget this; it is not a `ConfigRail` swap.
 - **View/Edit toggle:** single page, `isEditing` state. View = charts + shared date control + "Edit" button, no handles/gridlines. Edit = drag/resize handles, "+ Add widget", click-a-widget-to-open-popover, "Done" button.
 - **Filter model:** report-level date range lives in the toolbar (both modes). Per-widget filters live in the popover. Each widget header renders **filter chips** of its effective filters; the date chip is styled "inherited" vs "override".
 - **Editor popover contents:** title · source dropdown (from `/sources`) · measure(s) · dimension(s) · per-widget filters (accounts, categories, status, type, amount, tags) · date inherit-or-override. Changing source swaps the available dimensions/measures from the catalog.
@@ -88,10 +91,12 @@ Every `build_rows` is org-scoped; the registry never bypasses `org_id`.
 
 ### Data model / persistence
 
-- `layout_json` already exists and is strictly validated (PR #424). Widgets are JSON, so **no DB migration** is needed for the new widget fields.
-- Widget gains `source: str`. Pre-launch, no back-compat shim: existing saved widgets are treated as `source:"transactions"` by hard default in the reader, no data migration.
-- Report-level filter shape changes: `canvas_filters_json` keeps **date_range only**; accounts/categories move to per-widget. Per the pre-launch no-data-migration policy, any accounts/categories previously stored at canvas level are **dropped**, not migrated.
-- New sources (Accounts/NetWorth/Recurring) are read-only queries — no schema changes.
+- `layout_json` / `canvas_filters_json` are `JSON` columns, so **no DB migration for widget storage**. But "no DB migration" ≠ "no schema change": the strict Pydantic validators in `report_layout.py` and `reports_query.py` **must change** in Phase 1 (see below). NetWorth's classification likely *does* need a DB migration (Open Decisions).
+- **`source` lives on the widget `config`, not the envelope.** `_WidgetBase` is `extra="forbid"` with a regression test (`test_reject_extra_widget_envelope_key`); adding `source` there would 422. The config models are `extra="ignore"` and already hold `dataset`, so `source` slots next to it forward-compatibly. Phase 1 still must **widen the closed `Dataset` enum and relax the required `dataset` field** so non-transactions widgets validate, while keeping the `extra="forbid"` envelope test green.
+- Pre-launch, no back-compat shim: a widget config with no `source` is read as `source:"transactions"` by hard default.
+- **Report-level filters: `canvas_filters_json` surfaces only `date_range` in the UI**; accounts/categories move to per-widget. The backend `CanvasFilters` schema (`extra="forbid"`) **keeps** the `account_ids`/`category_ids` fields modeled-but-tolerated so any saved report still carrying them does not 422 on next PATCH; the v3 UI simply stops reading/writing them. (Pre-launch we could instead remove the fields and wipe old rows, but tolerate-and-ignore is lower-risk and needs no data touch.) The cascade code (`resolve.ts`, `CanvasFiltersBar.tsx`, `resolve.test.ts`) is edited to drop the account/category tier.
+- New sources Accounts/Recurring are read-only queries — no schema change. NetWorth is the exception (classification).
+- **Formatter precedence:** a widget's explicit `config.format` (if set) wins; otherwise the registry `Measure.format` is the default. Documented so the two don't diverge.
 
 ## Error handling
 
@@ -101,16 +106,22 @@ Every `build_rows` is org-scoped; the registry never bypasses `org_id`.
 
 ## Testing
 
-- **Backend:** per-source `build_rows` tests — org-scoping isolation, each dimension/measure correctness, empty-range behavior; `/sources` catalog shape; `/query` dispatch + 400s. `TransactionsSource` must pass the existing reports query tests unchanged (parity proof).
+- **Backend:** per-source `build_rows` tests — org-scoping isolation, each dimension/measure correctness, empty-range behavior; `/sources` catalog shape; `/query` dispatch + 400s. `TransactionsSource` must reproduce the existing reports-query results (parity proof) — the parity suite is migrated to the new `/query` body shape but its expected outputs are identical.
 - **Frontend (full `vitest run`, not single-file — per the project's full-suite rule):** popover opens without changing grid geometry (no-reflow assertion); layout persists literally across save/reload; filter chips reflect effective filters; view/edit toggle strips/adds chrome; source-swap repopulates editor dropdowns; currency formatter output.
 
 ## Phasing (each phase = its own PR, conventional-commit title, subagent-driven)
 
-1. **Backend registry + TransactionsSource parity** + `/sources` + `/query` + tests. (No frontend change; transactions behavior identical.)
-2. **Frontend data-layer swap** to `/query` + `/sources` catalog; source dropdown in the editor.
-3. **Canvas layout fix** — literal positions, reliable persistence, no auto-movement.
-4. **View/Edit toggle + popover editor** replacing `ConfigRail`; filter chips + shared-date inherit/override model.
-5. **AccountsSource, NetWorthSource, RecurringSource** + editor wiring per source.
-6. **Currency formatting** across all widgets.
+1. **Backend registry + TransactionsSource parity** — `ReportSource` interface + registry, `TransactionsSource` wrapping the existing compiler, the `reports_query.py` schema widening (`source` discriminator + per-source measure validation), `/sources` + `/query` endpoints, migrated parity tests. (No frontend change; transactions behavior identical.) Includes the `report_layout.py` change to accept `source` on widget config + relax `dataset`.
+2. **Frontend data-layer swap** — `useReportQuery` → `POST /reports/query` with `widget.source`; fetch `/sources` once via SWR. **Data layer only — no editor UI change** (the source dropdown lands in Phase 4 with the new editor, to avoid throwaway work in `ConfigRail`, which Phase 4 replaces).
+3. **Canvas layout fix** — `compactType={null}` + `preventCollision`, literal `{x,y,w,h}` persistence, save-on-stop, `handleLayoutChange` mount-time guard. No auto-movement.
+4. **View/Edit toggle + popover editor** — add `@floating-ui/react`; replace `ConfigRail` with the portaled anchored popover (incl. the **source dropdown**); filter chips; shared-date inherit/override model; drop canvas account/category tier in `resolve.ts`/`CanvasFiltersBar`.
+5. **AccountsSource + RecurringSource** + editor wiring — the two cheap, single-table read-only sources.
+6. **NetWorthSource** — isolated. Gated on the Open Decisions below (asset/liability classification + currency). Carries its own migration if classification becomes a column. Do not start until those decisions are made.
+7. **Currency formatting** across all widgets (formatter precedence: `config.format` › `Measure.format`).
 
-Phases 1–4 are the core redesign; 5 adds the new sources; 6 is the polish item. 5 and 6 are independently shippable.
+Phases 1–4 are the core redesign. 5 adds the cheap sources. 6 (NetWorth) is isolated and decision-gated. 7 is polish. 5, 6, 7 are independently shippable.
+
+## Open Decisions (block Phase 6 only — core build proceeds without them)
+
+1. **Asset vs liability classification.** No such flag exists. Options: (a) hardcoded slug map for the 5 system types (`checking/savings/investment/cash` = asset, `credit_card` = liability) + a per-type default for user-created custom types; (b) a new `kind`/`is_liability` column on `account_types` (migration) with admin/UI to set it. (a) is faster and ships NetWorth without a migration; (b) is correct long-term for custom types.
+2. **Multi-currency net worth.** Accounts carry a `currency`. Summing EUR+USD balances is meaningless without FX. Options: (a) NetWorth assumes a single-currency org and sums raw (document the limitation); (b) out-of-scope until an FX/rates feature exists. Recommend (a) for now.

--- a/specs/2026-06-11-reports-v3-flexible-canvas-design.md
+++ b/specs/2026-06-11-reports-v3-flexible-canvas-design.md
@@ -1,0 +1,116 @@
+# Reports v3 — Flexible Canvas & Pluggable Data Sources
+
+**Date:** 2026-06-11
+**Status:** Design — pending user review
+**Branch:** `feat/reports-v3`
+**Supersedes parts of:** `2026-05-22-reports-v2-flexible-canvas.md`, `2026-06-01-reports-simplify-and-complete.md` (v2 canvas/edit model)
+
+## Problem
+
+The current Reports v2 builder has five concrete problems, confirmed from a user screen recording:
+
+1. **Widgets don't respect position/size.** The grid auto-compacts and layout isn't reliably persisted, so widgets jump and the canvas renders as a ragged masonry with gaps.
+2. **Opening "Widget settings" reflows the whole canvas.** The settings panel (`ConfigRail`) takes horizontal space → the react-grid-layout container shrinks → every widget resizes/repositions.
+3. **Filter model is opaque.** A pinned top card holds report-wide filters (date/accounts/categories) *plus* hidden per-widget overrides, so you can't tell what any widget is actually showing.
+4. **No separation between presenting and editing.** The same chrome-heavy canvas is used to view and to build.
+5. **Data source is locked to Transactions.** You can't report on accounts, net worth, recurring obligations, or compare anything else the app knows.
+
+## Goals
+
+- Editing a widget never moves or resizes anything on the canvas.
+- A widget is **self-describing**: you can see what it queries and filters without opening it.
+- Reporting is **pluggable** across app entities, starting with Transactions, Accounts, Net worth, and Recurring.
+- Viewing a report is clean; editing is a deliberate mode on the same page.
+- Chart values are currency-formatted.
+
+## Non-goals (explicitly out of scope)
+
+- Plans/Scenarios as a report source (folded into the separate Plans redesign).
+- Budgets and Forecast Plans as sources **now** — deferred to a phase-2 "over-time" source (their single-period value already lives on their own pages; only cross-period trend would be new).
+- Two independent layouts for view vs edit (one layout, chrome stripped).
+- Global-only filters / per-widget-only filters (we chose the hybrid below).
+- Text-contains filters, settled-date, reconciliation-state, flags, scheduled delivery, collaborative editing.
+
+## Locked decisions (from brainstorm)
+
+| Area | Decision |
+|---|---|
+| Widget editor | **Anchored popover** beside the clicked widget, portaled over the canvas — never changes canvas width. |
+| Filters | **Shared report-level date range** (toolbar) that widgets inherit and may override; **all other filters per-widget**. Every widget shows its effective filters as chips. |
+| Data sources (now) | Transactions, Accounts & balances, Net worth over time, Recurring obligations. |
+| Data sources (later) | Budgets / Forecast Plans (phase-2 over-time trend), Plans/Scenarios (Plans redesign). |
+| View vs Edit | **Same arrangement**, editing chrome stripped in View; **toggle** on the same page (no separate route). |
+| Layout policy | **Free 12-column grid, positions honored literally** — no auto-compaction, no auto-movement when widgets are added/removed/resized; gaps allowed. |
+| Backend extension | **Source registry / semantic layer** (one class per source behind a common interface). |
+
+---
+
+## Architecture
+
+### Backend — Source registry
+
+A `ReportSource` interface with one implementation per source, registered in a keyed lookup.
+
+```
+class ReportSource (Protocol)
+    key: str                         # "transactions" | "accounts" | "net_worth" | "recurring"
+    label: str
+    def dimensions() -> list[Dimension]    # {key, label, kind}
+    def measures()   -> list[Measure]      # {key, label, agg, format}
+    async def build_rows(db, org_id, query: ReportQuery) -> list[Row]
+```
+
+- `Dimension.kind` ∈ {category, account, status, type, tag, time, account_type, …} — drives which filter control the editor renders.
+- `Measure.format` ∈ {currency, number, percent} — drives both axis/tooltip formatting and the value formatter.
+- `Row` is the existing row shape widgets already consume `{ [dimensionKey]: value, [measureKey]: number }`, so the chart layer is unchanged.
+
+**Implementations:**
+- `TransactionsSource` — wraps the existing `reports_query_service` AST verbatim. No behavior change; it just moves behind the interface. Dimensions: category, account, status, type, tag, payee, time(month/day). Measures: sum, count, avg.
+- `AccountsSource` — balance by account / account_type; pending vs cleared balance; count. Read-only over `accounts` (+ pending tx for pending balance).
+- `NetWorthSource` — derived monthly time-series: assets − liabilities per month over the date range. Logic fully hidden behind `build_rows` (no single-table AST).
+- `RecurringSource` — committed/upcoming recurring amounts by category and due-month from recurring templates.
+
+Every `build_rows` is org-scoped; the registry never bypasses `org_id`.
+
+**Endpoints:**
+- `GET /api/v1/reports/sources` → catalog: each source with `dimensions[]` + `measures[]`. The editor reads this; the frontend hardcodes nothing about a source's shape.
+- `POST /api/v1/reports/query` → `{source, measures[], dimensions[], filters, date_range}` → dispatch to the source → rows. Replaces the implicit transactions-only query path.
+
+### Frontend — Canvas, modes, editor
+
+- **Layout engine:** keep react-grid-layout but set `compactType={null}` + `preventCollision` (or `allowOverlap` off) so positions are literal. Persist `{x,y,w,h}` per widget in `layout_json`; load on mount; debounced save on drag/resize **stop** only. This fixes problems #1 and #4 of v2's behavior.
+- **No-reflow guarantee:** the editor is a **portaled popover** anchored to the selected widget (Popover/floating primitive), so it overlays and never alters the grid container width. Fixes #2.
+- **View/Edit toggle:** single page, `isEditing` state. View = charts + shared date control + "Edit" button, no handles/gridlines. Edit = drag/resize handles, "+ Add widget", click-a-widget-to-open-popover, "Done" button.
+- **Filter model:** report-level date range lives in the toolbar (both modes). Per-widget filters live in the popover. Each widget header renders **filter chips** of its effective filters; the date chip is styled "inherited" vs "override".
+- **Editor popover contents:** title · source dropdown (from `/sources`) · measure(s) · dimension(s) · per-widget filters (accounts, categories, status, type, amount, tags) · date inherit-or-override. Changing source swaps the available dimensions/measures from the catalog.
+- **Data layer:** `useReportQuery` calls `POST /reports/query` with `widget.source`; `/reports/sources` fetched once via SWR to drive the editor. New widgets copy the previous widget's filters (and date-inherit) so users aren't retyping.
+- **Currency formatting:** one shared recharts value formatter keyed on `measure.format` + org currency, applied to tooltips and axes across Bar/Line/Area/StackedBar/Pie/Sparkline/Table. Closes the deferred backlog item.
+
+### Data model / persistence
+
+- `layout_json` already exists and is strictly validated (PR #424). Widgets are JSON, so **no DB migration** is needed for the new widget fields.
+- Widget gains `source: str`. Pre-launch, no back-compat shim: existing saved widgets are treated as `source:"transactions"` by hard default in the reader, no data migration.
+- Report-level filter shape changes: `canvas_filters_json` keeps **date_range only**; accounts/categories move to per-widget. Per the pre-launch no-data-migration policy, any accounts/categories previously stored at canvas level are **dropped**, not migrated.
+- New sources (Accounts/NetWorth/Recurring) are read-only queries — no schema changes.
+
+## Error handling
+
+- `/reports/query` validates `source` against the registry → 400 on unknown source; validates requested dimensions/measures belong to that source → 400 with the offending key.
+- A widget whose source/measure no longer resolves renders an inline "this widget needs attention" state (not a crashed canvas), and the popover surfaces what's invalid.
+- Net worth / recurring with an empty range return an empty series, not an error.
+
+## Testing
+
+- **Backend:** per-source `build_rows` tests — org-scoping isolation, each dimension/measure correctness, empty-range behavior; `/sources` catalog shape; `/query` dispatch + 400s. `TransactionsSource` must pass the existing reports query tests unchanged (parity proof).
+- **Frontend (full `vitest run`, not single-file — per the project's full-suite rule):** popover opens without changing grid geometry (no-reflow assertion); layout persists literally across save/reload; filter chips reflect effective filters; view/edit toggle strips/adds chrome; source-swap repopulates editor dropdowns; currency formatter output.
+
+## Phasing (each phase = its own PR, conventional-commit title, subagent-driven)
+
+1. **Backend registry + TransactionsSource parity** + `/sources` + `/query` + tests. (No frontend change; transactions behavior identical.)
+2. **Frontend data-layer swap** to `/query` + `/sources` catalog; source dropdown in the editor.
+3. **Canvas layout fix** — literal positions, reliable persistence, no auto-movement.
+4. **View/Edit toggle + popover editor** replacing `ConfigRail`; filter chips + shared-date inherit/override model.
+5. **AccountsSource, NetWorthSource, RecurringSource** + editor wiring per source.
+6. **Currency formatting** across all widgets.
+
+Phases 1–4 are the core redesign; 5 adds the new sources; 6 is the polish item. 5 and 6 are independently shippable.

--- a/specs/2026-06-11-reports-v3-flexible-canvas-design.md
+++ b/specs/2026-06-11-reports-v3-flexible-canvas-design.md
@@ -100,7 +100,7 @@ Every `build_rows` is org-scoped; the registry never bypasses `org_id`.
 
 ## Error handling
 
-- `/reports/query` validates `source` against the registry → 400 on unknown source; validates requested dimensions/measures belong to that source → 400 with the offending key.
+- `/reports/query` validates `source`/`dataset` at the wire via the closed Pydantic `Dataset` enum → **422** on any unknown value (Pydantic rejects it before the handler runs; there is no 400 path). A registry miss — e.g. the enum is widened in Phase 5 but the source isn't registered yet — surfaces as **500** (server bug, not user input). Requested dimensions/measures outside a source's catalog → 422 (per-source validation, Phase 5).
 - A widget whose source/measure no longer resolves renders an inline "this widget needs attention" state (not a crashed canvas), and the popover surfaces what's invalid.
 - Net worth / recurring with an empty range return an empty series, not an error.
 

--- a/specs/2026-06-11-reports-v3-phase1-plan.md
+++ b/specs/2026-06-11-reports-v3-phase1-plan.md
@@ -1,0 +1,534 @@
+# Reports v3 — Phase 1 Implementation Plan (Backend Source Registry)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a pluggable `ReportSource` registry behind the existing reports query path, plus a `GET /api/v1/reports/sources` catalog endpoint — with the transactions query path behaving identically (parity).
+
+**Architecture:** The `POST /api/v1/reports/query` AST already carries a `dataset` discriminator (`ReportsQuery.dataset`, today a single-value enum). Phase 1 inserts a registry indirection: the router dispatches on `dataset` to a registered `ReportSource`, and Phase 1 registers exactly one — `TransactionsSource` — which delegates to the existing `execute_query` compiler. A new `/sources` endpoint returns each registered source's dimensions + measures (derived from the existing closed enums) so the frontend can later drive the editor from data. No enum widening, no per-source measure validation, and no new wire fields yet — those land in Phase 5 when a second source exists. This phase is pure, behavior-preserving indirection + a read-only catalog.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2.0 async, Pydantic v2, pytest (async). Tests run in an **isolated compose project** per the parallel-agent rule: `docker compose -p team-reportsv3-p1 up -d backend mysql redis`, then `docker compose -p team-reportsv3-p1 exec backend pytest ...`.
+
+**Reference files (read before starting):**
+- `backend/app/services/reports_query_service.py` — `execute_query(db, ast: ReportsQuery, *, org_id: int) -> tuple[list[dict], QueryMeta]`; the compiler this phase wraps. **Read it fully first.**
+- `backend/app/schemas/reports_query.py` — the AST: `Dataset`, `Aggregation`, `MeasureField`, `Dimension`, `Measure`, `ReportsQuery`, `QueryMeta`, `ReportsQueryResponse`.
+- `backend/app/routers/reports.py:155-172` — the existing `run_query` route that calls `execute_query`; this is the call site we redirect through the registry.
+- `backend/app/tests/` — find the existing reports query test module (e.g. `test_reports_query_service.py` / `test_reports_query.py`) for the parity baseline.
+
+---
+
+## File Structure
+
+- **Create** `backend/app/reports/sources/__init__.py` — registry: `ReportSource` protocol, `register`/`get_source`/`all_sources`, and the module that imports the concrete sources so they self-register.
+- **Create** `backend/app/reports/sources/base.py` — `ReportSource` Protocol + the `Dimension`/`Measure` catalog dataclasses (`SourceDimension`, `SourceMeasure`) returned by `/sources`.
+- **Create** `backend/app/reports/sources/transactions.py` — `TransactionsSource`: `key="transactions"`, `dimensions()`, `measures()`, `build_rows()` delegating to `execute_query`.
+- **Create** `backend/app/schemas/report_sources.py` — response models for `GET /sources` (`SourceCatalogEntry`, `SourceDimensionOut`, `SourceMeasureOut`).
+- **Modify** `backend/app/routers/reports.py` — redirect `run_query` through the registry dispatcher; add `GET /sources`.
+- **Create** `backend/tests/services/test_report_sources_registry.py` — registry + catalog + dispatch tests.
+- The existing reports-query parity tests stay green **unchanged** (no wire change in Phase 1).
+
+> **Note on `reports/` package:** if `backend/app/reports/` already exists (it holds `templates.py`, imported in `routers/reports.py:51`), add the `sources/` subpackage inside it. If `app/reports/__init__.py` is missing, create it.
+
+---
+
+### Task 1: `ReportSource` protocol + catalog dataclasses
+
+**Files:**
+- Create: `backend/app/reports/sources/base.py`
+- Test: `backend/tests/services/test_report_sources_registry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/services/test_report_sources_registry.py
+from app.reports.sources.base import ReportSource, SourceDimension, SourceMeasure
+
+
+def test_source_dimension_and_measure_are_simple_value_objects():
+    dim = SourceDimension(key="category", label="Category", kind="category")
+    meas = SourceMeasure(key="sum_amount", label="Total", agg="sum", field="amount", format="currency")
+    assert dim.key == "category" and dim.kind == "category"
+    assert meas.agg == "sum" and meas.format == "currency"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose -p team-reportsv3-p1 exec backend pytest tests/services/test_report_sources_registry.py::test_source_dimension_and_measure_are_simple_value_objects -v`
+Expected: FAIL with `ModuleNotFoundError: app.reports.sources.base`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backend/app/reports/sources/base.py
+"""Reports v3 — pluggable source layer.
+
+A ``ReportSource`` answers three questions: which dimensions can you
+group/filter by, which measures can you plot, and how do you build the
+rows for a query. The registry dispatches the reports query AST on its
+``dataset`` discriminator to the registered source. Phase 1 ships one
+source (transactions) that delegates to the existing compiler; the
+interface is what makes accounts / recurring / net-worth additive later.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.reports_query import QueryMeta, ReportsQuery
+
+
+@dataclass(frozen=True)
+class SourceDimension:
+    key: str       # matches the AST Dimension value, e.g. "category"
+    label: str     # human label for the editor, e.g. "Category"
+    kind: str      # control hint: category|account|status|type|tag|time|account_type
+
+
+@dataclass(frozen=True)
+class SourceMeasure:
+    key: str       # stable id for the editor, e.g. "sum_amount"
+    label: str     # human label, e.g. "Total amount"
+    agg: str       # sum|count|avg|distinct
+    field: str     # amount|id|category_id|account_id (AST MeasureField value)
+    format: str    # currency|number|percent
+
+
+@runtime_checkable
+class ReportSource(Protocol):
+    key: str
+    label: str
+
+    def dimensions(self) -> list[SourceDimension]: ...
+
+    def measures(self) -> list[SourceMeasure]: ...
+
+    async def build_rows(
+        self, db: AsyncSession, org_id: int, query: ReportsQuery
+    ) -> tuple[list[dict], QueryMeta]: ...
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker compose -p team-reportsv3-p1 exec backend pytest tests/services/test_report_sources_registry.py::test_source_dimension_and_measure_are_simple_value_objects -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/reports/sources/base.py backend/tests/services/test_report_sources_registry.py
+git commit -m "feat(reports): ReportSource protocol + catalog value objects"
+```
+
+---
+
+### Task 2: Registry (register / get_source / all_sources)
+
+**Files:**
+- Create: `backend/app/reports/sources/__init__.py`
+- Test: `backend/tests/services/test_report_sources_registry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to backend/tests/services/test_report_sources_registry.py
+import pytest
+from app.reports import sources as source_registry
+
+
+def test_registry_resolves_transactions_and_rejects_unknown():
+    src = source_registry.get_source("transactions")
+    assert src.key == "transactions"
+    assert "transactions" in {s.key for s in source_registry.all_sources()}
+    with pytest.raises(KeyError):
+        source_registry.get_source("nope")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose -p team-reportsv3-p1 exec backend pytest tests/services/test_report_sources_registry.py::test_registry_resolves_transactions_and_rejects_unknown -v`
+Expected: FAIL — `get_source`/`all_sources` not defined (and `transactions` source not yet built; this passes after Task 3 registers it).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backend/app/reports/sources/__init__.py
+"""Source registry. Concrete sources self-register on import."""
+from __future__ import annotations
+
+from app.reports.sources.base import ReportSource
+
+_REGISTRY: dict[str, ReportSource] = {}
+
+
+def register(source: ReportSource) -> None:
+    if source.key in _REGISTRY:
+        raise ValueError(f"duplicate report source key: {source.key!r}")
+    _REGISTRY[source.key] = source
+
+
+def get_source(key: str) -> ReportSource:
+    try:
+        return _REGISTRY[key]
+    except KeyError as exc:
+        raise KeyError(f"unknown report source: {key!r}") from exc
+
+
+def all_sources() -> list[ReportSource]:
+    return list(_REGISTRY.values())
+
+
+# Import concrete sources so they self-register. Kept at the bottom to
+# avoid a circular import (transactions.py imports from .base).
+from app.reports.sources import transactions as _transactions  # noqa: E402,F401
+```
+
+- [ ] **Step 4: Run test** — will still fail until Task 3 creates `transactions.py`. That is expected; proceed to Task 3, then re-run.
+
+- [ ] **Step 5: Commit** (after Task 3 makes it green — commit registry + source together)
+
+---
+
+### Task 3: `TransactionsSource` (parity delegate)
+
+**Files:**
+- Create: `backend/app/reports/sources/transactions.py`
+- Test: `backend/tests/services/test_report_sources_registry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to backend/tests/services/test_report_sources_registry.py
+def test_transactions_source_catalog_matches_ast_enums():
+    from app.reports import sources as source_registry
+    from app.schemas.reports_query import Dimension as AstDimension
+
+    src = source_registry.get_source("transactions")
+    dim_keys = {d.key for d in src.dimensions()}
+    # Every catalog dimension is a real AST Dimension value (no typos).
+    assert dim_keys.issubset({d.value for d in AstDimension})
+    assert {"category", "account", "status", "txn_type", "month"}.issubset(dim_keys)
+    measure_keys = {m.key for m in src.measures()}
+    assert {"sum_amount", "count_rows"}.issubset(measure_keys)
+    # Currency measures advertise currency format for the formatter.
+    sum_amount = next(m for m in src.measures() if m.key == "sum_amount")
+    assert sum_amount.format == "currency" and sum_amount.field == "amount"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose -p team-reportsv3-p1 exec backend pytest tests/services/test_report_sources_registry.py -k transactions_source_catalog -v`
+Expected: FAIL — `transactions.py` missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backend/app/reports/sources/transactions.py
+"""Transactions source — wraps the existing reports query compiler.
+
+build_rows delegates to ``execute_query`` verbatim, so the transactions
+query path is byte-for-byte identical to pre-registry behavior. The
+catalog (dimensions/measures) is derived from the closed AST enums so it
+cannot drift from what the compiler actually accepts.
+"""
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.reports.sources import register
+from app.reports.sources.base import ReportSource, SourceDimension, SourceMeasure
+from app.schemas.reports_query import QueryMeta, ReportsQuery
+from app.services.reports_query_service import execute_query
+
+_DIMENSIONS = [
+    SourceDimension("category", "Category", "category"),
+    SourceDimension("category_master", "Category group", "category"),
+    SourceDimension("account", "Account", "account"),
+    SourceDimension("tag", "Tag", "tag"),
+    SourceDimension("txn_type", "Type", "type"),
+    SourceDimension("status", "Status", "status"),
+    SourceDimension("month", "Month", "time"),
+    SourceDimension("week", "Week", "time"),
+    SourceDimension("day", "Day", "time"),
+]
+
+_MEASURES = [
+    SourceMeasure("sum_amount", "Total amount", "sum", "amount", "currency"),
+    SourceMeasure("avg_amount", "Average amount", "avg", "amount", "currency"),
+    SourceMeasure("count_rows", "Transaction count", "count", "id", "number"),
+]
+
+
+class TransactionsSource:
+    key = "transactions"
+    label = "Transactions"
+
+    def dimensions(self) -> list[SourceDimension]:
+        return list(_DIMENSIONS)
+
+    def measures(self) -> list[SourceMeasure]:
+        return list(_MEASURES)
+
+    async def build_rows(
+        self, db: AsyncSession, org_id: int, query: ReportsQuery
+    ) -> tuple[list[dict], QueryMeta]:
+        return await execute_query(db, query, org_id=org_id)
+
+
+_INSTANCE: ReportSource = TransactionsSource()
+register(_INSTANCE)
+```
+
+- [ ] **Step 4: Run the full registry test file**
+
+Run: `docker compose -p team-reportsv3-p1 exec backend pytest tests/services/test_report_sources_registry.py -v`
+Expected: all PASS (Task 2's test now green too).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/reports/sources/__init__.py backend/app/reports/sources/transactions.py backend/tests/services/test_report_sources_registry.py
+git commit -m "feat(reports): source registry + TransactionsSource parity delegate"
+```
+
+---
+
+### Task 4: Dispatch `POST /query` through the registry
+
+**Files:**
+- Modify: `backend/app/routers/reports.py:155-172` (the `run_query` route)
+- Test: existing reports-query parity test module (must stay green) + a new dispatch assertion in `test_report_sources_registry.py`
+
+- [ ] **Step 1: Write the failing test** (dispatch indirection is used, not `execute_query` directly)
+
+```python
+# append to backend/tests/services/test_report_sources_registry.py
+@pytest.mark.asyncio
+async def test_run_query_dispatches_via_registry(monkeypatch):
+    """The route resolves the source from the AST dataset and calls its
+    build_rows — proving the indirection, not a direct execute_query call."""
+    from app.routers import reports as reports_router
+    from app.schemas.reports_query import (
+        Aggregation, Dataset, Dimension, Measure, MeasureField, QueryMeta, ReportsQuery,
+    )
+
+    called = {}
+
+    async def fake_build_rows(db, org_id, query):
+        called["org_id"] = org_id
+        called["dataset"] = query.dataset.value
+        return ([{"category": "Food", "value": 12}], QueryMeta(row_count=1, truncated=False, query_ms=1))
+
+    src = reports_router.get_source("transactions")
+    monkeypatch.setattr(src, "build_rows", fake_build_rows)
+
+    ast = ReportsQuery(
+        dataset=Dataset.TRANSACTIONS,
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+        dimensions=[Dimension.CATEGORY],
+    )
+    rows, meta = await reports_router._run_source_query(_db_stub(), ast, org_id=42)
+    assert called == {"org_id": 42, "dataset": "transactions"}
+    assert rows[0]["category"] == "Food" and meta.row_count == 1
+
+
+def _db_stub():
+    return object()  # build_rows is monkeypatched; the session is never touched
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose -p team-reportsv3-p1 exec backend pytest tests/services/test_report_sources_registry.py -k run_query_dispatches -v`
+Expected: FAIL — `reports_router._run_source_query` / `get_source` not imported in router.
+
+- [ ] **Step 3: Write minimal implementation** — edit `backend/app/routers/reports.py`
+
+Add the import near the other `app.services` import (replace the direct `execute_query` import):
+
+```python
+from app.reports.sources import get_source, all_sources
+```
+
+Add a dispatcher helper above `run_query`:
+
+```python
+async def _run_source_query(db, ast, *, org_id: int):
+    """Resolve the AST's dataset to a registered ReportSource and run it.
+
+    Unknown dataset is impossible from the wire (the Dataset enum is
+    closed and validated by Pydantic), so a KeyError here is a server
+    bug, not user input — let it surface as 500.
+    """
+    source = get_source(ast.dataset.value)
+    return await source.build_rows(db, org_id, ast)
+```
+
+Change the body of `run_query` to call the dispatcher:
+
+```python
+    rows, meta = await _run_source_query(db, body, org_id=current_user.org_id)
+    return ReportsQueryResponse(rows=rows, meta=meta)
+```
+
+(Remove the now-unused `from app.services.reports_query_service import execute_query` import — `TransactionsSource` owns that call now. Confirm nothing else in the router references `execute_query`.)
+
+- [ ] **Step 4: Run the dispatch test AND the full existing reports-query suite**
+
+Run: `docker compose -p team-reportsv3-p1 exec backend pytest tests/services/test_report_sources_registry.py tests/services/test_reports_query_service.py -v`
+(substitute the real parity test module name discovered in pre-reading)
+Expected: dispatch test PASS; **every pre-existing parity test PASS unchanged** (proves no behavior change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/routers/reports.py backend/tests/services/test_report_sources_registry.py
+git commit -m "feat(reports): dispatch /query through the source registry"
+```
+
+---
+
+### Task 5: `GET /api/v1/reports/sources` catalog endpoint
+
+**Files:**
+- Create: `backend/app/schemas/report_sources.py`
+- Modify: `backend/app/routers/reports.py` (add route ABOVE `GET /{report_id}` so the literal path isn't captured by the int matcher — same reason as `/templates` at line 223)
+- Test: a router/integration test (mirror the existing reports router test's auth + client setup)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/routers/test_report_sources_endpoint.py
+# Reuse the existing reports-router test fixtures (authed async client + a
+# user in an org + feature_reports_v2 enabled). Copy the fixture wiring
+# from the existing reports router test module discovered in pre-reading.
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_sources_endpoint_lists_transactions_catalog(authed_client):
+    resp = await authed_client.get("/api/v1/reports/sources")
+    assert resp.status_code == 200
+    body = resp.json()
+    keys = {s["key"] for s in body}
+    assert "transactions" in keys
+    tx = next(s for s in body if s["key"] == "transactions")
+    assert tx["label"] == "Transactions"
+    assert any(d["key"] == "category" for d in tx["dimensions"])
+    assert any(m["key"] == "sum_amount" and m["format"] == "currency" for m in tx["measures"])
+
+
+@pytest.mark.asyncio
+async def test_sources_endpoint_404_when_flag_off(authed_client_flag_off):
+    resp = await authed_client_flag_off.get("/api/v1/reports/sources")
+    assert resp.status_code == 404
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose -p team-reportsv3-p1 exec backend pytest tests/routers/test_report_sources_endpoint.py -v`
+Expected: FAIL — 404 (route not defined) for the first test.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backend/app/schemas/report_sources.py
+from pydantic import BaseModel
+
+
+class SourceDimensionOut(BaseModel):
+    key: str
+    label: str
+    kind: str
+
+
+class SourceMeasureOut(BaseModel):
+    key: str
+    label: str
+    agg: str
+    field: str
+    format: str
+
+
+class SourceCatalogEntry(BaseModel):
+    key: str
+    label: str
+    dimensions: list[SourceDimensionOut]
+    measures: list[SourceMeasureOut]
+```
+
+In `backend/app/routers/reports.py`, add the import:
+
+```python
+from app.schemas.report_sources import (
+    SourceCatalogEntry, SourceDimensionOut, SourceMeasureOut,
+)
+```
+
+And the route, placed immediately ABOVE `GET /{report_id}` (after `/templates`):
+
+```python
+@router.get("/sources", response_model=list[SourceCatalogEntry])
+async def list_sources(current_user: User = Depends(get_current_user)):
+    """Catalog of reportable sources with their dimensions + measures.
+
+    Drives the widget editor's source/dimension/measure pickers so the
+    frontend hardcodes nothing about a source's shape. Auth-gated +
+    behind the reports-v2 flag like every route on this router.
+    """
+    return [
+        SourceCatalogEntry(
+            key=s.key,
+            label=s.label,
+            dimensions=[SourceDimensionOut(**vars(d)) for d in s.dimensions()],
+            measures=[SourceMeasureOut(**vars(m)) for m in s.measures()],
+        )
+        for s in all_sources()
+    ]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker compose -p team-reportsv3-p1 exec backend pytest tests/routers/test_report_sources_endpoint.py -v`
+Expected: PASS (both — the flag-off 404 is provided by the existing `require_reports_v2_enabled` router dependency).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/schemas/report_sources.py backend/app/routers/reports.py backend/tests/routers/test_report_sources_endpoint.py
+git commit -m "feat(reports): GET /reports/sources catalog endpoint"
+```
+
+---
+
+### Task 6: Full-suite green + branch verification
+
+- [ ] **Step 1: Run the entire backend reports test surface**
+
+Run: `docker compose -p team-reportsv3-p1 exec backend pytest tests/ -k "report" -v`
+Expected: all PASS — new registry/catalog tests + every pre-existing reports test (parity proof).
+
+- [ ] **Step 2: Run the full backend suite (catch unrelated breakage from the import change)**
+
+Run: `docker compose -p team-reportsv3-p1 exec backend pytest -q`
+Expected: no new failures vs. the pre-change baseline.
+
+- [ ] **Step 3: Tear down the isolated stack**
+
+Run: `docker compose -p team-reportsv3-p1 down -v`
+
+- [ ] **Step 4: Open the PR** (branch `feat/reports-v3`, conventional title)
+
+PR title: `feat(reports): pluggable source registry + /sources catalog (Reports v3 phase 1)`
+Body: 2-3 lines, no test-plan section, no AI attribution (per project rules).
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 rows):** registry ✓ (Tasks 1-3) · `/query` dispatch ✓ (Task 4) · `/sources` catalog ✓ (Task 5) · TransactionsSource parity ✓ (Task 3 delegate + Task 4/6 parity runs). Enum widening + per-source measure validation are **correctly deferred to Phase 5** (no second source exists yet) — noted in Architecture so a reader doesn't expect them here.
+
+**Placeholder scan:** none — every code step has complete code. The one runtime unknown (the exact parity test module name) is flagged explicitly as a pre-reading lookup, not left silent.
+
+**Type consistency:** `SourceDimension`/`SourceMeasure` (dataclasses, Task 1) → consumed by `TransactionsSource` (Task 3) → serialized via `SourceDimensionOut`/`SourceMeasureOut` (`vars(d)` maps dataclass fields to the Pydantic fields 1:1, Task 5). `get_source`/`all_sources` defined Task 2, imported into the router Task 4/5. `_run_source_query` defined + tested Task 4. `build_rows` signature identical across base.py, transactions.py, and the dispatch test.
+
+**Out-of-scope guard:** no frontend changes, no `report_layout.py` change, no `Dataset` enum change, no migration — all consistent with "behavior-preserving Phase 1."

--- a/specs/2026-06-11-reports-v3-phase1-plan.md
+++ b/specs/2026-06-11-reports-v3-phase1-plan.md
@@ -6,6 +6,8 @@
 
 **Architecture:** The `POST /api/v1/reports/query` AST already carries a `dataset` discriminator (`ReportsQuery.dataset`, today a single-value enum). Phase 1 inserts a registry indirection: the router dispatches on `dataset` to a registered `ReportSource`, and Phase 1 registers exactly one — `TransactionsSource` — which delegates to the existing `execute_query` compiler. A new `/sources` endpoint returns each registered source's dimensions + measures (derived from the existing closed enums) so the frontend can later drive the editor from data. No enum widening, no per-source measure validation, and no new wire fields yet — those land in Phase 5 when a second source exists. This phase is pure, behavior-preserving indirection + a read-only catalog.
 
+**Phase 2 sequencing note:** Phase 2's frontend data-layer swap uses the EXISTING `dataset` wire field on `POST /reports/query` (mapping the widget's current `dataset` through the registry); the new `source` field on widget config and `Dataset` enum widening land in Phase 5. Phase 2 must NOT send a `source` key — it does not exist on the wire schema yet and would 422.
+
 **Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2.0 async, Pydantic v2, pytest (async). Tests run in an **isolated compose project** per the parallel-agent rule: `docker compose -p team-reportsv3-p1 up -d backend mysql redis`, then `docker compose -p team-reportsv3-p1 exec backend pytest ...`.
 
 **Reference files (read before starting):**

--- a/specs/2026-06-11-reports-v3-phase1-plan.md
+++ b/specs/2026-06-11-reports-v3-phase1-plan.md
@@ -12,7 +12,7 @@
 - `backend/app/services/reports_query_service.py` — `execute_query(db, ast: ReportsQuery, *, org_id: int) -> tuple[list[dict], QueryMeta]`; the compiler this phase wraps. **Read it fully first.**
 - `backend/app/schemas/reports_query.py` — the AST: `Dataset`, `Aggregation`, `MeasureField`, `Dimension`, `Measure`, `ReportsQuery`, `QueryMeta`, `ReportsQueryResponse`.
 - `backend/app/routers/reports.py:155-172` — the existing `run_query` route that calls `execute_query`; this is the call site we redirect through the registry.
-- `backend/app/tests/` — find the existing reports query test module (e.g. `test_reports_query_service.py` / `test_reports_query.py`) for the parity baseline.
+- `backend/tests/services/test_reports_query_service.py` + `backend/tests/routers/test_reports.py` — the existing parity baseline (must stay green unchanged). New tests go in `backend/tests/services/` (unit) and `backend/tests/routers/` (endpoint).
 
 ---
 


### PR DESCRIPTION
First phase of the Reports v3 redesign (spec: `specs/2026-06-11-reports-v3-flexible-canvas-design.md`).

Introduces a pluggable data-source layer behind the reports query path, with the transactions path behaving identically (parity).

- New `app/reports/sources/` package: `ReportSource` protocol + `SourceDimension`/`SourceMeasure` value objects, a keyed registry (`register`/`get_source`/`all_sources`), and `TransactionsSource` that delegates to the existing `execute_query` compiler verbatim.
- `POST /api/v1/reports/query` now dispatches on the AST `dataset` discriminator through the registry instead of calling `execute_query` directly. No behavior change for transactions.
- New `GET /api/v1/reports/sources` catalog endpoint returning each source's dimensions + measures, so the widget editor can be data-driven (consumed in a later frontend phase). Auth-gated and behind the reports-v2 flag like every route on the router.

Deliberately out of scope for this phase: enum widening for new sources, per-source measure validation, the new sources themselves (accounts/recurring/net-worth), frontend changes, migrations — all sequenced in later phases per the spec.

Full backend suite green (2307 passed, 9 skipped); the existing reports query + router parity suites pass unchanged.