### PR TITLE
fix(reports): canvas honors widget position/size, no auto-compaction

### DIFF
--- a/frontend/components/reports/Canvas.tsx
+++ b/frontend/components/reports/Canvas.tsx
@@ -24,6 +24,7 @@ import "react-resizable/css/styles.css";
 import { Responsive, WidthProvider, type Layout } from "react-grid-layout";
 
 import type { LayoutJson, Widget } from "@/lib/reports/types";
+import { widgetsFromLayout, gridChanged } from "@/lib/reports/layout";
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
@@ -63,15 +64,8 @@ export default function Canvas({
 
   function handleLayoutChange(next: Layout[]) {
     if (!editMode) return;
-    const byId = new Map(next.map((l) => [l.i, l]));
-    const updated: Widget[] = items.map((w) => {
-      const l = byId.get(w.id);
-      if (!l) return w;
-      return {
-        ...w,
-        grid: { x: l.x, y: l.y, w: l.w, h: l.h },
-      };
-    });
+    const updated = widgetsFromLayout(items, next);
+    if (!gridChanged(items, updated)) return; // swallow mount-time / no-op emissions
     onLayoutChange({ ...layout, widgets: updated });
   }
 
@@ -83,6 +77,8 @@ export default function Canvas({
         breakpoints={BREAKPOINTS}
         cols={COLS}
         rowHeight={60}
+        compactType={null}
+        preventCollision
         isDraggable={editMode}
         isResizable={editMode}
         draggableHandle="[data-grid-drag-handle]"

--- a/frontend/components/reports/Canvas.tsx
+++ b/frontend/components/reports/Canvas.tsx
@@ -38,6 +38,12 @@ interface Props {
   renderWidget: (widget: Widget) => React.ReactNode;
 }
 
+// The editor canvas is desktop-only — true mobile widths render the
+// read-only stack in the page, never this grid. So sm/xs/xxs are only
+// reached in the 640–767px "narrow desktop / settings-panel-open" gap.
+// Their exact column counts only affect how a narrow *view* reflows;
+// editing never persists from them (handleLayoutChange gates on a 12-col
+// breakpoint), so a clamped sm/xs layout can never corrupt the stored one.
 const COLS = { lg: 12, md: 12, sm: 6, xs: 1, xxs: 1 } as const;
 const BREAKPOINTS = { lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 } as const;
 
@@ -87,10 +93,16 @@ export default function Canvas({
     <div data-testid="reports-canvas" className="w-full">
       <ResponsiveGridLayout
         className="layout"
+        // Pre-seed every breakpoint with the same layout so RGL never
+        // falls through to findOrGenerateResponsiveLayout, which would run
+        // compact() and emit a spurious onLayoutChange.
         layouts={{ lg: rgLayout, md: rgLayout, sm: rgLayout, xs: rgLayout, xxs: rgLayout }}
         breakpoints={BREAKPOINTS}
         cols={COLS}
         rowHeight={60}
+        // null + preventCollision = literal placement: widgets never
+        // auto-compact, and a drag/resize into an occupied cell snaps back
+        // to the last valid position instead of displacing the neighbour.
         compactType={null}
         preventCollision
         isDraggable={editMode}

--- a/frontend/components/reports/Canvas.tsx
+++ b/frontend/components/reports/Canvas.tsx
@@ -13,7 +13,7 @@
  * passed in as children keyed by widget id so layout JSON ↔ render
  * order stay coupled.
  */
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 // react-grid-layout ships its CSS as a separate import. Loading the
 // stylesheet at the canvas module keeps the dep colocated with the
 // only consumer, so removing Reports doesn't leave a dangling import
@@ -48,6 +48,17 @@ export default function Canvas({
   renderWidget,
 }: Props) {
   const items = layout.widgets ?? [];
+  // The stored layout is the 12-column (lg/md) layout. At narrower
+  // breakpoints react-grid-layout clamps widget widths to fit fewer
+  // columns (e.g. a w=12 table → w=6 at sm); those clamped layouts are
+  // responsive *views*, not edits. Persisting one back would corrupt the
+  // canonical layout (w=12 → w=6) and falsely mark the report dirty on
+  // load whenever the canvas renders below 12 cols (e.g. the settings
+  // panel narrows it on a laptop). Tracked in a ref, not state, because
+  // RGL fires onBreakpointChange synchronously *before* onLayoutChange in
+  // the same width-change cycle — a ref reads fresh within that tick
+  // where state would still be stale.
+  const colsRef = useRef<number>(COLS.lg);
   const rgLayout = useMemo<Layout[]>(
     () =>
       items.map((w) => ({
@@ -64,6 +75,9 @@ export default function Canvas({
 
   function handleLayoutChange(next: Layout[]) {
     if (!editMode) return;
+    // Only persist edits made at a full-width (12-col) breakpoint; a
+    // narrower breakpoint's clamped layout is a view, not an edit.
+    if (colsRef.current < COLS.lg) return;
     const updated = widgetsFromLayout(items, next);
     if (!gridChanged(items, updated)) return; // swallow mount-time / no-op emissions
     onLayoutChange({ ...layout, widgets: updated });
@@ -83,6 +97,9 @@ export default function Canvas({
         isResizable={editMode}
         draggableHandle="[data-grid-drag-handle]"
         onLayoutChange={handleLayoutChange}
+        onBreakpointChange={(_breakpoint, newCols) => {
+          colsRef.current = newCols;
+        }}
         margin={[12, 12]}
       >
         {items.map((w) => (

--- a/frontend/lib/reports/layout.ts
+++ b/frontend/lib/reports/layout.ts
@@ -1,16 +1,15 @@
+import type { Layout } from "react-grid-layout";
+
 import type { Widget } from "@/lib/reports/types";
 
-/** Minimal shape of a react-grid-layout item (the fields we read). */
-export interface RglItem {
-  i: string;
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-}
+/** The react-grid-layout item fields we read — a subset of RGL's `Layout`,
+ *  reused rather than re-declared so it can't drift from the library type. */
+export type RglItem = Pick<Layout, "i" | "x" | "y" | "w" | "h">;
 
 /** Apply react-grid-layout positions back onto widgets, keyed by id.
- *  Widgets with no matching rgl item are returned unchanged. */
+ *  Always returns exactly `items.length` widgets (it maps over `items`);
+ *  a widget with no matching rgl item is returned unchanged, and an rgl
+ *  item with no matching widget is ignored. */
 export function widgetsFromLayout(items: Widget[], rglItems: RglItem[]): Widget[] {
   const byId = new Map(rglItems.map((l) => [l.i, l]));
   return items.map((wgt) => {
@@ -20,14 +19,21 @@ export function widgetsFromLayout(items: Widget[], rglItems: RglItem[]): Widget[
   });
 }
 
-/** True only when at least one widget's grid x/y/w/h actually differs.
- *  Used to ignore react-grid-layout's mount-time and no-op emissions so
- *  loading a report does not spuriously mark the editor dirty. */
+/** True when the set of widgets (by id) changed OR any widget's grid
+ *  x/y/w/h differs. Used to ignore react-grid-layout's mount-time and
+ *  no-op emissions so loading a report does not spuriously mark the
+ *  editor dirty. On the canvas path `next` is always
+ *  `widgetsFromLayout(items, …)`, so in practice only real drag/resize
+ *  deltas reach the field comparison; the length/id guards are defensive
+ *  for any other caller. */
 export function gridChanged(prev: Widget[], next: Widget[]): boolean {
   if (prev.length !== next.length) return true;
   const byId = new Map(prev.map((p) => [p.id, p.grid]));
   for (const n of next) {
     const g = byId.get(n.id);
+    // Defensive: widgetsFromLayout preserves every id from `prev`, so a
+    // miss only happens if gridChanged is called with a `next` built
+    // elsewhere — treat an unknown id as a change.
     if (!g) return true;
     if (g.x !== n.grid.x || g.y !== n.grid.y || g.w !== n.grid.w || g.h !== n.grid.h) {
       return true;

--- a/frontend/lib/reports/layout.ts
+++ b/frontend/lib/reports/layout.ts
@@ -1,0 +1,37 @@
+import type { Widget } from "@/lib/reports/types";
+
+/** Minimal shape of a react-grid-layout item (the fields we read). */
+export interface RglItem {
+  i: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Apply react-grid-layout positions back onto widgets, keyed by id.
+ *  Widgets with no matching rgl item are returned unchanged. */
+export function widgetsFromLayout(items: Widget[], rglItems: RglItem[]): Widget[] {
+  const byId = new Map(rglItems.map((l) => [l.i, l]));
+  return items.map((wgt) => {
+    const l = byId.get(wgt.id);
+    if (!l) return wgt;
+    return { ...wgt, grid: { x: l.x, y: l.y, w: l.w, h: l.h } };
+  });
+}
+
+/** True only when at least one widget's grid x/y/w/h actually differs.
+ *  Used to ignore react-grid-layout's mount-time and no-op emissions so
+ *  loading a report does not spuriously mark the editor dirty. */
+export function gridChanged(prev: Widget[], next: Widget[]): boolean {
+  if (prev.length !== next.length) return true;
+  const byId = new Map(prev.map((p) => [p.id, p.grid]));
+  for (const n of next) {
+    const g = byId.get(n.id);
+    if (!g) return true;
+    if (g.x !== n.grid.x || g.y !== n.grid.y || g.w !== n.grid.w || g.h !== n.grid.h) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/frontend/tests/components/reports/Canvas.test.tsx
+++ b/frontend/tests/components/reports/Canvas.test.tsx
@@ -1,36 +1,56 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import type { LayoutJson } from "@/lib/reports/types";
+
+// The props the mocked react-grid-layout captures so tests can drive its
+// callbacks directly.
+interface CapturedProps {
+  compactType: unknown;
+  preventCollision?: boolean;
+  onLayoutChange: (
+    layout: Array<{ i: string; x: number; y: number; w: number; h: number }>,
+  ) => void;
+  onBreakpointChange: (breakpoint: string, cols: number) => void;
+  children?: ReactNode;
+}
 
 // WidthProvider is stubbed as identity and Responsive is replaced with a
 // prop-capturing stub: jsdom can't measure container width, so we can't
 // exercise RGL's real ResizeObserver mount emission. Instead we drive
-// `captured.onLayoutChange` / `captured.onBreakpointChange` manually to
+// `props.onLayoutChange` / `props.onBreakpointChange` manually to
 // unit-test the guard logic in isolation.
-let captured: any = null;
-vi.mock("react-grid-layout", () => {
-  const React = require("react");
-  const Responsive = (props: any) => {
+let captured: CapturedProps | null = null;
+vi.mock("react-grid-layout", () => ({
+  Responsive: (props: CapturedProps) => {
     captured = props;
-    return React.createElement("div", { "data-testid": "rgl" }, props.children);
-  };
-  return { Responsive, WidthProvider: (C: any) => C, default: { Responsive } };
-});
+    return <div data-testid="rgl">{props.children}</div>;
+  },
+  WidthProvider: <T,>(c: T): T => c,
+}));
 
 import Canvas from "@/components/reports/Canvas";
-import type { LayoutJson } from "@/lib/reports/types";
 
 const layout: LayoutJson = {
   version: 1,
   widgets: [
     { id: "a", type: "kpi", title: "A", grid: { x: 0, y: 0, w: 4, h: 4 }, config: {} },
-  ] as any,
+  ] as unknown as LayoutJson["widgets"],
 };
 
-function renderCanvas(onLayoutChange = vi.fn()) {
+function renderCanvas(editMode = true) {
+  const onLayoutChange = vi.fn();
   render(
-    <Canvas layout={layout} editMode onLayoutChange={onLayoutChange} renderWidget={() => <div>w</div>} />,
+    <Canvas
+      layout={layout}
+      editMode={editMode}
+      onLayoutChange={onLayoutChange}
+      renderWidget={() => <div>w</div>}
+    />,
   );
-  return onLayoutChange;
+  if (!captured) throw new Error("react-grid-layout stub did not capture props");
+  return { props: captured, onLayoutChange };
 }
 
 describe("Canvas literal layout", () => {
@@ -39,57 +59,54 @@ describe("Canvas literal layout", () => {
   });
 
   it("ignores layout emissions when not in edit mode", () => {
-    const cb = vi.fn();
-    render(
-      <Canvas layout={layout} editMode={false} onLayoutChange={cb} renderWidget={() => <div>w</div>} />,
-    );
-    captured.onLayoutChange([{ i: "a", x: 3, y: 0, w: 4, h: 4 }]); // genuine move
-    expect(cb).not.toHaveBeenCalled();
+    const { props, onLayoutChange } = renderCanvas(false);
+    props.onLayoutChange([{ i: "a", x: 3, y: 0, w: 4, h: 4 }]); // genuine move
+    expect(onLayoutChange).not.toHaveBeenCalled();
   });
 
   it("passes compactType=null and preventCollision to react-grid-layout", () => {
-    renderCanvas();
-    expect(captured.compactType).toBeNull();
-    expect(captured.preventCollision).toBe(true);
+    const { props } = renderCanvas();
+    expect(props.compactType).toBeNull();
+    expect(props.preventCollision).toBe(true);
   });
 
   it("does NOT call onLayoutChange for a mount/no-op emission (same grid)", () => {
-    const cb = renderCanvas();
-    captured.onLayoutChange([{ i: "a", x: 0, y: 0, w: 4, h: 4 }]); // identical → ignored
-    expect(cb).not.toHaveBeenCalled();
+    const { props, onLayoutChange } = renderCanvas();
+    props.onLayoutChange([{ i: "a", x: 0, y: 0, w: 4, h: 4 }]); // identical → ignored
+    expect(onLayoutChange).not.toHaveBeenCalled();
   });
 
   it("DOES call onLayoutChange when a widget actually moves", () => {
-    const cb = renderCanvas();
-    captured.onLayoutChange([{ i: "a", x: 3, y: 0, w: 4, h: 4 }]); // moved → propagate
-    expect(cb).toHaveBeenCalledTimes(1);
-    expect(cb.mock.calls[0][0].widgets[0].grid.x).toBe(3);
+    const { props, onLayoutChange } = renderCanvas();
+    props.onLayoutChange([{ i: "a", x: 3, y: 0, w: 4, h: 4 }]); // moved → propagate
+    expect(onLayoutChange).toHaveBeenCalledTimes(1);
+    expect(onLayoutChange.mock.calls[0][0].widgets[0].grid.x).toBe(3);
   });
 
   it("DOES call onLayoutChange on a resize-only change (h only)", () => {
-    const cb = renderCanvas();
-    captured.onLayoutChange([{ i: "a", x: 0, y: 0, w: 4, h: 6 }]); // resized → propagate
-    expect(cb).toHaveBeenCalledTimes(1);
-    expect(cb.mock.calls[0][0].widgets[0].grid.h).toBe(6);
+    const { props, onLayoutChange } = renderCanvas();
+    props.onLayoutChange([{ i: "a", x: 0, y: 0, w: 4, h: 6 }]); // resized → propagate
+    expect(onLayoutChange).toHaveBeenCalledTimes(1);
+    expect(onLayoutChange.mock.calls[0][0].widgets[0].grid.h).toBe(6);
   });
 
   it("does NOT persist a clamped layout emitted at a narrow (<12 col) breakpoint", () => {
-    const cb = renderCanvas();
+    const { props, onLayoutChange } = renderCanvas();
     // RGL switches to the sm breakpoint (6 cols) and clamps the widget's
     // width — a responsive view, not an edit. onBreakpointChange fires
     // synchronously before onLayoutChange in the same cycle.
-    captured.onBreakpointChange("sm", 6);
-    captured.onLayoutChange([{ i: "a", x: 0, y: 0, w: 2, h: 4 }]); // clamped → ignored
-    expect(cb).not.toHaveBeenCalled();
+    props.onBreakpointChange("sm", 6);
+    props.onLayoutChange([{ i: "a", x: 0, y: 0, w: 2, h: 4 }]); // clamped → ignored
+    expect(onLayoutChange).not.toHaveBeenCalled();
   });
 
   it("resumes persisting after returning to a 12-col breakpoint", () => {
-    const cb = renderCanvas();
-    captured.onBreakpointChange("sm", 6);
-    captured.onLayoutChange([{ i: "a", x: 0, y: 0, w: 2, h: 4 }]); // ignored (narrow)
-    captured.onBreakpointChange("lg", 12);
-    captured.onLayoutChange([{ i: "a", x: 1, y: 0, w: 4, h: 4 }]); // real edit at lg
-    expect(cb).toHaveBeenCalledTimes(1);
-    expect(cb.mock.calls[0][0].widgets[0].grid.x).toBe(1);
+    const { props, onLayoutChange } = renderCanvas();
+    props.onBreakpointChange("sm", 6);
+    props.onLayoutChange([{ i: "a", x: 0, y: 0, w: 2, h: 4 }]); // ignored (narrow)
+    props.onBreakpointChange("lg", 12);
+    props.onLayoutChange([{ i: "a", x: 1, y: 0, w: 4, h: 4 }]); // real edit at lg
+    expect(onLayoutChange).toHaveBeenCalledTimes(1);
+    expect(onLayoutChange.mock.calls[0][0].widgets[0].grid.x).toBe(1);
   });
 });

--- a/frontend/tests/components/reports/Canvas.test.tsx
+++ b/frontend/tests/components/reports/Canvas.test.tsx
@@ -1,7 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
 
-// Capture the props react-grid-layout receives + expose its onLayoutChange.
+// WidthProvider is stubbed as identity and Responsive is replaced with a
+// prop-capturing stub: jsdom can't measure container width, so we can't
+// exercise RGL's real ResizeObserver mount emission. Instead we drive
+// `captured.onLayoutChange` / `captured.onBreakpointChange` manually to
+// unit-test the guard logic in isolation.
 let captured: any = null;
 vi.mock("react-grid-layout", () => {
   const React = require("react");
@@ -30,6 +34,19 @@ function renderCanvas(onLayoutChange = vi.fn()) {
 }
 
 describe("Canvas literal layout", () => {
+  beforeEach(() => {
+    captured = null; // reset so a test that forgets to render fails loudly
+  });
+
+  it("ignores layout emissions when not in edit mode", () => {
+    const cb = vi.fn();
+    render(
+      <Canvas layout={layout} editMode={false} onLayoutChange={cb} renderWidget={() => <div>w</div>} />,
+    );
+    captured.onLayoutChange([{ i: "a", x: 3, y: 0, w: 4, h: 4 }]); // genuine move
+    expect(cb).not.toHaveBeenCalled();
+  });
+
   it("passes compactType=null and preventCollision to react-grid-layout", () => {
     renderCanvas();
     expect(captured.compactType).toBeNull();

--- a/frontend/tests/components/reports/Canvas.test.tsx
+++ b/frontend/tests/components/reports/Canvas.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+// Capture the props react-grid-layout receives + expose its onLayoutChange.
+let captured: any = null;
+vi.mock("react-grid-layout", () => {
+  const React = require("react");
+  const Responsive = (props: any) => {
+    captured = props;
+    return React.createElement("div", { "data-testid": "rgl" }, props.children);
+  };
+  return { Responsive, WidthProvider: (C: any) => C, default: { Responsive } };
+});
+
+import Canvas from "@/components/reports/Canvas";
+import type { LayoutJson } from "@/lib/reports/types";
+
+const layout: LayoutJson = {
+  version: 1,
+  widgets: [
+    { id: "a", type: "kpi", title: "A", grid: { x: 0, y: 0, w: 4, h: 4 }, config: {} },
+  ] as any,
+};
+
+function renderCanvas(onLayoutChange = vi.fn()) {
+  render(
+    <Canvas layout={layout} editMode onLayoutChange={onLayoutChange} renderWidget={() => <div>w</div>} />,
+  );
+  return onLayoutChange;
+}
+
+describe("Canvas literal layout", () => {
+  it("passes compactType=null and preventCollision to react-grid-layout", () => {
+    renderCanvas();
+    expect(captured.compactType).toBeNull();
+    expect(captured.preventCollision).toBe(true);
+  });
+
+  it("does NOT call onLayoutChange for a mount/no-op emission (same grid)", () => {
+    const cb = renderCanvas();
+    captured.onLayoutChange([{ i: "a", x: 0, y: 0, w: 4, h: 4 }]); // identical → ignored
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("DOES call onLayoutChange when a widget actually moves", () => {
+    const cb = renderCanvas();
+    captured.onLayoutChange([{ i: "a", x: 3, y: 0, w: 4, h: 4 }]); // moved → propagate
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0].widgets[0].grid.x).toBe(3);
+  });
+});

--- a/frontend/tests/components/reports/Canvas.test.tsx
+++ b/frontend/tests/components/reports/Canvas.test.tsx
@@ -48,4 +48,31 @@ describe("Canvas literal layout", () => {
     expect(cb).toHaveBeenCalledTimes(1);
     expect(cb.mock.calls[0][0].widgets[0].grid.x).toBe(3);
   });
+
+  it("DOES call onLayoutChange on a resize-only change (h only)", () => {
+    const cb = renderCanvas();
+    captured.onLayoutChange([{ i: "a", x: 0, y: 0, w: 4, h: 6 }]); // resized → propagate
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0].widgets[0].grid.h).toBe(6);
+  });
+
+  it("does NOT persist a clamped layout emitted at a narrow (<12 col) breakpoint", () => {
+    const cb = renderCanvas();
+    // RGL switches to the sm breakpoint (6 cols) and clamps the widget's
+    // width — a responsive view, not an edit. onBreakpointChange fires
+    // synchronously before onLayoutChange in the same cycle.
+    captured.onBreakpointChange("sm", 6);
+    captured.onLayoutChange([{ i: "a", x: 0, y: 0, w: 2, h: 4 }]); // clamped → ignored
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("resumes persisting after returning to a 12-col breakpoint", () => {
+    const cb = renderCanvas();
+    captured.onBreakpointChange("sm", 6);
+    captured.onLayoutChange([{ i: "a", x: 0, y: 0, w: 2, h: 4 }]); // ignored (narrow)
+    captured.onBreakpointChange("lg", 12);
+    captured.onLayoutChange([{ i: "a", x: 1, y: 0, w: 4, h: 4 }]); // real edit at lg
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0].widgets[0].grid.x).toBe(1);
+  });
 });

--- a/frontend/tests/lib/reports/layout.test.ts
+++ b/frontend/tests/lib/reports/layout.test.ts
@@ -22,6 +22,16 @@ describe("widgetsFromLayout", () => {
     const out = widgetsFromLayout(items, [{ i: "ghost", x: 9, y: 9, w: 1, h: 1 }]);
     expect(out[0].grid).toEqual({ x: 0, y: 0, w: 4, h: 4 });
   });
+
+  it("returns exactly items.length widgets, ignoring extra phantom rgl items", () => {
+    const items = [w("a", 0, 0)];
+    const out = widgetsFromLayout(items, [
+      { i: "a", x: 1, y: 0, w: 4, h: 4 },
+      { i: "phantom", x: 5, y: 5, w: 2, h: 2 },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].grid).toEqual({ x: 1, y: 0, w: 4, h: 4 });
+  });
 });
 
 describe("gridChanged", () => {

--- a/frontend/tests/lib/reports/layout.test.ts
+++ b/frontend/tests/lib/reports/layout.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { widgetsFromLayout, gridChanged } from "@/lib/reports/layout";
+import type { Widget } from "@/lib/reports/types";
+
+const w = (id: string, x: number, y: number, ww = 4, h = 4): Widget =>
+  ({ id, type: "kpi", title: id, grid: { x, y, w: ww, h }, config: {} } as unknown as Widget);
+
+describe("widgetsFromLayout", () => {
+  it("applies new x/y/w/h from the rgl items, keyed by id", () => {
+    const items = [w("a", 0, 0), w("b", 0, 4)];
+    const next = [
+      { i: "a", x: 2, y: 0, w: 4, h: 4 },
+      { i: "b", x: 0, y: 4, w: 6, h: 5 },
+    ];
+    const out = widgetsFromLayout(items, next);
+    expect(out[0].grid).toEqual({ x: 2, y: 0, w: 4, h: 4 });
+    expect(out[1].grid).toEqual({ x: 0, y: 4, w: 6, h: 5 });
+  });
+
+  it("leaves a widget untouched when no rgl item matches its id", () => {
+    const items = [w("a", 0, 0)];
+    const out = widgetsFromLayout(items, [{ i: "ghost", x: 9, y: 9, w: 1, h: 1 }]);
+    expect(out[0].grid).toEqual({ x: 0, y: 0, w: 4, h: 4 });
+  });
+});
+
+describe("gridChanged", () => {
+  it("is false when every widget's grid is identical (mount / no-op emission)", () => {
+    const items = [w("a", 0, 0), w("b", 0, 4)];
+    expect(gridChanged(items, widgetsFromLayout(items, [
+      { i: "a", x: 0, y: 0, w: 4, h: 4 },
+      { i: "b", x: 0, y: 4, w: 4, h: 4 },
+    ]))).toBe(false);
+  });
+
+  it("is true when any x/y/w/h moved (real drag/resize)", () => {
+    const items = [w("a", 0, 0)];
+    expect(gridChanged(items, [{ ...items[0], grid: { x: 1, y: 0, w: 4, h: 4 } } as Widget])).toBe(true);
+  });
+});

--- a/specs/2026-06-12-reports-v3-canvas-layout-plan.md
+++ b/specs/2026-06-12-reports-v3-canvas-layout-plan.md
@@ -1,0 +1,277 @@
+# Reports v3 — Canvas Layout Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make the report canvas honor widget positions/sizes literally — no auto-compaction, no auto-movement, and no spurious "unsaved changes" on load.
+
+**Architecture:** `frontend/components/reports/Canvas.tsx` wraps react-grid-layout's `WidthProvider(Responsive)`. Two changes: (1) set `compactType={null}` + `preventCollision` so widgets stay exactly where placed and never auto-pack; (2) guard `handleLayoutChange` so it only propagates a change when a widget's grid actually differs — this swallows the mount-time emission (from WidthProvider's first measure) and any no-op emission, which today flips the editor to `dirty=true` on load. The grid-diff logic is extracted into pure, unit-testable helpers. Persistence is unchanged (explicit Save button already; layout changes just set `dirty`).
+
+**Tech Stack:** Next.js 16 / React 19 / TypeScript, react-grid-layout, vitest. **Frontend test rule:** run the FULL `vitest run` suite, never a single file (per `reference_frontend_full_suite_verification`).
+
+**Out of scope (next phase):** the ConfigRail→popover rebuild that eliminates the settings-panel-open reflow (that's the Phase-4 editor work). This PR does not touch ConfigRail or the page flex container.
+
+**Reference (current code, read first):**
+- `frontend/components/reports/Canvas.tsx` — `rgLayout` useMemo (~50-62), `<ResponsiveGridLayout>` JSX (~80-97), `handleLayoutChange` (~64-76). Today: no `compactType`/`preventCollision`; `handleLayoutChange` maps every emission into widgets and calls `onLayoutChange` unconditionally.
+- `frontend/app/reports/[id]/page.tsx` — `updateLayout` (~403-406) sets `dirty=true`; `hydrateFromReport` (~329-340) resets `dirty=false` on load.
+- `frontend/tests/app/reports-editor-page.test.tsx` — stubs Canvas (jsdom can't measure width); asserts add/save/filter flows. Must stay green.
+
+---
+
+## File Structure
+- **Create** `frontend/lib/reports/layout.ts` — pure helpers `widgetsFromLayout(items, rglItems)` and `gridChanged(prev, next)`.
+- **Modify** `frontend/components/reports/Canvas.tsx` — use the helpers in `handleLayoutChange` (early-return on no change) + add `compactType={null}` and `preventCollision`.
+- **Create** `frontend/tests/lib/reports/layout.test.ts` — unit tests for the helpers.
+- **Create/extend** `frontend/tests/components/reports/Canvas.test.tsx` — mock react-grid-layout to assert `onLayoutChange` fires only on a real grid change, not on a mount-time/no-op emission.
+
+---
+
+### Task 1: Pure grid-diff helpers (TDD)
+
+**Files:**
+- Create: `frontend/lib/reports/layout.ts`
+- Test: `frontend/tests/lib/reports/layout.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// frontend/tests/lib/reports/layout.test.ts
+import { describe, it, expect } from "vitest";
+import { widgetsFromLayout, gridChanged } from "@/lib/reports/layout";
+import type { Widget } from "@/lib/reports/types";
+
+const w = (id: string, x: number, y: number, ww = 4, h = 4): Widget =>
+  ({ id, type: "kpi", title: id, grid: { x, y, w: ww, h }, config: {} } as unknown as Widget);
+
+describe("widgetsFromLayout", () => {
+  it("applies new x/y/w/h from the rgl items, keyed by id", () => {
+    const items = [w("a", 0, 0), w("b", 0, 4)];
+    const next = [
+      { i: "a", x: 2, y: 0, w: 4, h: 4 },
+      { i: "b", x: 0, y: 4, w: 6, h: 5 },
+    ];
+    const out = widgetsFromLayout(items, next);
+    expect(out[0].grid).toEqual({ x: 2, y: 0, w: 4, h: 4 });
+    expect(out[1].grid).toEqual({ x: 0, y: 4, w: 6, h: 5 });
+  });
+
+  it("leaves a widget untouched when no rgl item matches its id", () => {
+    const items = [w("a", 0, 0)];
+    const out = widgetsFromLayout(items, [{ i: "ghost", x: 9, y: 9, w: 1, h: 1 }]);
+    expect(out[0].grid).toEqual({ x: 0, y: 0, w: 4, h: 4 });
+  });
+});
+
+describe("gridChanged", () => {
+  it("is false when every widget's grid is identical (mount / no-op emission)", () => {
+    const items = [w("a", 0, 0), w("b", 0, 4)];
+    expect(gridChanged(items, widgetsFromLayout(items, [
+      { i: "a", x: 0, y: 0, w: 4, h: 4 },
+      { i: "b", x: 0, y: 4, w: 4, h: 4 },
+    ]))).toBe(false);
+  });
+
+  it("is true when any x/y/w/h moved (real drag/resize)", () => {
+    const items = [w("a", 0, 0)];
+    expect(gridChanged(items, [{ ...items[0], grid: { x: 1, y: 0, w: 4, h: 4 } } as Widget])).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `docker compose exec -T frontend npx vitest run tests/lib/reports/layout.test.ts`
+Expected: FAIL — module `@/lib/reports/layout` not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// frontend/lib/reports/layout.ts
+import type { Widget } from "@/lib/reports/types";
+
+/** Minimal shape of a react-grid-layout item (the fields we read). */
+export interface RglItem {
+  i: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Apply react-grid-layout positions back onto widgets, keyed by id.
+ *  Widgets with no matching rgl item are returned unchanged. */
+export function widgetsFromLayout(items: Widget[], rglItems: RglItem[]): Widget[] {
+  const byId = new Map(rglItems.map((l) => [l.i, l]));
+  return items.map((wgt) => {
+    const l = byId.get(wgt.id);
+    if (!l) return wgt;
+    return { ...wgt, grid: { x: l.x, y: l.y, w: l.w, h: l.h } };
+  });
+}
+
+/** True only when at least one widget's grid x/y/w/h actually differs.
+ *  Used to ignore react-grid-layout's mount-time and no-op emissions so
+ *  loading a report does not spuriously mark the editor dirty. */
+export function gridChanged(prev: Widget[], next: Widget[]): boolean {
+  if (prev.length !== next.length) return true;
+  const byId = new Map(prev.map((p) => [p.id, p.grid]));
+  for (const n of next) {
+    const g = byId.get(n.id);
+    if (!g) return true;
+    if (g.x !== n.grid.x || g.y !== n.grid.y || g.w !== n.grid.w || g.h !== n.grid.h) {
+      return true;
+    }
+  }
+  return false;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `docker compose exec -T frontend npx vitest run tests/lib/reports/layout.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/lib/reports/layout.ts frontend/tests/lib/reports/layout.test.ts
+git commit -m "feat(reports): pure grid-diff helpers for literal canvas layout"
+```
+
+---
+
+### Task 2: Wire the guard + literal-layout props into Canvas
+
+**Files:**
+- Modify: `frontend/components/reports/Canvas.tsx`
+- Test: `frontend/tests/components/reports/Canvas.test.tsx`
+
+- [ ] **Step 1: Write the failing test** (mock react-grid-layout so we can drive `onLayoutChange`)
+
+```tsx
+// frontend/tests/components/reports/Canvas.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+
+// Capture the props react-grid-layout receives + expose its onLayoutChange.
+let captured: any = null;
+vi.mock("react-grid-layout", () => {
+  const React = require("react");
+  const Responsive = (props: any) => {
+    captured = props;
+    return React.createElement("div", { "data-testid": "rgl" }, props.children);
+  };
+  return { Responsive, WidthProvider: (C: any) => C, default: { Responsive } };
+});
+
+import Canvas from "@/components/reports/Canvas";
+import type { LayoutJson } from "@/lib/reports/types";
+
+const layout: LayoutJson = {
+  version: 1,
+  widgets: [
+    { id: "a", type: "kpi", title: "A", grid: { x: 0, y: 0, w: 4, h: 4 }, config: {} },
+  ] as any,
+};
+
+function renderCanvas(onLayoutChange = vi.fn()) {
+  render(
+    <Canvas layout={layout} editMode onLayoutChange={onLayoutChange} renderWidget={() => <div>w</div>} />,
+  );
+  return onLayoutChange;
+}
+
+describe("Canvas literal layout", () => {
+  it("passes compactType=null and preventCollision to react-grid-layout", () => {
+    renderCanvas();
+    expect(captured.compactType).toBeNull();
+    expect(captured.preventCollision).toBe(true);
+  });
+
+  it("does NOT call onLayoutChange for a mount/no-op emission (same grid)", () => {
+    const cb = renderCanvas();
+    captured.onLayoutChange([{ i: "a", x: 0, y: 0, w: 4, h: 4 }]); // identical → ignored
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("DOES call onLayoutChange when a widget actually moves", () => {
+    const cb = renderCanvas();
+    captured.onLayoutChange([{ i: "a", x: 3, y: 0, w: 4, h: 4 }]); // moved → propagate
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0].widgets[0].grid.x).toBe(3);
+  });
+});
+```
+
+Note: adapt the mock to however the file imports RGL (`import { Responsive, WidthProvider } from "react-grid-layout"`). If `Canvas` is a named vs default export, match it. Verify against the real file before finalizing.
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `docker compose exec -T frontend npx vitest run tests/components/reports/Canvas.test.tsx`
+Expected: FAIL — `compactType` undefined / `onLayoutChange` called on no-op.
+
+- [ ] **Step 3: Implement** — edit `frontend/components/reports/Canvas.tsx`
+
+Import the helpers:
+```tsx
+import { widgetsFromLayout, gridChanged } from "@/lib/reports/layout";
+```
+
+Replace the body of `handleLayoutChange` so it early-returns on no change:
+```tsx
+function handleLayoutChange(next: Layout[]) {
+  if (!editMode) return;
+  const updated = widgetsFromLayout(items, next);
+  if (!gridChanged(items, updated)) return; // swallow mount-time / no-op emissions
+  onLayoutChange({ ...layout, widgets: updated });
+}
+```
+
+Add the two props to `<ResponsiveGridLayout>`:
+```tsx
+  compactType={null}
+  preventCollision
+```
+(place them alongside the existing `cols`/`rowHeight` props).
+
+- [ ] **Step 4: Run the new test + verify pass**
+
+Run: `docker compose exec -T frontend npx vitest run tests/components/reports/Canvas.test.tsx`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/reports/Canvas.tsx frontend/tests/components/reports/Canvas.test.tsx
+git commit -m "fix(reports): honor widget positions literally, no spurious dirty on load"
+```
+
+---
+
+### Task 3: Full-suite verification + type-check + PR
+
+- [ ] **Step 1: TypeScript type-check**
+
+Run: `docker compose exec -T frontend npx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 2: FULL vitest suite** (NOT a single file — load-bearing per the project rule)
+
+Run: `docker compose exec -T frontend npx vitest run`
+Expected: all green, including `tests/app/reports-editor-page.test.tsx` (the existing add/save/filter flows must be unaffected — this change only suppresses no-op emissions and adds two RGL props).
+
+- [ ] **Step 3: Open the PR**
+
+Branch `feat/reports-v3-canvas`. Push and open PR.
+Title: `fix(reports): canvas honors widget position/size, no auto-compaction (Reports v3 phase 2)`
+Body: concise, no test-plan section, no AI attribution. Note it fixes the literal-placement + spurious-dirty bugs; the settings-panel-open reflow is fixed with the popover editor in the next phase.
+
+---
+
+## Self-Review
+
+**Spec coverage:** literal positions (`compactType={null}` + `preventCollision`) ✓ Task 2 · no spurious dirty on load (mount-emission guard via `gridChanged`) ✓ Tasks 1-2 · persistence unchanged (explicit Save already) ✓ (no change needed). The ConfigRail-reflow is explicitly deferred to the popover phase and called out in scope.
+
+**Placeholder scan:** none — full code in every step. The one runtime unknown (exact RGL import style / Canvas export shape) is flagged as a verify-against-the-real-file step, not left silent.
+
+**Type consistency:** `RglItem`/`widgetsFromLayout`/`gridChanged` defined in Task 1, consumed by name in Task 2. `Widget` type imported from `@/lib/reports/types` in both. The `gridChanged` signature (prev: Widget[], next: Widget[]) matches its Task-2 call site `gridChanged(items, updated)`.


### PR DESCRIPTION
Fixes the reported bug where report widgets ignore their set position/size and the canvas jumps on load.

- `Canvas.tsx` now passes `compactType={null}` + `preventCollision` to react-grid-layout, so widgets stay exactly where placed and never auto-pack or shift when others are added/resized/removed. Gaps are allowed (literal placement).
- `handleLayoutChange` now ignores react-grid-layout's mount-time and no-op emissions (via new pure helpers `widgetsFromLayout`/`gridChanged` in `lib/reports/layout.ts`), so simply loading a report no longer flips the editor to an unsaved/dirty state.

The settings-panel-open reflow (ConfigRail shrinking the canvas) is fixed in the next phase, when the editor becomes a floating popover that doesn't steal width.

Full frontend suite green (1675 tests), tsc clean.