### PR TITLE
fix(charts): label forecast/budget bar tooltips with color swatch + series name

### DIFF
--- a/frontend/app/budgets/BudgetOverviewChart.tsx
+++ b/frontend/app/budgets/BudgetOverviewChart.tsx
@@ -19,6 +19,7 @@ import {
 import { formatAmount } from "@/lib/format";
 import { chartColor } from "@/lib/chart-colors";
 import { BudgetSpentBarShape, type BudgetSpentBarShapeProps } from "@/lib/chart-shapes";
+import { SeriesTooltip } from "@/components/charts/SeriesTooltip";
 
 export interface BudgetOverviewDatum {
   name: string;
@@ -43,13 +44,18 @@ export default function BudgetOverviewChart({
         <XAxis type="number" hide />
         <YAxis type="category" dataKey="name" width={100} tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
         <Tooltip
-          formatter={(v, name) => [
-            formatAmount(Number(v)),
-            name === "spent" ? <span style={{ color: chartColor.spent }}>Spent</span>
-              : name === "over" ? <span style={{ color: chartColor.over }}>Over budget</span>
-              : <span style={{ color: chartColor.remaining }}>Remaining</span>,
-          ]}
-          contentStyle={{ fontSize: "11px" }}
+          content={
+            <SeriesTooltip
+              format={formatAmount}
+              resolve={(entry) =>
+                entry.dataKey === "spent"
+                  ? { label: "Spent", color: chartColor.spent }
+                  : entry.dataKey === "over"
+                    ? { label: "Over budget", color: chartColor.over }
+                    : { label: "Remaining", color: chartColor.remaining }
+              }
+            />
+          }
         />
         {/* D5 fix: shared BudgetSpentBarShape recomputes corner radii
             per-row so a stack at >=100% utilization (no remaining

--- a/frontend/app/budgets/BudgetOverviewChart.tsx
+++ b/frontend/app/budgets/BudgetOverviewChart.tsx
@@ -20,6 +20,7 @@ import { formatAmount } from "@/lib/format";
 import { chartColor } from "@/lib/chart-colors";
 import { BudgetSpentBarShape, type BudgetSpentBarShapeProps } from "@/lib/chart-shapes";
 import { SeriesTooltip } from "@/components/charts/SeriesTooltip";
+import { resolveBudgetSeries } from "@/lib/reports/chart-series-tooltip";
 
 export interface BudgetOverviewDatum {
   name: string;
@@ -45,16 +46,7 @@ export default function BudgetOverviewChart({
         <YAxis type="category" dataKey="name" width={100} tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
         <Tooltip
           content={
-            <SeriesTooltip
-              format={formatAmount}
-              resolve={(entry) =>
-                entry.dataKey === "spent"
-                  ? { label: "Spent", color: chartColor.spent }
-                  : entry.dataKey === "over"
-                    ? { label: "Over budget", color: chartColor.over }
-                    : { label: "Remaining", color: chartColor.remaining }
-              }
-            />
+            <SeriesTooltip format={formatAmount} resolve={resolveBudgetSeries} />
           }
         />
         {/* D5 fix: shared BudgetSpentBarShape recomputes corner radii

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -20,6 +20,10 @@ import { useTransactionAddedListener } from "@/lib/hooks/use-transaction-added";
 import { PieChart, Pie, BarChart, Bar, XAxis, YAxis, Cell, Tooltip, ResponsiveContainer } from "recharts";
 import { chartColor } from "@/lib/chart-colors";
 import { SeriesTooltip } from "@/components/charts/SeriesTooltip";
+import {
+  resolveBudgetSeries,
+  resolveForecastSeries,
+} from "@/lib/reports/chart-series-tooltip";
 import { BudgetSpentBarShape, type BudgetSpentBarShapeProps } from "@/lib/chart-shapes";
 import OnTrackTile from "@/components/dashboard/OnTrackTile";
 import AIForecastRefineToggle from "@/components/dashboard/AIForecastRefineToggle";
@@ -1054,16 +1058,7 @@ export default function DashboardPage() {
                       <YAxis type="category" dataKey="name" width={100} tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
                       <Tooltip
                         content={
-                          <SeriesTooltip
-                            format={formatAmount}
-                            resolve={(entry) =>
-                              entry.dataKey === "spent"
-                                ? { label: "Spent", color: chartColor.spent }
-                                : entry.dataKey === "remaining"
-                                  ? { label: "Remaining", color: chartColor.remaining }
-                                  : null
-                            }
-                          />
+                          <SeriesTooltip format={formatAmount} resolve={resolveBudgetSeries} />
                         }
                       />
                       {/* D5 follow-up: shared BudgetSpentBarShape so
@@ -1125,27 +1120,7 @@ export default function DashboardPage() {
                           <YAxis type="category" dataKey="name" width={90} tick={{ fill: chartColor.axisTick, fontSize: 10 }} />
                           <Tooltip
                             content={
-                              <SeriesTooltip
-                                format={formatAmount}
-                                resolve={(entry) => {
-                                  if (entry.dataKey === "planned") {
-                                    return { label: "Planned", color: chartColor.planned };
-                                  }
-                                  if (entry.dataKey === "actual") {
-                                    const row = entry.payload as
-                                      | { planned?: number; actual?: number }
-                                      | undefined;
-                                    const isOver = row
-                                      ? Number(row.actual) > Number(row.planned)
-                                      : false;
-                                    return {
-                                      label: "Actual",
-                                      color: isOver ? chartColor.over : chartColor.actual,
-                                    };
-                                  }
-                                  return null;
-                                }}
-                              />
+                              <SeriesTooltip format={formatAmount} resolve={resolveForecastSeries} />
                             }
                           />
                           <Bar dataKey="planned" fill={chartColor.planned} radius={[4, 4, 4, 4]} animationDuration={220}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -897,6 +897,10 @@ export default function DashboardPage() {
                               opacity={chartFilter && chartFilter !== d.name ? 0.3 : 1} />
                           ))}
                         </Pie>
+                        {/* Single-series pie: recharts renders the slice
+                            name itself, so a value `formatter` is enough.
+                            SeriesTooltip is only needed for the multi-series
+                            bar charts where the name node failed to render. */}
                         <Tooltip formatter={(v) => formatAmount(Number(v))} contentStyle={{ fontSize: "12px" }} />
                       </PieChart>
                     </ResponsiveContainer>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -19,6 +19,7 @@ import { useTransactionAddedListener } from "@/lib/hooks/use-transaction-added";
 
 import { PieChart, Pie, BarChart, Bar, XAxis, YAxis, Cell, Tooltip, ResponsiveContainer } from "recharts";
 import { chartColor } from "@/lib/chart-colors";
+import { SeriesTooltip } from "@/components/charts/SeriesTooltip";
 import { BudgetSpentBarShape, type BudgetSpentBarShapeProps } from "@/lib/chart-shapes";
 import OnTrackTile from "@/components/dashboard/OnTrackTile";
 import AIForecastRefineToggle from "@/components/dashboard/AIForecastRefineToggle";
@@ -1052,11 +1053,18 @@ export default function DashboardPage() {
                       <XAxis type="number" hide />
                       <YAxis type="category" dataKey="name" width={100} tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
                       <Tooltip
-                        formatter={(v, name) => [
-                          formatAmount(Number(v)),
-                          name === "spent" ? <span style={{ color: chartColor.spent }}>Spent</span> : <span style={{ color: chartColor.remaining }}>Remaining</span>,
-                        ]}
-                        contentStyle={{ fontSize: "11px" }}
+                        content={
+                          <SeriesTooltip
+                            format={formatAmount}
+                            resolve={(entry) =>
+                              entry.dataKey === "spent"
+                                ? { label: "Spent", color: chartColor.spent }
+                                : entry.dataKey === "remaining"
+                                  ? { label: "Remaining", color: chartColor.remaining }
+                                  : null
+                            }
+                          />
+                        }
                       />
                       {/* D5 follow-up: shared BudgetSpentBarShape so
                           the spent bar rounds its right edge at >=100%
@@ -1116,22 +1124,29 @@ export default function DashboardPage() {
                           <XAxis type="number" hide />
                           <YAxis type="category" dataKey="name" width={90} tick={{ fill: chartColor.axisTick, fontSize: 10 }} />
                           <Tooltip
-                            formatter={(v, name, item) => {
-                              if (name === "planned") {
-                                return [
-                                  formatAmount(Number(v)),
-                                  <span key="planned" style={{ color: chartColor.planned }}>Planned</span>,
-                                ];
-                              }
-                              const row = (item as { payload?: { planned: number; actual: number } } | undefined)?.payload;
-                              const isOver = row ? row.actual > row.planned : false;
-                              const labelColor = isOver ? chartColor.over : chartColor.actual;
-                              return [
-                                formatAmount(Number(v)),
-                                <span key="actual" style={{ color: labelColor }}>Actual</span>,
-                              ];
-                            }}
-                            contentStyle={{ fontSize: "11px" }}
+                            content={
+                              <SeriesTooltip
+                                format={formatAmount}
+                                resolve={(entry) => {
+                                  if (entry.dataKey === "planned") {
+                                    return { label: "Planned", color: chartColor.planned };
+                                  }
+                                  if (entry.dataKey === "actual") {
+                                    const row = entry.payload as
+                                      | { planned?: number; actual?: number }
+                                      | undefined;
+                                    const isOver = row
+                                      ? Number(row.actual) > Number(row.planned)
+                                      : false;
+                                    return {
+                                      label: "Actual",
+                                      color: isOver ? chartColor.over : chartColor.actual,
+                                    };
+                                  }
+                                  return null;
+                                }}
+                              />
+                            }
                           />
                           <Bar dataKey="planned" fill={chartColor.planned} radius={[4, 4, 4, 4]} animationDuration={220}
                             cursor="pointer"

--- a/frontend/app/forecast-plans/ForecastPlanChart.tsx
+++ b/frontend/app/forecast-plans/ForecastPlanChart.tsx
@@ -20,6 +20,7 @@ import {
 import { formatAmount } from "@/lib/format";
 import { chartColor } from "@/lib/chart-colors";
 import { SeriesTooltip } from "@/components/charts/SeriesTooltip";
+import { resolveForecastSeries } from "@/lib/reports/chart-series-tooltip";
 
 export interface ForecastPlanChartDatum {
   categoryId: number;
@@ -51,27 +52,7 @@ export default function ForecastPlanChart({
         />
         <Tooltip
           content={
-            <SeriesTooltip
-              format={formatAmount}
-              resolve={(entry) => {
-                if (entry.dataKey === "planned") {
-                  return { label: "Planned", color: chartColor.planned };
-                }
-                if (entry.dataKey === "actual") {
-                  const row = entry.payload as
-                    | { planned?: number; actual?: number }
-                    | undefined;
-                  const isOver = row
-                    ? Number(row.actual) > Number(row.planned)
-                    : false;
-                  return {
-                    label: "Actual",
-                    color: isOver ? chartColor.over : chartColor.actual,
-                  };
-                }
-                return null;
-              }}
-            />
+            <SeriesTooltip format={formatAmount} resolve={resolveForecastSeries} />
           }
         />
         <Bar

--- a/frontend/app/forecast-plans/ForecastPlanChart.tsx
+++ b/frontend/app/forecast-plans/ForecastPlanChart.tsx
@@ -19,6 +19,7 @@ import {
 
 import { formatAmount } from "@/lib/format";
 import { chartColor } from "@/lib/chart-colors";
+import { SeriesTooltip } from "@/components/charts/SeriesTooltip";
 
 export interface ForecastPlanChartDatum {
   categoryId: number;
@@ -49,11 +50,29 @@ export default function ForecastPlanChart({
           tick={{ fill: chartColor.axisTick, fontSize: 11 }}
         />
         <Tooltip
-          formatter={(v, name) => [
-            formatAmount(Number(v)),
-            name === "planned" ? <span style={{ color: chartColor.planned }}>Planned</span> : <span style={{ color: chartColor.actual }}>Actual</span>,
-          ]}
-          contentStyle={{ fontSize: "11px" }}
+          content={
+            <SeriesTooltip
+              format={formatAmount}
+              resolve={(entry) => {
+                if (entry.dataKey === "planned") {
+                  return { label: "Planned", color: chartColor.planned };
+                }
+                if (entry.dataKey === "actual") {
+                  const row = entry.payload as
+                    | { planned?: number; actual?: number }
+                    | undefined;
+                  const isOver = row
+                    ? Number(row.actual) > Number(row.planned)
+                    : false;
+                  return {
+                    label: "Actual",
+                    color: isOver ? chartColor.over : chartColor.actual,
+                  };
+                }
+                return null;
+              }}
+            />
+          }
         />
         <Bar
           dataKey="planned"

--- a/frontend/components/charts/SeriesTooltip.tsx
+++ b/frontend/components/charts/SeriesTooltip.tsx
@@ -72,11 +72,11 @@ export function SeriesTooltip({
         borderRadius: 8,
         padding: "8px 10px",
         fontSize: 11,
-        boxShadow: "0 4px 14px rgba(0,0,0,0.12)",
+        boxShadow: "var(--shadow-card)",
         minWidth: 120,
       }}
     >
-      {label != null && (
+      {!!label && (
         <div
           style={{
             fontWeight: 600,
@@ -89,7 +89,7 @@ export function SeriesTooltip({
       )}
       {rows.map(({ entry, series }, i) => (
         <div
-          key={i}
+          key={String(entry.dataKey ?? i)}
           style={{
             display: "flex",
             alignItems: "center",
@@ -98,7 +98,7 @@ export function SeriesTooltip({
           }}
         >
           <span
-            aria-hidden
+            aria-hidden="true"
             style={{
               width: 9,
               height: 9,

--- a/frontend/components/charts/SeriesTooltip.tsx
+++ b/frontend/components/charts/SeriesTooltip.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+/**
+ * Shared recharts tooltip for category bar charts (forecast / budget).
+ *
+ * recharts' default item template (and a `formatter` that returns a
+ * coloured `name` node) does NOT reliably render the series name in
+ * recharts 3.x, so these charts showed bare numbers with no indication
+ * of which value was Planned vs Actual/Spent/Remaining. This component
+ * takes full control of `content` and renders, per series row:
+ *
+ *     ▢ <label>            <value>
+ *
+ * The swatch colour matches the bar (including dynamic per-row colours
+ * like green-under / red-over) because the caller resolves it from the
+ * hovered row. Colours come in from the caller as theme tokens
+ * (`var(--color-*)`), so this file holds no off-token literals.
+ */
+import type { ReactNode } from "react";
+
+export interface TooltipSeries {
+  /** Human label, e.g. "Planned" / "Spent". */
+  label: string;
+  /** Swatch colour — a CSS colour string, normally a `var(--color-*)` token. */
+  color: string;
+}
+
+/** One entry recharts hands us in `payload`. */
+export interface SeriesTooltipEntry {
+  dataKey?: string | number;
+  value?: number | string;
+  name?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface SeriesTooltipProps {
+  active?: boolean;
+  payload?: SeriesTooltipEntry[];
+  /** Category title (recharts passes the x/y category here). */
+  label?: ReactNode;
+  /**
+   * Map a hovered series entry → its label + swatch colour. Return
+   * `null` to omit the row (e.g. a zero-height stacked segment).
+   */
+  resolve: (entry: SeriesTooltipEntry) => TooltipSeries | null;
+  /** Value formatter (e.g. the page's `formatAmount`). */
+  format: (value: number) => string;
+}
+
+export function SeriesTooltip({
+  active,
+  payload,
+  label,
+  resolve,
+  format,
+}: SeriesTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+
+  const rows = payload
+    .map((entry) => ({ entry, series: resolve(entry) }))
+    .filter((r): r is { entry: SeriesTooltipEntry; series: TooltipSeries } =>
+      r.series !== null,
+    );
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        background: "var(--color-surface)",
+        border: "1px solid var(--color-border)",
+        borderRadius: 8,
+        padding: "8px 10px",
+        fontSize: 11,
+        boxShadow: "0 4px 14px rgba(0,0,0,0.12)",
+        minWidth: 120,
+      }}
+    >
+      {label != null && (
+        <div
+          style={{
+            fontWeight: 600,
+            marginBottom: 4,
+            color: "var(--color-text)",
+          }}
+        >
+          {label}
+        </div>
+      )}
+      {rows.map(({ entry, series }, i) => (
+        <div
+          key={i}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "1px 0",
+          }}
+        >
+          <span
+            aria-hidden
+            style={{
+              width: 9,
+              height: 9,
+              borderRadius: 2,
+              background: series.color,
+              flex: "0 0 auto",
+            }}
+          />
+          <span style={{ color: "var(--color-text-secondary)" }}>
+            {series.label}
+          </span>
+          <span
+            style={{
+              marginLeft: "auto",
+              paddingLeft: 12,
+              fontVariantNumeric: "tabular-nums",
+              color: "var(--color-text)",
+            }}
+          >
+            {format(Number(entry.value))}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/charts/SeriesTooltip.tsx
+++ b/frontend/components/charts/SeriesTooltip.tsx
@@ -81,7 +81,7 @@ export function SeriesTooltip({
           style={{
             fontWeight: 600,
             marginBottom: 4,
-            color: "var(--color-text)",
+            color: "var(--color-text-primary)",
           }}
         >
           {label}
@@ -115,7 +115,7 @@ export function SeriesTooltip({
               marginLeft: "auto",
               paddingLeft: 12,
               fontVariantNumeric: "tabular-nums",
-              color: "var(--color-text)",
+              color: "var(--color-text-primary)",
             }}
           >
             {format(Number(entry.value))}

--- a/frontend/lib/reports/chart-series-tooltip.ts
+++ b/frontend/lib/reports/chart-series-tooltip.ts
@@ -1,0 +1,81 @@
+/**
+ * Series resolvers for the shared `SeriesTooltip` on the forecast/budget
+ * bar charts. Centralised here (rather than inline in each chart) so the
+ * four charts stay in sync and the colour-tier logic is unit-tested.
+ *
+ * The swatch colour must MATCH the bar the user is hovering, including the
+ * dynamic per-row fills: forecast `actual` turns red when it exceeds
+ * `planned`; budget `spent` walks the utilisation tiers (gold → watch →
+ * over) exactly like its `<Cell>` fill. Zero-height stacked segments
+ * (e.g. `over` on an on-budget row) are omitted so the tooltip doesn't
+ * show noise like "Over budget: $0.00".
+ */
+import { chartColor } from "@/lib/chart-colors";
+import type {
+  SeriesTooltipEntry,
+  TooltipSeries,
+} from "@/components/charts/SeriesTooltip";
+
+/** Planned-vs-actual charts. `actual` is red when it exceeds `planned`. */
+export function resolveForecastSeries(
+  entry: SeriesTooltipEntry,
+): TooltipSeries | null {
+  if (entry.dataKey === "planned") {
+    return { label: "Planned", color: chartColor.planned };
+  }
+  if (entry.dataKey === "actual") {
+    const row = entry.payload as
+      | { planned?: number; actual?: number }
+      | undefined;
+    const over = row ? Number(row.actual) > Number(row.planned) : false;
+    return { label: "Actual", color: over ? chartColor.over : chartColor.actual };
+  }
+  return null;
+}
+
+/**
+ * Budget charts (dashboard "Budget Progress" + budgets page overview).
+ * The `spent` swatch tracks the utilisation tier so it matches the bar's
+ * per-row `<Cell>` fill; zero-value stacked segments are dropped.
+ */
+export function resolveBudgetSeries(
+  entry: SeriesTooltipEntry,
+): TooltipSeries | null {
+  if (Number(entry.value) === 0) return null; // omit zero-height segments
+  if (entry.dataKey === "spent") {
+    const pct = budgetPercentUsed(entry.payload);
+    return {
+      label: "Spent",
+      color:
+        pct > 100
+          ? chartColor.over
+          : pct > 80
+            ? chartColor.watch
+            : chartColor.spent,
+    };
+  }
+  if (entry.dataKey === "over") {
+    return { label: "Over budget", color: chartColor.over };
+  }
+  if (entry.dataKey === "remaining") {
+    return { label: "Remaining", color: chartColor.remaining };
+  }
+  return null;
+}
+
+/**
+ * Resolve a row's utilisation %. The dashboard datum carries `pct`
+ * (percent_used) directly; the budgets-page datum doesn't, so derive it:
+ * an `over` amount means >100%, otherwise spent / (spent + remaining).
+ */
+function budgetPercentUsed(payload: SeriesTooltipEntry["payload"]): number {
+  const row = payload as
+    | { pct?: number; spent?: number; remaining?: number; over?: number }
+    | undefined;
+  if (row?.pct != null) return Number(row.pct);
+  if (Number(row?.over) > 0) return 101;
+  const spent = Number(row?.spent ?? 0);
+  const remaining = Number(row?.remaining ?? 0);
+  const total = spent + remaining;
+  return total > 0 ? (spent / total) * 100 : 0;
+}

--- a/frontend/tests/components/charts/SeriesTooltip.test.tsx
+++ b/frontend/tests/components/charts/SeriesTooltip.test.tsx
@@ -66,4 +66,24 @@ describe("SeriesTooltip", () => {
     expect(screen.getByText("Spent")).toBeInTheDocument();
     expect(screen.queryByText("$9.00")).not.toBeInTheDocument();
   });
+
+  it("renders nothing when every row resolves to null", () => {
+    const { container } = render(
+      <SeriesTooltip
+        active
+        label="X"
+        payload={[{ dataKey: "a", value: 1 }]}
+        resolve={() => null}
+        format={fmt}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for an empty payload", () => {
+    const { container } = render(
+      <SeriesTooltip active payload={[]} resolve={() => null} format={fmt} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/frontend/tests/components/charts/SeriesTooltip.test.tsx
+++ b/frontend/tests/components/charts/SeriesTooltip.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { SeriesTooltip } from "@/components/charts/SeriesTooltip";
+
+const fmt = (v: number) => `$${v.toFixed(2)}`;
+
+describe("SeriesTooltip", () => {
+  it("renders nothing when inactive", () => {
+    const { container } = render(
+      <SeriesTooltip
+        active={false}
+        payload={[{ dataKey: "planned", value: 10 }]}
+        resolve={() => ({ label: "Planned", color: "var(--color-accent)" })}
+        format={fmt}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the title plus a label + formatted value per resolved series", () => {
+    render(
+      <SeriesTooltip
+        active
+        label="Housing"
+        payload={[
+          { dataKey: "planned", value: 3800 },
+          {
+            dataKey: "actual",
+            value: 3758.06,
+            payload: { planned: 3800, actual: 3758.06 },
+          },
+        ]}
+        resolve={(e) =>
+          e.dataKey === "planned"
+            ? { label: "Planned", color: "var(--color-accent)" }
+            : { label: "Actual", color: "var(--color-success)" }
+        }
+        format={fmt}
+      />,
+    );
+    expect(screen.getByText("Housing")).toBeInTheDocument();
+    expect(screen.getByText("Planned")).toBeInTheDocument();
+    expect(screen.getByText("$3800.00")).toBeInTheDocument();
+    expect(screen.getByText("Actual")).toBeInTheDocument();
+    expect(screen.getByText("$3758.06")).toBeInTheDocument();
+  });
+
+  it("omits rows whose resolve returns null", () => {
+    render(
+      <SeriesTooltip
+        active
+        label="X"
+        payload={[
+          { dataKey: "spent", value: 5 },
+          { dataKey: "ghost", value: 9 },
+        ]}
+        resolve={(e) =>
+          e.dataKey === "spent"
+            ? { label: "Spent", color: "var(--color-accent)" }
+            : null
+        }
+        format={fmt}
+      />,
+    );
+    expect(screen.getByText("Spent")).toBeInTheDocument();
+    expect(screen.queryByText("$9.00")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/lib/reports/chart-series-tooltip.test.ts
+++ b/frontend/tests/lib/reports/chart-series-tooltip.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  resolveForecastSeries,
+  resolveBudgetSeries,
+} from "@/lib/reports/chart-series-tooltip";
+import { chartColor } from "@/lib/chart-colors";
+
+describe("resolveForecastSeries", () => {
+  it("maps planned to the planned colour", () => {
+    expect(resolveForecastSeries({ dataKey: "planned", value: 100 })).toEqual({
+      label: "Planned",
+      color: chartColor.planned,
+    });
+  });
+
+  it("colours actual green when at/under plan", () => {
+    expect(
+      resolveForecastSeries({
+        dataKey: "actual",
+        value: 80,
+        payload: { planned: 100, actual: 80 },
+      }),
+    ).toEqual({ label: "Actual", color: chartColor.actual });
+  });
+
+  it("colours actual red when over plan (matches the bar's Cell fill)", () => {
+    expect(
+      resolveForecastSeries({
+        dataKey: "actual",
+        value: 120,
+        payload: { planned: 100, actual: 120 },
+      }),
+    ).toEqual({ label: "Actual", color: chartColor.over });
+  });
+
+  it("returns null for an unknown series", () => {
+    expect(resolveForecastSeries({ dataKey: "ghost", value: 1 })).toBeNull();
+  });
+});
+
+describe("resolveBudgetSeries", () => {
+  it("omits zero-value stacked segments (no 'Over budget: $0.00' noise)", () => {
+    expect(resolveBudgetSeries({ dataKey: "over", value: 0 })).toBeNull();
+    expect(resolveBudgetSeries({ dataKey: "remaining", value: 0 })).toBeNull();
+    expect(resolveBudgetSeries({ dataKey: "spent", value: 0 })).toBeNull();
+  });
+
+  it("walks the spent swatch through the utilisation tiers via pct (dashboard datum)", () => {
+    expect(
+      resolveBudgetSeries({ dataKey: "spent", value: 50, payload: { pct: 50 } })?.color,
+    ).toBe(chartColor.spent);
+    expect(
+      resolveBudgetSeries({ dataKey: "spent", value: 90, payload: { pct: 90 } })?.color,
+    ).toBe(chartColor.watch);
+    expect(
+      resolveBudgetSeries({ dataKey: "spent", value: 110, payload: { pct: 110 } })?.color,
+    ).toBe(chartColor.over);
+  });
+
+  it("derives the tier from over/spent/remaining when pct is absent (budgets-page datum)", () => {
+    expect(
+      resolveBudgetSeries({
+        dataKey: "spent",
+        value: 100,
+        payload: { spent: 100, remaining: 0, over: 20 },
+      })?.color,
+    ).toBe(chartColor.over); // over > 0 → over-budget tier
+    expect(
+      resolveBudgetSeries({
+        dataKey: "spent",
+        value: 90,
+        payload: { spent: 90, remaining: 10, over: 0 },
+      })?.color,
+    ).toBe(chartColor.watch); // 90% → watch
+    expect(
+      resolveBudgetSeries({
+        dataKey: "spent",
+        value: 50,
+        payload: { spent: 50, remaining: 50, over: 0 },
+      })?.color,
+    ).toBe(chartColor.spent); // 50% → normal
+  });
+
+  it("labels non-zero over and remaining with their colours", () => {
+    expect(resolveBudgetSeries({ dataKey: "over", value: 20 })).toEqual({
+      label: "Over budget",
+      color: chartColor.over,
+    });
+    expect(resolveBudgetSeries({ dataKey: "remaining", value: 30 })).toEqual({
+      label: "Remaining",
+      color: chartColor.remaining,
+    });
+  });
+});


### PR DESCRIPTION
The forecast/budget bar-chart tooltips showed bare numbers (e.g. Housing "3,758.06" / "3,800.00") with no indication of which value was Planned vs Actual/Spent/Remaining. These charts are separate from the Reports v2 widgets that #439 fixed, so they were never addressed.

Root cause: a recharts `formatter` returning a coloured `<span>` name does not render the series name in recharts 3.x, so only the value showed.

Fix: a shared, theme-token-only `SeriesTooltip` (`components/charts/SeriesTooltip.tsx`) takes over `content` and renders, per series, a color swatch + label + value. Wired into all four affected tooltips:
- Dashboard "Budget Progress" (Spent / Remaining)
- Dashboard "Forecast by Category" (Planned / Actual, with green-under / red-over swatch)
- Forecast Plans page chart (Planned / Actual)
- Budgets page chart (Spent / Remaining / Over budget)

Swatch colors mirror the bars, including the dynamic under/over coloring. Full frontend suite green (1671), tsc clean.