### PR TITLE
feat(reports): grouped value formatting across report widgets

### DIFF
--- a/frontend/components/reports/widgets/AreaWidget.tsx
+++ b/frontend/components/reports/widgets/AreaWidget.tsx
@@ -49,6 +49,7 @@ export default function AreaWidget({ widget, canvasFilters, editMode }: Props) {
   );
 
   const dimensionKey = widget.config.dimensions[0] ?? "dimension";
+  const format = widget.config.format ?? "number";
   const seriesKeys = widget.config.measures.map((_, i) => `s${i}`);
   const rows = mergeSeriesRows(series, dimensionKey, seriesKeys);
   const labels = widget.config.measures.map((m, i) =>
@@ -108,6 +109,7 @@ export default function AreaWidget({ widget, canvasFilters, editMode }: Props) {
             seriesKeys={seriesKeys}
             labels={labels}
             stackId={stackId}
+            format={format}
           />
         )}
       </div>

--- a/frontend/components/reports/widgets/AreaWidgetChart.tsx
+++ b/frontend/components/reports/widgets/AreaWidgetChart.tsx
@@ -58,6 +58,7 @@ export default function AreaWidgetChart({
           interval={0}
         />
         <YAxis
+          width={80}
           tick={{ fill: chartColor.axisTick, fontSize: 11 }}
           tickFormatter={(v) => formatMeasureValue(Number(v), format)}
         />

--- a/frontend/components/reports/widgets/AreaWidgetChart.tsx
+++ b/frontend/components/reports/widgets/AreaWidgetChart.tsx
@@ -19,6 +19,7 @@ import {
 } from "recharts";
 
 import { chartColor } from "@/lib/chart-colors";
+import { formatMeasureValue } from "@/lib/reports/series";
 
 // Canonical categorical chart palette (theme tokens, mirrors the
 // dashboard). chart-5 (danger/red) sits last so neutral series don't
@@ -36,6 +37,8 @@ export interface AreaWidgetChartProps {
   seriesKeys: string[];
   labels: string[];
   stackId?: string;
+  /** Display format for the measure value (tooltip + value axis). */
+  format: "currency" | "number" | "percent";
 }
 
 export default function AreaWidgetChart({
@@ -43,6 +46,7 @@ export default function AreaWidgetChart({
   seriesKeys,
   labels,
   stackId,
+  format,
 }: AreaWidgetChartProps) {
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -53,8 +57,14 @@ export default function AreaWidgetChart({
           tick={{ fill: chartColor.axisTick, fontSize: 11 }}
           interval={0}
         />
-        <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
-        <Tooltip cursor={{ stroke: "var(--color-border)" }} />
+        <YAxis
+          tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+          tickFormatter={(v) => formatMeasureValue(Number(v), format)}
+        />
+        <Tooltip
+          cursor={{ stroke: "var(--color-border)" }}
+          formatter={(v) => formatMeasureValue(Number(v), format)}
+        />
         {seriesKeys.length > 1 && <Legend wrapperStyle={{ fontSize: 11 }} />}
         {seriesKeys.map((key, i) => (
           <Area

--- a/frontend/components/reports/widgets/BarWidget.tsx
+++ b/frontend/components/reports/widgets/BarWidget.tsx
@@ -105,6 +105,7 @@ export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
 
   const rows = sliced ? stackedRows : simpleRows;
   const hasRows = rows.length > 0;
+  const format = widget.config.format ?? "number";
 
   // CSV export. Single-series: [dimension, measure]. Sliced (break-down
   // by a secondary dimension): [primary dimension, ...one column per
@@ -169,6 +170,7 @@ export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
             secondaryValues={secondaryValues}
             seriesKeys={seriesKeys}
             valueName={measureLabel}
+            format={format}
           />
         )}
       </div>

--- a/frontend/components/reports/widgets/BarWidgetChart.tsx
+++ b/frontend/components/reports/widgets/BarWidgetChart.tsx
@@ -71,6 +71,7 @@ export default function BarWidgetChart({
           interval={0}
         />
         <YAxis
+          width={80}
           tick={{ fill: chartColor.axisTick, fontSize: 11 }}
           tickFormatter={(v) => formatMeasureValue(Number(v), format)}
         />

--- a/frontend/components/reports/widgets/BarWidgetChart.tsx
+++ b/frontend/components/reports/widgets/BarWidgetChart.tsx
@@ -17,6 +17,7 @@ import {
 } from "recharts";
 
 import { chartColor } from "@/lib/chart-colors";
+import { formatMeasureValue } from "@/lib/reports/series";
 
 // Canonical categorical chart palette (theme tokens, mirrors the
 // dashboard). chart-5 (danger/red) sits last so neutral break-down
@@ -48,6 +49,8 @@ export interface BarWidgetChartProps {
    * ``name`` from their secondary value.
    */
   valueName: string;
+  /** Display format for the measure value (tooltip + value axis). */
+  format: "currency" | "number" | "percent";
 }
 
 export default function BarWidgetChart({
@@ -56,6 +59,7 @@ export default function BarWidgetChart({
   secondaryValues,
   seriesKeys,
   valueName,
+  format,
 }: BarWidgetChartProps) {
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -66,8 +70,14 @@ export default function BarWidgetChart({
           tick={{ fill: chartColor.axisTick, fontSize: 11 }}
           interval={0}
         />
-        <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
-        <Tooltip cursor={{ fill: "var(--color-border)", opacity: 0.3 }} />
+        <YAxis
+          tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+          tickFormatter={(v) => formatMeasureValue(Number(v), format)}
+        />
+        <Tooltip
+          cursor={{ fill: "var(--color-border)", opacity: 0.3 }}
+          formatter={(v) => formatMeasureValue(Number(v), format)}
+        />
         {sliced ? (
           secondaryValues.map((sv, i) => (
             <Bar

--- a/frontend/components/reports/widgets/KPIWidget.tsx
+++ b/frontend/components/reports/widgets/KPIWidget.tsx
@@ -11,6 +11,7 @@
  * handle, title bar) wraps it.
  */
 import { useReportQuery } from "@/lib/reports/useReportQuery";
+import { formatMeasureValue } from "@/lib/reports/series";
 import type { CanvasFilters, KPIWidget as KPIWidgetType } from "@/lib/reports/types";
 import WidgetCsvButton from "./WidgetCsvButton";
 import type { CsvCell } from "@/lib/reports/csv";
@@ -95,7 +96,7 @@ export default function KPIWidget({
             data-testid="kpi-widget-value"
             className="text-2xl font-semibold text-text-primary"
           >
-            {formatValue(value, format)}
+            {formatMeasureValue(value, format)}
           </div>
           {showDelta && delta !== null && (
             <div
@@ -124,18 +125,4 @@ function readValue(
   if (v === null || v === undefined) return null;
   const n = typeof v === "number" ? v : Number(v);
   return Number.isFinite(n) ? n : null;
-}
-
-function formatValue(value: number, format: "currency" | "number" | "percent") {
-  if (format === "currency") {
-    return value.toLocaleString(undefined, {
-      style: "currency",
-      currency: "USD",
-      maximumFractionDigits: 2,
-    });
-  }
-  if (format === "percent") {
-    return `${value.toFixed(1)}%`;
-  }
-  return value.toLocaleString();
 }

--- a/frontend/components/reports/widgets/LineWidget.tsx
+++ b/frontend/components/reports/widgets/LineWidget.tsx
@@ -48,6 +48,7 @@ export default function LineWidget({ widget, canvasFilters, editMode }: Props) {
   );
 
   const dimensionKey = widget.config.dimensions[0] ?? "dimension";
+  const format = widget.config.format ?? "number";
   const seriesKeys = widget.config.measures.map((_, i) => `s${i}`);
   const rows = mergeSeriesRows(series, dimensionKey, seriesKeys);
   const labels = widget.config.measures.map((m, i) =>
@@ -106,6 +107,7 @@ export default function LineWidget({ widget, canvasFilters, editMode }: Props) {
             seriesKeys={seriesKeys}
             labels={labels}
             smooth={widget.config.smooth}
+            format={format}
           />
         )}
       </div>

--- a/frontend/components/reports/widgets/LineWidgetChart.tsx
+++ b/frontend/components/reports/widgets/LineWidgetChart.tsx
@@ -17,6 +17,7 @@ import {
 } from "recharts";
 
 import { chartColor } from "@/lib/chart-colors";
+import { formatMeasureValue } from "@/lib/reports/series";
 
 // Canonical categorical chart palette (theme tokens, mirrors the
 // dashboard). chart-5 (danger/red) sits last so neutral series don't
@@ -34,6 +35,8 @@ export interface LineWidgetChartProps {
   seriesKeys: string[];
   labels: string[];
   smooth?: boolean;
+  /** Display format for the measure value (tooltip + value axis). */
+  format: "currency" | "number" | "percent";
 }
 
 export default function LineWidgetChart({
@@ -41,6 +44,7 @@ export default function LineWidgetChart({
   seriesKeys,
   labels,
   smooth,
+  format,
 }: LineWidgetChartProps) {
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -51,8 +55,14 @@ export default function LineWidgetChart({
           tick={{ fill: chartColor.axisTick, fontSize: 11 }}
           interval={0}
         />
-        <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
-        <Tooltip cursor={{ stroke: "var(--color-border)" }} />
+        <YAxis
+          tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+          tickFormatter={(v) => formatMeasureValue(Number(v), format)}
+        />
+        <Tooltip
+          cursor={{ stroke: "var(--color-border)" }}
+          formatter={(v) => formatMeasureValue(Number(v), format)}
+        />
         {seriesKeys.length > 1 && <Legend wrapperStyle={{ fontSize: 11 }} />}
         {seriesKeys.map((key, i) => (
           <Line

--- a/frontend/components/reports/widgets/LineWidgetChart.tsx
+++ b/frontend/components/reports/widgets/LineWidgetChart.tsx
@@ -56,6 +56,7 @@ export default function LineWidgetChart({
           interval={0}
         />
         <YAxis
+          width={80}
           tick={{ fill: chartColor.axisTick, fontSize: 11 }}
           tickFormatter={(v) => formatMeasureValue(Number(v), format)}
         />

--- a/frontend/components/reports/widgets/PieWidget.tsx
+++ b/frontend/components/reports/widgets/PieWidget.tsx
@@ -49,6 +49,7 @@ export default function PieWidget({ widget, canvasFilters, editMode }: Props) {
     value: typeof r.value === "number" ? r.value : Number(r.value ?? 0),
   }));
   const rows = topNWithOther(rawRows, topN);
+  const format = widget.config.format ?? "number";
 
   // CSV export mirrors the displayed slices (after the top-N "Other"
   // roll-up): [dimension, measure].
@@ -99,7 +100,7 @@ export default function PieWidget({ widget, canvasFilters, editMode }: Props) {
             No data
           </div>
         ) : (
-          <PieWidgetChart rows={rows} />
+          <PieWidgetChart rows={rows} format={format} />
         )}
       </div>
     </div>

--- a/frontend/components/reports/widgets/PieWidgetChart.tsx
+++ b/frontend/components/reports/widgets/PieWidgetChart.tsx
@@ -8,6 +8,8 @@
  */
 import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 
+import { formatMeasureValue } from "@/lib/reports/series";
+
 // Canonical categorical chart palette (theme tokens, mirrors the
 // dashboard donut). Slices cycle through chart-1..chart-5; the explicit
 // "Other" roll-up below stays on the neutral border track.
@@ -21,9 +23,11 @@ const PIE_COLORS = [
 
 export interface PieWidgetChartProps {
   rows: Array<{ label: string; value: number }>;
+  /** Display format for the measure value (tooltip only — pie has no axis). */
+  format: "currency" | "number" | "percent";
 }
 
-export default function PieWidgetChart({ rows }: PieWidgetChartProps) {
+export default function PieWidgetChart({ rows, format }: PieWidgetChartProps) {
   return (
     <ResponsiveContainer width="100%" height="100%">
       <PieChart>
@@ -47,7 +51,7 @@ export default function PieWidgetChart({ rows }: PieWidgetChartProps) {
             />
           ))}
         </Pie>
-        <Tooltip />
+        <Tooltip formatter={(v) => formatMeasureValue(Number(v), format)} />
         <Legend
           verticalAlign="bottom"
           wrapperStyle={{ fontSize: 11 }}

--- a/frontend/components/reports/widgets/SparklineWidget.tsx
+++ b/frontend/components/reports/widgets/SparklineWidget.tsx
@@ -17,7 +17,7 @@
 import dynamic from "next/dynamic";
 
 import { useReportQuery } from "@/lib/reports/useReportQuery";
-import { dimensionHeader } from "@/lib/reports/series";
+import { dimensionHeader, formatMeasureValue } from "@/lib/reports/series";
 import type {
   CanvasFilters,
   SparklineWidget as SparklineWidgetType,
@@ -107,27 +107,13 @@ export default function SparklineWidget({
             data-testid="sparkline-widget-value"
             className="text-xl font-semibold text-text-primary"
           >
-            {formatValue(lastValue ?? 0, format)}
+            {formatMeasureValue(lastValue ?? 0, format)}
           </div>
           <div className="-mx-1 h-10">
-            <SparklineWidgetChart rows={rows} />
+            <SparklineWidgetChart rows={rows} format={format} />
           </div>
         </>
       )}
     </div>
   );
-}
-
-function formatValue(value: number, format: "currency" | "number" | "percent") {
-  if (format === "currency") {
-    return value.toLocaleString(undefined, {
-      style: "currency",
-      currency: "USD",
-      maximumFractionDigits: 0,
-    });
-  }
-  if (format === "percent") {
-    return `${value.toFixed(1)}%`;
-  }
-  return value.toLocaleString();
 }

--- a/frontend/components/reports/widgets/SparklineWidgetChart.tsx
+++ b/frontend/components/reports/widgets/SparklineWidgetChart.tsx
@@ -8,17 +8,25 @@
  */
 import { Line, LineChart, ResponsiveContainer, Tooltip } from "recharts";
 
+import { formatMeasureValue } from "@/lib/reports/series";
+
 export interface SparklineWidgetChartProps {
   rows: Array<{ label: string; value: number }>;
+  /** Display format for the measure value (tooltip only — sparkline has no axis). */
+  format: "currency" | "number" | "percent";
 }
 
 export default function SparklineWidgetChart({
   rows,
+  format,
 }: SparklineWidgetChartProps) {
   return (
     <ResponsiveContainer width="100%" height="100%">
       <LineChart data={rows} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
-        <Tooltip cursor={false} />
+        <Tooltip
+          cursor={false}
+          formatter={(v) => formatMeasureValue(Number(v), format)}
+        />
         <Line
           type="monotone"
           dataKey="value"

--- a/frontend/components/reports/widgets/StackedBarWidget.tsx
+++ b/frontend/components/reports/widgets/StackedBarWidget.tsx
@@ -57,6 +57,7 @@ export default function StackedBarWidget({
   );
 
   const dimensionKey = widget.config.dimensions[0] ?? "dimension";
+  const format = widget.config.format ?? "number";
   const seriesKeys = widget.config.measures.map((_, i) => `s${i}`);
   const rows = mergeSeriesRows(series, dimensionKey, seriesKeys);
   const labels = widget.config.measures.map((m, i) =>
@@ -120,6 +121,7 @@ export default function StackedBarWidget({
             seriesKeys={seriesKeys}
             labels={labels}
             stackId={stackId}
+            format={format}
           />
         )}
       </div>

--- a/frontend/components/reports/widgets/StackedBarWidgetChart.tsx
+++ b/frontend/components/reports/widgets/StackedBarWidgetChart.tsx
@@ -56,6 +56,7 @@ export default function StackedBarWidgetChart({
           interval={0}
         />
         <YAxis
+          width={80}
           tick={{ fill: chartColor.axisTick, fontSize: 11 }}
           tickFormatter={(v) => formatMeasureValue(Number(v), format)}
         />

--- a/frontend/components/reports/widgets/StackedBarWidgetChart.tsx
+++ b/frontend/components/reports/widgets/StackedBarWidgetChart.tsx
@@ -17,6 +17,7 @@ import {
 } from "recharts";
 
 import { chartColor } from "@/lib/chart-colors";
+import { formatMeasureValue } from "@/lib/reports/series";
 
 // Canonical categorical chart palette (theme tokens, mirrors the
 // dashboard). chart-5 (danger/red) sits last so neutral series don't
@@ -34,6 +35,8 @@ export interface StackedBarWidgetChartProps {
   seriesKeys: string[];
   labels: string[];
   stackId?: string;
+  /** Display format for the measure value (tooltip + value axis). */
+  format: "currency" | "number" | "percent";
 }
 
 export default function StackedBarWidgetChart({
@@ -41,6 +44,7 @@ export default function StackedBarWidgetChart({
   seriesKeys,
   labels,
   stackId,
+  format,
 }: StackedBarWidgetChartProps) {
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -51,8 +55,14 @@ export default function StackedBarWidgetChart({
           tick={{ fill: chartColor.axisTick, fontSize: 11 }}
           interval={0}
         />
-        <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
-        <Tooltip cursor={{ fill: "var(--color-border)", opacity: 0.3 }} />
+        <YAxis
+          tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+          tickFormatter={(v) => formatMeasureValue(Number(v), format)}
+        />
+        <Tooltip
+          cursor={{ fill: "var(--color-border)", opacity: 0.3 }}
+          formatter={(v) => formatMeasureValue(Number(v), format)}
+        />
         {seriesKeys.length > 1 && <Legend wrapperStyle={{ fontSize: 11 }} />}
         {seriesKeys.map((key, i) => (
           <Bar

--- a/frontend/components/reports/widgets/TableWidget.tsx
+++ b/frontend/components/reports/widgets/TableWidget.tsx
@@ -22,6 +22,7 @@ import { useMemo, useState } from "react";
 import { useSeriesQueries } from "@/lib/reports/useReportQuery";
 import {
   DIMENSION_HEADERS,
+  formatMeasureValue,
   mergeSeriesRowsForTable,
   seriesLabel,
 } from "@/lib/reports/series";
@@ -295,13 +296,5 @@ function formatCell(
   if (v === null || v === undefined) return "";
   const n = typeof v === "number" ? v : Number(v);
   if (!Number.isFinite(n)) return String(v);
-  if (format === "currency") {
-    return n.toLocaleString(undefined, {
-      style: "currency",
-      currency: "USD",
-      maximumFractionDigits: 2,
-    });
-  }
-  if (format === "percent") return `${n.toFixed(1)}%`;
-  return n.toLocaleString();
+  return formatMeasureValue(n, format);
 }

--- a/frontend/lib/reports/series.ts
+++ b/frontend/lib/reports/series.ts
@@ -5,6 +5,7 @@
  * series fires N parallel queries and stitches the rows here by the
  * shared dimension key.
  */
+import { formatAmount } from "@/lib/format";
 import type {
   Dimension,
   Measure,
@@ -61,6 +62,19 @@ export const MEASURE_FIELD_LABELS: Record<MeasureField, string> = {
 /** Display label for a measure field, falling back to the raw key. */
 export function measureFieldLabel(field: MeasureField): string {
   return MEASURE_FIELD_LABELS[field] ?? field;
+}
+
+/** Format a measure value for display in widget tooltips, axes and cells.
+ *  Grouped numbers, no currency symbol — matches the app's `formatAmount`
+ *  convention. Currency symbols are deferred to the future multi-currency
+ *  work (currency will be configured per account). */
+export function formatMeasureValue(
+  value: number,
+  format: "currency" | "number" | "percent",
+): string {
+  if (format === "percent") return `${value.toFixed(1)}%`;
+  if (format === "currency") return formatAmount(value); // grouped, 2dp, no symbol
+  return value.toLocaleString();
 }
 
 /**

--- a/frontend/lib/reports/series.ts
+++ b/frontend/lib/reports/series.ts
@@ -72,6 +72,10 @@ export function formatMeasureValue(
   value: number,
   format: "currency" | "number" | "percent",
 ): string {
+  // Recharts hands tick/tooltip values in as `any`; a degenerate
+  // undefined/NaN would otherwise surface as the literal "NaN". Mirror
+  // the Number.isFinite guard KPIWidget/TableWidget already apply.
+  if (!Number.isFinite(value)) return "";
   if (format === "percent") return `${value.toFixed(1)}%`;
   if (format === "currency") return formatAmount(value); // grouped, 2dp, no symbol
   return value.toLocaleString();

--- a/frontend/tests/components/reports/widgets/kpi-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/kpi-widget.test.tsx
@@ -41,10 +41,12 @@ describe("KPIWidget", () => {
     renderWithSWR(<KPIWidget widget={makeWidget()} />);
 
     const value = await screen.findByTestId("kpi-widget-value");
-    // Currency formatting renders the symbol; assert the digits are
-    // present so the test is locale-tolerant.
-    expect(value.textContent).toContain("1,234");
-    expect(value.textContent).toContain("56");
+    // Grouped, 2dp, NO currency symbol (symbols deferred to the future
+    // multi-currency work). Assert the grouped digits and the absence
+    // of any "$"/"USD".
+    expect(value.textContent).toContain("1,234.56");
+    expect(value.textContent).not.toContain("$");
+    expect(value.textContent).not.toContain("USD");
   });
 
   it("renders a delta vs the supplied prior-period value when compare_prior_period is on", async () => {

--- a/frontend/tests/components/reports/widgets/table-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/table-widget.test.tsx
@@ -147,8 +147,10 @@ describe("TableWidget", () => {
     const totalRow = await screen.findByTestId("table-widget-total-row");
     // Dimension cell reads "Total".
     expect(totalRow).toHaveTextContent("Total");
-    // 200 + 80 + 20 = 300, formatted as currency.
-    expect(totalRow).toHaveTextContent("$300.00");
+    // 200 + 80 + 20 = 300, grouped 2dp with NO currency symbol
+    // (symbols deferred to the future multi-currency work).
+    expect(totalRow).toHaveTextContent("300.00");
+    expect(totalRow.textContent).not.toContain("$");
   });
 
   it("sums ALL rows in the total even across multiple pages", async () => {

--- a/frontend/tests/lib/reports/format-measure-value.test.ts
+++ b/frontend/tests/lib/reports/format-measure-value.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+
+import { formatMeasureValue } from "@/lib/reports/series";
+import { formatAmount } from "@/lib/format";
+
+describe("formatMeasureValue", () => {
+  it("currency → grouped, 2 decimals, no currency symbol", () => {
+    const out = formatMeasureValue(1234.56, "currency");
+    // Matches the app's grouped-no-symbol money convention.
+    expect(out).toBe(formatAmount(1234.56));
+    expect(out).toBe("1,234.56");
+    // Currency symbols are deferred to the future multi-currency work.
+    expect(out).not.toContain("$");
+    expect(out).not.toContain("USD");
+  });
+
+  it("percent → one-decimal percentage", () => {
+    expect(formatMeasureValue(12.3, "percent")).toBe("12.3%");
+    expect(formatMeasureValue(12.34, "percent")).toBe("12.3%");
+  });
+
+  it("number → grouped integer, no decimals forced", () => {
+    expect(formatMeasureValue(1234, "number")).toBe("1,234");
+  });
+});

--- a/frontend/tests/lib/reports/format-measure-value.test.ts
+++ b/frontend/tests/lib/reports/format-measure-value.test.ts
@@ -5,21 +5,35 @@ import { formatAmount } from "@/lib/format";
 
 describe("formatMeasureValue", () => {
   it("currency → grouped, 2 decimals, no currency symbol", () => {
+    // Compare against formatAmount (the same fn the app uses) rather than a
+    // hardcoded "1,234.56" so the test is locale-independent.
     const out = formatMeasureValue(1234.56, "currency");
-    // Matches the app's grouped-no-symbol money convention.
     expect(out).toBe(formatAmount(1234.56));
-    expect(out).toBe("1,234.56");
     // Currency symbols are deferred to the future multi-currency work.
     expect(out).not.toContain("$");
     expect(out).not.toContain("USD");
   });
 
-  it("percent → one-decimal percentage", () => {
+  it("percent → one-decimal percentage (toFixed is locale-independent)", () => {
     expect(formatMeasureValue(12.3, "percent")).toBe("12.3%");
     expect(formatMeasureValue(12.34, "percent")).toBe("12.3%");
+    expect(formatMeasureValue(0, "percent")).toBe("0.0%");
   });
 
-  it("number → grouped integer, no decimals forced", () => {
-    expect(formatMeasureValue(1234, "number")).toBe("1,234");
+  it("number → grouped via toLocaleString", () => {
+    expect(formatMeasureValue(1234, "number")).toBe((1234).toLocaleString());
+    expect(formatMeasureValue(1234567, "number")).toBe((1234567).toLocaleString());
+  });
+
+  it("handles zero and negative values", () => {
+    expect(formatMeasureValue(0, "currency")).toBe(formatAmount(0));
+    expect(formatMeasureValue(-1234.5, "currency")).toBe(formatAmount(-1234.5));
+    expect(formatMeasureValue(-50, "number")).toBe((-50).toLocaleString());
+  });
+
+  it('returns "" for non-finite values (never a literal "NaN")', () => {
+    expect(formatMeasureValue(NaN, "currency")).toBe("");
+    expect(formatMeasureValue(Infinity, "number")).toBe("");
+    expect(formatMeasureValue(Number(undefined), "percent")).toBe("");
   });
 });


### PR DESCRIPTION
Report-builder widgets (Bar/Line/Area/StackedBar/Pie/Sparkline) rendered bare, ungrouped numbers in tooltips and on value axes. KPI and Table inconsistently hardcoded a "USD" symbol.

Unifies all report-widget value formatting to the app's grouped, no-symbol convention via a shared `formatMeasureValue(value, format)` (currency → grouped 2dp like `formatAmount`, percent → `N.N%`, number → grouped):
- Each chart widget now passes its `config.format` to its chart and formats the Tooltip value + value-axis ticks.
- KPI and Table drop the hardcoded `USD` symbol so money renders consistently everywhere.
- Table CSV export stays raw numbers (correct for spreadsheets).

Currency symbols + locale-aware formatting are intentionally deferred to the future i18n/l10n + multi-currency work (currency will be configured per account, with no cross-currency mixing).

Full suite green (1696), tsc + eslint clean.