### PR TITLE
refactor(reports): extract ConfigRail into reusable widget-editor pieces

### DIFF
--- a/frontend/components/reports/ConfigRail.tsx
+++ b/frontend/components/reports/ConfigRail.tsx
@@ -6,7 +6,14 @@
  * ``onUpdate`` so the report's full layout state stays the single
  * source of truth (debounced save handled at the editor level).
  *
- * PR3 expands this rail to support:
+ * The individual control blocks (Section, the measure editors, the
+ * FilterEditor, and the mutation closures) now live under
+ * ``components/reports/config`` so the anchored ``WidgetEditorPopover``
+ * can reuse the exact same pieces. This rail renders them unchanged so
+ * its external behaviour, markup, and every ``onUpdate`` payload stay
+ * identical to before the extraction.
+ *
+ * Widget-type rules preserved here:
  *
  *  - All 8 v1 widget types via the ``WidgetType`` union.
  *  - Multi-series widgets (line / area / stacked bar / table) expose
@@ -15,100 +22,37 @@
  *    series widgets cap at 5 too (visual register breaks past that).
  *  - Pie / Sparkline are locked to a single dimension + single
  *    aggregation (no add-series button).
- *  - Per-widget filter overrides go through the new filter
- *    primitives (CategoryPicker, TagFilter, AccountFilter,
- *    DatePresetChips); the "Overrides canvas" pill from PR2 still
- *    fires when the widget value DIFFERS from the canvas value on
- *    the same field.
+ *  - Per-widget filter overrides go through the filter primitives
+ *    (CategoryPicker, TagFilter, AccountFilter, DatePresetChips); the
+ *    "Overrides canvas" pill fires when the widget value DIFFERS from
+ *    the canvas value on the same field.
  */
-import { useId } from "react";
-
-import AccountFilter from "@/components/reports/filters/AccountFilter";
-import CategoryPicker from "@/components/reports/filters/CategoryPicker";
-import DatePresetChips from "@/components/reports/filters/DatePresetChips";
-import TagFilter from "@/components/reports/filters/TagFilter";
-import HelpTooltip from "@/components/help/HelpTooltip";
-import type { HelpTooltipKey } from "@/lib/help/tooltips";
+import Section from "@/components/reports/config/Section";
+import SingleMeasureEditor from "@/components/reports/config/SingleMeasureEditor";
+import MeasuresEditor from "@/components/reports/config/MeasuresEditor";
+import FilterEditor from "@/components/reports/config/FilterEditor";
+import { isMultiSeries } from "@/components/reports/config/controlConstants";
+import { useWidgetMutations } from "@/components/reports/config/useWidgetMutations";
+import { DIMENSION_OPTIONS } from "@/components/reports/config/controlConstants";
 import type {
-  AreaConfig,
-  Aggregation,
   BarConfig,
   CanvasFilters,
   Dimension,
   KPIConfig,
-  LineConfig,
-  Measure,
-  MeasureField,
   PieConfig,
-  SeriesConfig,
   SparklineConfig,
   StackedBarConfig,
+  AreaConfig,
   TableConfig,
-  TagMatch,
   Widget,
   WidgetFilters,
 } from "@/lib/reports/types";
-import { isFieldOverridden } from "@/lib/reports/resolve";
-import { MEASURE_FIELD_LABELS } from "@/lib/reports/series";
 
 interface Props {
   widget: Widget;
   canvasFilters: CanvasFilters;
   onUpdate: (next: Widget) => void;
   onClose: () => void;
-}
-
-const AGG_OPTIONS: Array<{ value: Aggregation; label: string }> = [
-  { value: "sum", label: "Sum" },
-  { value: "count", label: "Count" },
-  { value: "avg", label: "Average" },
-  { value: "distinct", label: "Distinct count" },
-];
-
-/** Tooltip key for each aggregation type (plain-language explainer). */
-const AGG_HELP_KEY: Record<Aggregation, HelpTooltipKey> = {
-  sum: "reports.agg.sum",
-  count: "reports.agg.count",
-  avg: "reports.agg.avg",
-  distinct: "reports.agg.distinct",
-};
-
-// Derived from the shared measure-field label map so the editor picker,
-// chart tooltips, and CSV headers can never drift apart.
-const FIELD_OPTIONS: Array<{ value: MeasureField; label: string }> = (
-  Object.keys(MEASURE_FIELD_LABELS) as MeasureField[]
-).map((value) => ({ value, label: MEASURE_FIELD_LABELS[value] }));
-
-const DIMENSION_OPTIONS: Array<{ value: Dimension; label: string }> = [
-  { value: "category", label: "Category" },
-  { value: "category_master", label: "Master category" },
-  { value: "account", label: "Account" },
-  { value: "tag", label: "Tag" },
-  { value: "txn_type", label: "Transaction type" },
-  { value: "status", label: "Status" },
-  { value: "month", label: "Month" },
-  { value: "week", label: "Week" },
-  { value: "day", label: "Day" },
-];
-
-const MAX_SERIES = 5;
-const MAX_TABLE_COLUMNS = 5;
-
-/** Widget types that carry ``config.measures`` (multi-series). */
-function isMultiSeries(
-  w: Widget,
-): w is Widget & { config: LineConfig | AreaConfig | StackedBarConfig | TableConfig } {
-  return (
-    w.type === "line" ||
-    w.type === "area" ||
-    w.type === "stacked_bar" ||
-    w.type === "table"
-  );
-}
-
-/** Widget types locked to a single dimension + single aggregation. */
-function isSingleAggLocked(w: Widget): boolean {
-  return w.type === "pie" || w.type === "sparkline";
 }
 
 export default function ConfigRail({
@@ -119,111 +63,17 @@ export default function ConfigRail({
 }: Props) {
   const filters: WidgetFilters = widget.config.filters ?? {};
 
-  function setTitle(title: string) {
-    onUpdate({ ...widget, title });
-  }
-
-  function setFilters(nextFilters: WidgetFilters) {
-    const next = {
-      ...widget,
-      config: { ...widget.config, filters: nextFilters },
-    } as Widget;
-    onUpdate(next);
-  }
-
-  function setSingleMeasure(measure: Measure) {
-    if (isMultiSeries(widget)) return;
-    const next = {
-      ...widget,
-      config: {
-        ...(widget.config as KPIConfig | BarConfig | PieConfig | SparklineConfig),
-        measure,
-      },
-    } as Widget;
-    onUpdate(next);
-  }
-
-  function setSeries(measures: SeriesConfig[]) {
-    if (!isMultiSeries(widget)) return;
-    const next: Widget = {
-      ...widget,
-      config: { ...widget.config, measures },
-    } as Widget;
-    onUpdate(next);
-  }
-
-  function setPrimaryDimension(dim: Dimension) {
-    if (widget.type === "kpi") return; // KPI has no dimensions
-    const cfg = widget.config as
-      | BarConfig
-      | LineConfig
-      | AreaConfig
-      | PieConfig
-      | SparklineConfig
-      | StackedBarConfig
-      | TableConfig;
-    const dims = [...(cfg.dimensions ?? [])];
-    dims[0] = dim;
-    const next: Widget = {
-      ...widget,
-      config: { ...cfg, dimensions: dims },
-    } as Widget;
-    onUpdate(next);
-  }
-
-  function setSecondaryDimension(dim: Dimension | "") {
-    if (widget.type === "kpi" || isSingleAggLocked(widget)) return;
-    const cfg = widget.config as
-      | BarConfig
-      | LineConfig
-      | AreaConfig
-      | StackedBarConfig
-      | TableConfig;
-    const dims = [...(cfg.dimensions ?? [])];
-    if (dim === "") {
-      dims.splice(1, 1);
-    } else {
-      dims[1] = dim;
-    }
-    const next: Widget = {
-      ...widget,
-      config: { ...cfg, dimensions: dims },
-    } as Widget;
-    onUpdate(next);
-  }
-
-  function setComparePrior(value: boolean) {
-    if (widget.type !== "kpi") return;
-    const next: Widget = {
-      ...widget,
-      config: {
-        ...(widget.config as KPIConfig),
-        compare_prior_period: value,
-      },
-    };
-    onUpdate(next);
-  }
-
-  function setTopN(value: number) {
-    if (widget.type !== "pie") return;
-    const next: Widget = {
-      ...widget,
-      config: { ...(widget.config as PieConfig), top_n: value },
-    };
-    onUpdate(next);
-  }
-
-  function setStacked(value: boolean) {
-    if (widget.type !== "area" && widget.type !== "stacked_bar") return;
-    const next: Widget = {
-      ...widget,
-      config: {
-        ...(widget.config as AreaConfig | StackedBarConfig),
-        stacked: value,
-      },
-    } as Widget;
-    onUpdate(next);
-  }
+  const {
+    setTitle,
+    setFilters,
+    setSingleMeasure,
+    setSeries,
+    setPrimaryDimension,
+    setSecondaryDimension,
+    setComparePrior,
+    setTopN,
+    setStacked,
+  } = useWidgetMutations(widget, onUpdate);
 
   return (
     <aside
@@ -393,374 +243,5 @@ export default function ConfigRail({
         onChange={setFilters}
       />
     </aside>
-  );
-}
-
-function Section({
-  label,
-  help,
-  children,
-}: {
-  label: string;
-  /** Optional help-tooltip key rendered as an info icon next to the label. */
-  help?: HelpTooltipKey;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex flex-col gap-1">
-      <div className="flex items-center gap-1 text-[11px] font-medium uppercase tracking-wider text-text-muted">
-        <span>{label}</span>
-        {help && <HelpTooltip k={help} />}
-      </div>
-      {children}
-    </div>
-  );
-}
-
-function OverridePill() {
-  return (
-    <span
-      data-testid="override-pill"
-      className="ml-2 inline-flex items-center rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-medium text-accent"
-    >
-      Overrides canvas
-    </span>
-  );
-}
-
-function SingleMeasureEditor({
-  measure,
-  onChange,
-}: {
-  measure: Measure;
-  onChange: (m: Measure) => void;
-}) {
-  return (
-    <>
-      <Section label="Aggregation" help={AGG_HELP_KEY[measure.agg]}>
-        <select
-          value={measure.agg}
-          onChange={(e) =>
-            onChange({ ...measure, agg: e.target.value as Aggregation })
-          }
-          aria-label="Aggregation"
-          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
-        >
-          {AGG_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      </Section>
-      <Section label="Field">
-        <select
-          value={measure.field}
-          onChange={(e) =>
-            onChange({ ...measure, field: e.target.value as MeasureField })
-          }
-          aria-label="Field"
-          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
-        >
-          {FIELD_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      </Section>
-    </>
-  );
-}
-
-function MeasuresEditor({
-  widget,
-  onChange,
-}: {
-  widget: Widget & { config: LineConfig | AreaConfig | StackedBarConfig | TableConfig };
-  onChange: (m: SeriesConfig[]) => void;
-}) {
-  const measures = widget.config.measures;
-  const cap = widget.type === "table" ? MAX_TABLE_COLUMNS : MAX_SERIES;
-
-  function update(idx: number, next: SeriesConfig) {
-    const copy = [...measures];
-    copy[idx] = next;
-    onChange(copy);
-  }
-
-  function add() {
-    if (measures.length >= cap) return;
-    onChange([
-      ...measures,
-      { measure: { agg: "sum", field: "amount" } },
-    ]);
-  }
-
-  function remove(idx: number) {
-    if (measures.length <= 1) return;
-    onChange(measures.filter((_, i) => i !== idx));
-  }
-
-  return (
-    <div className="flex flex-col gap-2">
-      <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
-        {widget.type === "table" ? "Columns" : "Series"}
-      </div>
-      {measures.map((s, idx) => (
-        <div
-          key={idx}
-          data-testid={`measure-row-${idx}`}
-          className="flex flex-col gap-1 rounded-md border border-border bg-bg p-2"
-        >
-          <div className="flex items-center justify-between">
-            <span className="text-xs text-text-muted">
-              {widget.type === "table" ? `Column ${idx + 1}` : `Series ${idx + 1}`}
-            </span>
-            {measures.length > 1 && (
-              <button
-                type="button"
-                data-testid={`measure-remove-${idx}`}
-                onClick={() => remove(idx)}
-                className="text-xs text-text-muted hover:text-danger"
-                aria-label={`Remove ${widget.type === "table" ? "column" : "series"} ${idx + 1}`}
-              >
-                Remove
-              </button>
-            )}
-          </div>
-          <input
-            type="text"
-            value={s.label ?? ""}
-            onChange={(e) =>
-              update(idx, { ...s, label: e.target.value || undefined })
-            }
-            placeholder={
-              widget.type === "table" ? "Column label" : "Series label"
-            }
-            aria-label={`Series ${idx + 1} label`}
-            className="rounded-md border border-border bg-bg px-2 py-1 text-xs text-text-primary"
-          />
-          <div className="flex items-center gap-1">
-            <select
-              value={s.measure.agg}
-              onChange={(e) =>
-                update(idx, {
-                  ...s,
-                  measure: { ...s.measure, agg: e.target.value as Aggregation },
-                })
-              }
-              aria-label={`Series ${idx + 1} aggregation`}
-              className="flex-1 rounded-md border border-border bg-bg px-2 py-1 text-xs text-text-primary"
-            >
-              {AGG_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-            <HelpTooltip k={AGG_HELP_KEY[s.measure.agg]} />
-            <select
-              value={s.measure.field}
-              onChange={(e) =>
-                update(idx, {
-                  ...s,
-                  measure: {
-                    ...s.measure,
-                    field: e.target.value as MeasureField,
-                  },
-                })
-              }
-              aria-label={`Series ${idx + 1} field`}
-              className="flex-1 rounded-md border border-border bg-bg px-2 py-1 text-xs text-text-primary"
-            >
-              {FIELD_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-      ))}
-      {measures.length < cap && (
-        <button
-          type="button"
-          data-testid="measure-add"
-          onClick={add}
-          className="rounded-md border border-dashed border-border px-2 py-1 text-xs text-text-secondary transition hover:border-accent hover:text-accent"
-        >
-          + Add {widget.type === "table" ? "column" : "series"}
-        </button>
-      )}
-    </div>
-  );
-}
-
-function FilterEditor({
-  filters,
-  canvasFilters,
-  onChange,
-}: {
-  filters: WidgetFilters;
-  canvasFilters: CanvasFilters;
-  onChange: (next: WidgetFilters) => void;
-}) {
-  return (
-    <div className="flex flex-col gap-4 rounded-md border border-border bg-bg p-3">
-      <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
-        Filters (this widget)
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <div className="flex items-center text-xs text-text-secondary">
-          Date range
-          {isFieldOverridden("date_range", filters, canvasFilters) && (
-            <OverridePill />
-          )}
-        </div>
-        <DatePresetChips
-          value={filters.date_range}
-          ariaPrefix="Widget"
-          onChange={(next) =>
-            onChange({
-              ...filters,
-              date_range: next || undefined,
-            })
-          }
-        />
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <div className="flex items-center text-xs text-text-secondary">
-          Accounts
-          {isFieldOverridden("account_ids", filters, canvasFilters) && (
-            <OverridePill />
-          )}
-        </div>
-        <AccountFilter
-          value={filters.account_ids ?? []}
-          ariaPrefix="Widget account"
-          label=""
-          onChange={(account_ids) =>
-            onChange({
-              ...filters,
-              account_ids: account_ids.length > 0 ? account_ids : undefined,
-            })
-          }
-        />
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <div className="flex items-center text-xs text-text-secondary">
-          Categories
-          {isFieldOverridden("category_ids", filters, canvasFilters) && (
-            <OverridePill />
-          )}
-        </div>
-        <CategoryPicker
-          value={filters.category_ids ?? []}
-          label=""
-          onChange={(category_ids) =>
-            onChange({
-              ...filters,
-              category_ids: category_ids.length > 0 ? category_ids : undefined,
-            })
-          }
-        />
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <TxnTypeRadioRow
-          value={filters.txn_type}
-          onChange={(txn_type) => onChange({ ...filters, txn_type })}
-        />
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <div className="text-xs text-text-secondary">Amount range</div>
-        <div className="flex gap-2">
-          <input
-            type="number"
-            aria-label="Widget amount min"
-            placeholder="min"
-            value={filters.amount_range?.min ?? ""}
-            onChange={(e) =>
-              onChange({
-                ...filters,
-                amount_range: {
-                  ...(filters.amount_range ?? {}),
-                  min: e.target.value === "" ? undefined : Number(e.target.value),
-                },
-              })
-            }
-            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
-          />
-          <input
-            type="number"
-            aria-label="Widget amount max"
-            placeholder="max"
-            value={filters.amount_range?.max ?? ""}
-            onChange={(e) =>
-              onChange({
-                ...filters,
-                amount_range: {
-                  ...(filters.amount_range ?? {}),
-                  max: e.target.value === "" ? undefined : Number(e.target.value),
-                },
-              })
-            }
-            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
-          />
-        </div>
-      </div>
-
-      <TagFilter
-        value={filters.tag_names ?? []}
-        match={(filters.tag_match ?? "all") as TagMatch}
-        onChange={({ tag_names, tag_match }) =>
-          onChange({
-            ...filters,
-            tag_names: tag_names.length > 0 ? tag_names : undefined,
-            tag_match: tag_names.length > 0 ? tag_match : undefined,
-          })
-        }
-      />
-    </div>
-  );
-}
-
-function TxnTypeRadioRow({
-  value,
-  onChange,
-}: {
-  value: "income" | "expense" | "transfer" | undefined;
-  onChange: (next: "income" | "expense" | "transfer" | undefined) => void;
-}) {
-  const name = useId();
-  const choices: Array<{ value: "" | "income" | "expense" | "transfer"; label: string }> = [
-    { value: "", label: "Any" },
-    { value: "income", label: "Income" },
-    { value: "expense", label: "Expense" },
-    { value: "transfer", label: "Transfer" },
-  ];
-  return (
-    <>
-      <div className="text-xs text-text-secondary">Transaction type</div>
-      <div className="flex flex-wrap gap-3 text-xs text-text-secondary">
-        {choices.map((c) => (
-          <label key={c.value} className="flex items-center gap-1">
-            <input
-              type="radio"
-              name={name}
-              aria-label={`Widget transaction type ${c.label}`}
-              checked={(value ?? "") === c.value}
-              onChange={() => onChange(c.value === "" ? undefined : (c.value as "income" | "expense" | "transfer"))}
-            />
-            <span>{c.label}</span>
-          </label>
-        ))}
-      </div>
-    </>
   );
 }

--- a/frontend/components/reports/ConfigRail.tsx
+++ b/frontend/components/reports/ConfigRail.tsx
@@ -31,9 +31,8 @@ import Section from "@/components/reports/config/Section";
 import SingleMeasureEditor from "@/components/reports/config/SingleMeasureEditor";
 import MeasuresEditor from "@/components/reports/config/MeasuresEditor";
 import FilterEditor from "@/components/reports/config/FilterEditor";
-import { isMultiSeries } from "@/components/reports/config/controlConstants";
-import { useWidgetMutations } from "@/components/reports/config/useWidgetMutations";
-import { DIMENSION_OPTIONS } from "@/components/reports/config/controlConstants";
+import { isMultiSeries, DIMENSION_OPTIONS } from "@/components/reports/config/controlConstants";
+import { buildWidgetMutations } from "@/components/reports/config/useWidgetMutations";
 import type {
   BarConfig,
   CanvasFilters,
@@ -73,7 +72,7 @@ export default function ConfigRail({
     setComparePrior,
     setTopN,
     setStacked,
-  } = useWidgetMutations(widget, onUpdate);
+  } = buildWidgetMutations(widget, onUpdate);
 
   return (
     <aside

--- a/frontend/components/reports/WidgetEditorPopover.tsx
+++ b/frontend/components/reports/WidgetEditorPopover.tsx
@@ -9,7 +9,7 @@
  * (``FloatingFocusManager``), the role/aria contract (``useRole``), tab
  * state, and which tabs/sub-controls a widget type shows. Every *mutation*
  * is delegated to the extracted control components (``DataTab`` /
- * ``StyleTab`` / ``FilterEditor`` via ``useWidgetMutations``).
+ * ``StyleTab`` / ``FilterEditor`` via ``buildWidgetMutations``).
  */
 import { useEffect, useId, useState } from "react";
 import {
@@ -28,7 +28,7 @@ import {
 import DataTab from "@/components/reports/config/DataTab";
 import StyleTab from "@/components/reports/config/StyleTab";
 import FilterEditor from "@/components/reports/config/FilterEditor";
-import { useWidgetMutations } from "@/components/reports/config/useWidgetMutations";
+import { buildWidgetMutations } from "@/components/reports/config/useWidgetMutations";
 import type { CanvasFilters, Widget } from "@/lib/reports/types";
 
 interface Props {
@@ -72,6 +72,12 @@ export default function WidgetEditorPopover({
     if (anchorEl && !anchorEl.isConnected) onClose();
   }, [anchorEl, onClose]);
 
+  // Reset to the default tab when the selected widget identity changes,
+  // so opening a different widget never lands on a stale tab.
+  useEffect(() => {
+    setTab("data");
+  }, [widget.id]);
+
   const dismiss = useDismiss(context, {
     outsidePress: true,
     escapeKey: true,
@@ -79,7 +85,7 @@ export default function WidgetEditorPopover({
   const role = useRole(context, { role: "dialog" });
   const { getFloatingProps } = useInteractions([dismiss, role]);
 
-  const { setFilters } = useWidgetMutations(widget, onUpdate);
+  const { setFilters } = buildWidgetMutations(widget, onUpdate);
 
   if (!anchorEl) return null;
 
@@ -93,15 +99,15 @@ export default function WidgetEditorPopover({
     <FloatingPortal>
       <FloatingFocusManager context={context} modal={false} initialFocus={-1}>
         <div
-          // refs.setFloating is floating-ui's ref-setter callback (its
-          // documented API), not a `.current` read; the React 19
-          // react-hooks/refs rule can't distinguish the two and misfires.
+          // react-hooks/refs flags reading `refs.setFloating` in render,
+          // but floating-ui's `setFloating` is a documented ref-SETTER
+          // callback meant to be passed straight to `ref=` (not a
+          // `.current` read), so the rule is a false positive here.
           // eslint-disable-next-line react-hooks/refs
           ref={refs.setFloating}
           style={floatingStyles}
           {...getFloatingProps()}
           data-testid="widget-editor-popover"
-          role="dialog"
           aria-label="Widget settings"
           className="z-50 flex max-h-[80vh] w-80 flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-lg"
         >
@@ -119,7 +125,7 @@ export default function WidgetEditorPopover({
           </div>
 
           <div role="tablist" aria-label="Widget settings tabs" className="flex border-b border-border">
-            {tabs.map((t) => {
+            {tabs.map((t, i) => {
               const active = tab === t.key;
               return (
                 <button
@@ -129,7 +135,19 @@ export default function WidgetEditorPopover({
                   id={`${baseId}-tab-${t.key}`}
                   aria-selected={active}
                   aria-controls={`${baseId}-panel-${t.key}`}
+                  tabIndex={active ? 0 : -1}
                   onClick={() => setTab(t.key)}
+                  onKeyDown={(e) => {
+                    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+                    e.preventDefault();
+                    const delta = e.key === "ArrowRight" ? 1 : -1;
+                    const nextIndex = (i + delta + tabs.length) % tabs.length;
+                    const next = tabs[nextIndex];
+                    setTab(next.key);
+                    document
+                      .getElementById(`${baseId}-tab-${next.key}`)
+                      ?.focus();
+                  }}
                   className={
                     active
                       ? "flex-1 border-b-2 border-accent px-3 py-2 text-xs font-medium text-text-primary"

--- a/frontend/components/reports/WidgetEditorPopover.tsx
+++ b/frontend/components/reports/WidgetEditorPopover.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+/**
+ * Anchored floating widget-editor popover. Floats over the canvas,
+ * anchored to the selected widget's shell DOM node (``anchorEl``), so it
+ * never consumes flex width and the canvas does not reflow when a widget
+ * is selected. It owns positioning (``useFloating`` + ``autoUpdate``),
+ * dismissal (``useDismiss`` outside-press + Escape), focus management
+ * (``FloatingFocusManager``), the role/aria contract (``useRole``), tab
+ * state, and which tabs/sub-controls a widget type shows. Every *mutation*
+ * is delegated to the extracted control components (``DataTab`` /
+ * ``StyleTab`` / ``FilterEditor`` via ``useWidgetMutations``).
+ */
+import { useEffect, useId, useState } from "react";
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  flip,
+  shift,
+  useDismiss,
+  useRole,
+  useInteractions,
+  FloatingPortal,
+  FloatingFocusManager,
+} from "@floating-ui/react";
+
+import DataTab from "@/components/reports/config/DataTab";
+import StyleTab from "@/components/reports/config/StyleTab";
+import FilterEditor from "@/components/reports/config/FilterEditor";
+import { useWidgetMutations } from "@/components/reports/config/useWidgetMutations";
+import type { CanvasFilters, Widget } from "@/lib/reports/types";
+
+interface Props {
+  widget: Widget;
+  canvasFilters: CanvasFilters;
+  anchorEl: HTMLElement | null;
+  onUpdate: (next: Widget) => void;
+  onClose: () => void;
+}
+
+type TabKey = "data" | "filters" | "style";
+
+export default function WidgetEditorPopover({
+  widget,
+  canvasFilters,
+  anchorEl,
+  onUpdate,
+  onClose,
+}: Props) {
+  const [tab, setTab] = useState<TabKey>("data");
+  const baseId = useId();
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: true,
+    onOpenChange: (next) => {
+      if (!next) onClose();
+    },
+    placement: "right-start",
+    middleware: [offset(8), flip({ padding: 8 }), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+  });
+
+  // Anchor to the selected widget element (external reference element).
+  useEffect(() => {
+    refs.setReference(anchorEl);
+  }, [anchorEl, refs]);
+
+  // querySelector anchor staleness guard: if the resolved node detaches
+  // (widget removed / canvas re-rendered the shell), close (deselect).
+  useEffect(() => {
+    if (anchorEl && !anchorEl.isConnected) onClose();
+  }, [anchorEl, onClose]);
+
+  const dismiss = useDismiss(context, {
+    outsidePress: true,
+    escapeKey: true,
+  });
+  const role = useRole(context, { role: "dialog" });
+  const { getFloatingProps } = useInteractions([dismiss, role]);
+
+  const { setFilters } = useWidgetMutations(widget, onUpdate);
+
+  if (!anchorEl) return null;
+
+  const tabs: Array<{ key: TabKey; label: string }> = [
+    { key: "data", label: "Data" },
+    { key: "filters", label: "Filters" },
+    { key: "style", label: "Style" },
+  ];
+
+  return (
+    <FloatingPortal>
+      <FloatingFocusManager context={context} modal={false} initialFocus={-1}>
+        <div
+          // refs.setFloating is floating-ui's ref-setter callback (its
+          // documented API), not a `.current` read; the React 19
+          // react-hooks/refs rule can't distinguish the two and misfires.
+          // eslint-disable-next-line react-hooks/refs
+          ref={refs.setFloating}
+          style={floatingStyles}
+          {...getFloatingProps()}
+          data-testid="widget-editor-popover"
+          role="dialog"
+          aria-label="Widget settings"
+          className="z-50 flex max-h-[80vh] w-80 flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-lg"
+        >
+          <div className="flex items-center justify-between border-b border-border p-4">
+            <h2 className="text-sm font-semibold text-text-primary">
+              Widget settings
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-xs text-text-muted hover:text-text-primary"
+            >
+              Close
+            </button>
+          </div>
+
+          <div role="tablist" aria-label="Widget settings tabs" className="flex border-b border-border">
+            {tabs.map((t) => {
+              const active = tab === t.key;
+              return (
+                <button
+                  key={t.key}
+                  type="button"
+                  role="tab"
+                  id={`${baseId}-tab-${t.key}`}
+                  aria-selected={active}
+                  aria-controls={`${baseId}-panel-${t.key}`}
+                  onClick={() => setTab(t.key)}
+                  className={
+                    active
+                      ? "flex-1 border-b-2 border-accent px-3 py-2 text-xs font-medium text-text-primary"
+                      : "flex-1 border-b-2 border-transparent px-3 py-2 text-xs font-medium text-text-muted hover:text-text-primary"
+                  }
+                >
+                  {t.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="flex flex-col gap-4 overflow-y-auto p-4">
+            <div
+              role="tabpanel"
+              id={`${baseId}-panel-data`}
+              aria-labelledby={`${baseId}-tab-data`}
+              hidden={tab !== "data"}
+              className="flex flex-col gap-4"
+            >
+              {tab === "data" && <DataTab widget={widget} onUpdate={onUpdate} />}
+            </div>
+            <div
+              role="tabpanel"
+              id={`${baseId}-panel-filters`}
+              aria-labelledby={`${baseId}-tab-filters`}
+              hidden={tab !== "filters"}
+              className="flex flex-col gap-4"
+            >
+              {tab === "filters" && (
+                <FilterEditor
+                  filters={widget.config.filters ?? {}}
+                  canvasFilters={canvasFilters}
+                  onChange={setFilters}
+                />
+              )}
+            </div>
+            <div
+              role="tabpanel"
+              id={`${baseId}-panel-style`}
+              aria-labelledby={`${baseId}-tab-style`}
+              hidden={tab !== "style"}
+              className="flex flex-col gap-4"
+            >
+              {tab === "style" && <StyleTab widget={widget} onUpdate={onUpdate} />}
+            </div>
+          </div>
+        </div>
+      </FloatingFocusManager>
+    </FloatingPortal>
+  );
+}

--- a/frontend/components/reports/config/DataTab.tsx
+++ b/frontend/components/reports/config/DataTab.tsx
@@ -5,7 +5,7 @@
  * primary/secondary dimension selects. Per-type sub-control visibility
  * lives here (it branches on ``widget.type``). All control logic is
  * extracted verbatim from ``ConfigRail``; mutations come from
- * ``useWidgetMutations``.
+ * ``buildWidgetMutations``.
  */
 import Section from "@/components/reports/config/Section";
 import SingleMeasureEditor from "@/components/reports/config/SingleMeasureEditor";
@@ -14,7 +14,7 @@ import {
   DIMENSION_OPTIONS,
   isMultiSeries,
 } from "@/components/reports/config/controlConstants";
-import { useWidgetMutations } from "@/components/reports/config/useWidgetMutations";
+import { buildWidgetMutations } from "@/components/reports/config/useWidgetMutations";
 import type {
   BarConfig,
   Dimension,
@@ -37,7 +37,7 @@ export default function DataTab({
     setSeries,
     setPrimaryDimension,
     setSecondaryDimension,
-  } = useWidgetMutations(widget, onUpdate);
+  } = buildWidgetMutations(widget, onUpdate);
 
   return (
     <>

--- a/frontend/components/reports/config/DataTab.tsx
+++ b/frontend/components/reports/config/DataTab.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+/**
+ * Data tab of the widget editor: data source, measure(s), and the
+ * primary/secondary dimension selects. Per-type sub-control visibility
+ * lives here (it branches on ``widget.type``). All control logic is
+ * extracted verbatim from ``ConfigRail``; mutations come from
+ * ``useWidgetMutations``.
+ */
+import Section from "@/components/reports/config/Section";
+import SingleMeasureEditor from "@/components/reports/config/SingleMeasureEditor";
+import MeasuresEditor from "@/components/reports/config/MeasuresEditor";
+import {
+  DIMENSION_OPTIONS,
+  isMultiSeries,
+} from "@/components/reports/config/controlConstants";
+import { useWidgetMutations } from "@/components/reports/config/useWidgetMutations";
+import type {
+  BarConfig,
+  Dimension,
+  KPIConfig,
+  PieConfig,
+  SparklineConfig,
+  TableConfig,
+  Widget,
+} from "@/lib/reports/types";
+
+export default function DataTab({
+  widget,
+  onUpdate,
+}: {
+  widget: Widget;
+  onUpdate: (next: Widget) => void;
+}) {
+  const {
+    setSingleMeasure,
+    setSeries,
+    setPrimaryDimension,
+    setSecondaryDimension,
+  } = useWidgetMutations(widget, onUpdate);
+
+  return (
+    <>
+      <Section label="Data source">
+        <select
+          disabled
+          value={widget.config.dataset}
+          aria-label="Data source"
+          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-muted"
+        >
+          <option value="transactions">Transactions</option>
+        </select>
+      </Section>
+
+      {/* Aggregation / measures section. Single-measure widgets show
+          one row; multi-series widgets show one row per series with
+          an "Add series" button at the bottom. */}
+      {isMultiSeries(widget) ? (
+        <MeasuresEditor
+          widget={widget}
+          onChange={setSeries}
+        />
+      ) : (
+        <SingleMeasureEditor
+          measure={
+            (widget.config as KPIConfig | BarConfig | PieConfig | SparklineConfig)
+              .measure
+          }
+          onChange={setSingleMeasure}
+        />
+      )}
+
+      {widget.type !== "kpi" && (
+        <Section label="Primary dimension" help="reports.master-category">
+          <select
+            value={
+              ((widget.config as BarConfig).dimensions ?? [])[0] ?? "category"
+            }
+            onChange={(e) => setPrimaryDimension(e.target.value as Dimension)}
+            aria-label="Primary dimension"
+            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+          >
+            {DIMENSION_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </Section>
+      )}
+
+      {/* Secondary dimension picker. For a bar widget this "Break down
+          by" slices each total bar into stacked segments (one color per
+          secondary value, e.g. per account) with a legend. For a table
+          it adds a second grouping column. Both consume
+          ``dimensions[1]`` and the backend AST already supports two
+          dimensions, so no query-layer change is needed. */}
+      {(widget.type === "bar" || widget.type === "table") && (
+        <Section
+          label={
+            widget.type === "bar"
+              ? "Break down by (optional)"
+              : "Secondary dimension (optional)"
+          }
+          help="reports.master-category"
+        >
+          <select
+            value={
+              ((widget.config as BarConfig | TableConfig).dimensions ?? [])[1] ??
+              ""
+            }
+            onChange={(e) =>
+              setSecondaryDimension((e.target.value || "") as Dimension | "")
+            }
+            aria-label={
+              widget.type === "bar" ? "Break down by" : "Secondary dimension"
+            }
+            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+          >
+            <option value="">None</option>
+            {DIMENSION_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </Section>
+      )}
+    </>
+  );
+}

--- a/frontend/components/reports/config/FilterEditor.tsx
+++ b/frontend/components/reports/config/FilterEditor.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+/**
+ * Per-widget filter override editor (date / accounts / categories /
+ * txn_type / amount_range / tags) plus the "Overrides canvas" pill.
+ * Extracted verbatim from ``ConfigRail``. The pill fires when a widget
+ * field DIFFERS from the canvas value on the same field, via
+ * ``isFieldOverridden`` from ``lib/reports/resolve`` (not reimplemented).
+ */
+import { useId } from "react";
+
+import AccountFilter from "@/components/reports/filters/AccountFilter";
+import CategoryPicker from "@/components/reports/filters/CategoryPicker";
+import DatePresetChips from "@/components/reports/filters/DatePresetChips";
+import TagFilter from "@/components/reports/filters/TagFilter";
+import { isFieldOverridden } from "@/lib/reports/resolve";
+import type {
+  CanvasFilters,
+  TagMatch,
+  WidgetFilters,
+} from "@/lib/reports/types";
+
+function OverridePill() {
+  return (
+    <span
+      data-testid="override-pill"
+      className="ml-2 inline-flex items-center rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-medium text-accent"
+    >
+      Overrides canvas
+    </span>
+  );
+}
+
+export default function FilterEditor({
+  filters,
+  canvasFilters,
+  onChange,
+}: {
+  filters: WidgetFilters;
+  canvasFilters: CanvasFilters;
+  onChange: (next: WidgetFilters) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4 rounded-md border border-border bg-bg p-3">
+      <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
+        Filters (this widget)
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center text-xs text-text-secondary">
+          Date range
+          {isFieldOverridden("date_range", filters, canvasFilters) && (
+            <OverridePill />
+          )}
+        </div>
+        <DatePresetChips
+          value={filters.date_range}
+          ariaPrefix="Widget"
+          onChange={(next) =>
+            onChange({
+              ...filters,
+              date_range: next || undefined,
+            })
+          }
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center text-xs text-text-secondary">
+          Accounts
+          {isFieldOverridden("account_ids", filters, canvasFilters) && (
+            <OverridePill />
+          )}
+        </div>
+        <AccountFilter
+          value={filters.account_ids ?? []}
+          ariaPrefix="Widget account"
+          label=""
+          onChange={(account_ids) =>
+            onChange({
+              ...filters,
+              account_ids: account_ids.length > 0 ? account_ids : undefined,
+            })
+          }
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center text-xs text-text-secondary">
+          Categories
+          {isFieldOverridden("category_ids", filters, canvasFilters) && (
+            <OverridePill />
+          )}
+        </div>
+        <CategoryPicker
+          value={filters.category_ids ?? []}
+          label=""
+          onChange={(category_ids) =>
+            onChange({
+              ...filters,
+              category_ids: category_ids.length > 0 ? category_ids : undefined,
+            })
+          }
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <TxnTypeRadioRow
+          value={filters.txn_type}
+          onChange={(txn_type) => onChange({ ...filters, txn_type })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="text-xs text-text-secondary">Amount range</div>
+        <div className="flex gap-2">
+          <input
+            type="number"
+            aria-label="Widget amount min"
+            placeholder="min"
+            value={filters.amount_range?.min ?? ""}
+            onChange={(e) =>
+              onChange({
+                ...filters,
+                amount_range: {
+                  ...(filters.amount_range ?? {}),
+                  min: e.target.value === "" ? undefined : Number(e.target.value),
+                },
+              })
+            }
+            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+          />
+          <input
+            type="number"
+            aria-label="Widget amount max"
+            placeholder="max"
+            value={filters.amount_range?.max ?? ""}
+            onChange={(e) =>
+              onChange({
+                ...filters,
+                amount_range: {
+                  ...(filters.amount_range ?? {}),
+                  max: e.target.value === "" ? undefined : Number(e.target.value),
+                },
+              })
+            }
+            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+          />
+        </div>
+      </div>
+
+      <TagFilter
+        value={filters.tag_names ?? []}
+        match={(filters.tag_match ?? "all") as TagMatch}
+        onChange={({ tag_names, tag_match }) =>
+          onChange({
+            ...filters,
+            tag_names: tag_names.length > 0 ? tag_names : undefined,
+            tag_match: tag_names.length > 0 ? tag_match : undefined,
+          })
+        }
+      />
+    </div>
+  );
+}
+
+function TxnTypeRadioRow({
+  value,
+  onChange,
+}: {
+  value: "income" | "expense" | "transfer" | undefined;
+  onChange: (next: "income" | "expense" | "transfer" | undefined) => void;
+}) {
+  const name = useId();
+  const choices: Array<{ value: "" | "income" | "expense" | "transfer"; label: string }> = [
+    { value: "", label: "Any" },
+    { value: "income", label: "Income" },
+    { value: "expense", label: "Expense" },
+    { value: "transfer", label: "Transfer" },
+  ];
+  return (
+    <>
+      <div className="text-xs text-text-secondary">Transaction type</div>
+      <div className="flex flex-wrap gap-3 text-xs text-text-secondary">
+        {choices.map((c) => (
+          <label key={c.value} className="flex items-center gap-1">
+            <input
+              type="radio"
+              name={name}
+              aria-label={`Widget transaction type ${c.label}`}
+              checked={(value ?? "") === c.value}
+              onChange={() => onChange(c.value === "" ? undefined : (c.value as "income" | "expense" | "transfer"))}
+            />
+            <span>{c.label}</span>
+          </label>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/frontend/components/reports/config/MeasuresEditor.tsx
+++ b/frontend/components/reports/config/MeasuresEditor.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+/**
+ * Multi-series measure editor (one row per ``config.measures`` entry, with
+ * add/remove and a per-type cap) for line / area / stacked_bar / table.
+ * Extracted verbatim from ``ConfigRail``.
+ */
+import HelpTooltip from "@/components/help/HelpTooltip";
+import {
+  AGG_HELP_KEY,
+  AGG_OPTIONS,
+  FIELD_OPTIONS,
+  MAX_SERIES,
+  MAX_TABLE_COLUMNS,
+} from "@/components/reports/config/controlConstants";
+import type {
+  Aggregation,
+  AreaConfig,
+  LineConfig,
+  MeasureField,
+  SeriesConfig,
+  StackedBarConfig,
+  TableConfig,
+  Widget,
+} from "@/lib/reports/types";
+
+export default function MeasuresEditor({
+  widget,
+  onChange,
+}: {
+  widget: Widget & { config: LineConfig | AreaConfig | StackedBarConfig | TableConfig };
+  onChange: (m: SeriesConfig[]) => void;
+}) {
+  const measures = widget.config.measures;
+  const cap = widget.type === "table" ? MAX_TABLE_COLUMNS : MAX_SERIES;
+
+  function update(idx: number, next: SeriesConfig) {
+    const copy = [...measures];
+    copy[idx] = next;
+    onChange(copy);
+  }
+
+  function add() {
+    if (measures.length >= cap) return;
+    onChange([
+      ...measures,
+      { measure: { agg: "sum", field: "amount" } },
+    ]);
+  }
+
+  function remove(idx: number) {
+    if (measures.length <= 1) return;
+    onChange(measures.filter((_, i) => i !== idx));
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
+        {widget.type === "table" ? "Columns" : "Series"}
+      </div>
+      {measures.map((s, idx) => (
+        <div
+          key={idx}
+          data-testid={`measure-row-${idx}`}
+          className="flex flex-col gap-1 rounded-md border border-border bg-bg p-2"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-text-muted">
+              {widget.type === "table" ? `Column ${idx + 1}` : `Series ${idx + 1}`}
+            </span>
+            {measures.length > 1 && (
+              <button
+                type="button"
+                data-testid={`measure-remove-${idx}`}
+                onClick={() => remove(idx)}
+                className="text-xs text-text-muted hover:text-danger"
+                aria-label={`Remove ${widget.type === "table" ? "column" : "series"} ${idx + 1}`}
+              >
+                Remove
+              </button>
+            )}
+          </div>
+          <input
+            type="text"
+            value={s.label ?? ""}
+            onChange={(e) =>
+              update(idx, { ...s, label: e.target.value || undefined })
+            }
+            placeholder={
+              widget.type === "table" ? "Column label" : "Series label"
+            }
+            aria-label={`Series ${idx + 1} label`}
+            className="rounded-md border border-border bg-bg px-2 py-1 text-xs text-text-primary"
+          />
+          <div className="flex items-center gap-1">
+            <select
+              value={s.measure.agg}
+              onChange={(e) =>
+                update(idx, {
+                  ...s,
+                  measure: { ...s.measure, agg: e.target.value as Aggregation },
+                })
+              }
+              aria-label={`Series ${idx + 1} aggregation`}
+              className="flex-1 rounded-md border border-border bg-bg px-2 py-1 text-xs text-text-primary"
+            >
+              {AGG_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <HelpTooltip k={AGG_HELP_KEY[s.measure.agg]} />
+            <select
+              value={s.measure.field}
+              onChange={(e) =>
+                update(idx, {
+                  ...s,
+                  measure: {
+                    ...s.measure,
+                    field: e.target.value as MeasureField,
+                  },
+                })
+              }
+              aria-label={`Series ${idx + 1} field`}
+              className="flex-1 rounded-md border border-border bg-bg px-2 py-1 text-xs text-text-primary"
+            >
+              {FIELD_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      ))}
+      {measures.length < cap && (
+        <button
+          type="button"
+          data-testid="measure-add"
+          onClick={add}
+          className="rounded-md border border-dashed border-border px-2 py-1 text-xs text-text-secondary transition hover:border-accent hover:text-accent"
+        >
+          + Add {widget.type === "table" ? "column" : "series"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/reports/config/Section.tsx
+++ b/frontend/components/reports/config/Section.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+/**
+ * Labelled section wrapper shared by every widget-editor control block
+ * (extracted verbatim from ``ConfigRail``). Renders an uppercase label
+ * with an optional ``HelpTooltip`` info icon, then the control children.
+ */
+import HelpTooltip from "@/components/help/HelpTooltip";
+import type { HelpTooltipKey } from "@/lib/help/tooltips";
+
+export default function Section({
+  label,
+  help,
+  children,
+}: {
+  label: string;
+  /** Optional help-tooltip key rendered as an info icon next to the label. */
+  help?: HelpTooltipKey;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-1 text-[11px] font-medium uppercase tracking-wider text-text-muted">
+        <span>{label}</span>
+        {help && <HelpTooltip k={help} />}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/frontend/components/reports/config/SingleMeasureEditor.tsx
+++ b/frontend/components/reports/config/SingleMeasureEditor.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * Single-measure editor (Aggregation + Field) for the single-measure
+ * widget types (kpi, bar, pie, sparkline). Extracted verbatim from
+ * ``ConfigRail``.
+ */
+import Section from "@/components/reports/config/Section";
+import {
+  AGG_HELP_KEY,
+  AGG_OPTIONS,
+  FIELD_OPTIONS,
+} from "@/components/reports/config/controlConstants";
+import type { Aggregation, Measure, MeasureField } from "@/lib/reports/types";
+
+export default function SingleMeasureEditor({
+  measure,
+  onChange,
+}: {
+  measure: Measure;
+  onChange: (m: Measure) => void;
+}) {
+  return (
+    <>
+      <Section label="Aggregation" help={AGG_HELP_KEY[measure.agg]}>
+        <select
+          value={measure.agg}
+          onChange={(e) =>
+            onChange({ ...measure, agg: e.target.value as Aggregation })
+          }
+          aria-label="Aggregation"
+          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        >
+          {AGG_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </Section>
+      <Section label="Field">
+        <select
+          value={measure.field}
+          onChange={(e) =>
+            onChange({ ...measure, field: e.target.value as MeasureField })
+          }
+          aria-label="Field"
+          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        >
+          {FIELD_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </Section>
+    </>
+  );
+}

--- a/frontend/components/reports/config/StyleTab.tsx
+++ b/frontend/components/reports/config/StyleTab.tsx
@@ -6,10 +6,10 @@
  * The stacked branch keeps ConfigRail's exact label split ("Stack mode"
  * for stacked_bar vs "Stack series" for area), the default split
  * (``stacked !== false`` vs ``Boolean(stacked)``), and the shared
- * ``aria-label="Stack series"``. Mutations come from ``useWidgetMutations``.
+ * ``aria-label="Stack series"``. Mutations come from ``buildWidgetMutations``.
  */
 import Section from "@/components/reports/config/Section";
-import { useWidgetMutations } from "@/components/reports/config/useWidgetMutations";
+import { buildWidgetMutations } from "@/components/reports/config/useWidgetMutations";
 import type {
   AreaConfig,
   KPIConfig,
@@ -25,10 +25,8 @@ export default function StyleTab({
   widget: Widget;
   onUpdate: (next: Widget) => void;
 }) {
-  const { setTitle, setComparePrior, setTopN, setStacked } = useWidgetMutations(
-    widget,
-    onUpdate,
-  );
+  const { setTitle, setComparePrior, setTopN, setStacked } =
+    buildWidgetMutations(widget, onUpdate);
 
   return (
     <>

--- a/frontend/components/reports/config/StyleTab.tsx
+++ b/frontend/components/reports/config/StyleTab.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+/**
+ * Style tab of the widget editor: title plus the widget-type-specific
+ * knobs (KPI compare-to-prior, Pie top-N, Area/StackedBar stack toggle).
+ * The stacked branch keeps ConfigRail's exact label split ("Stack mode"
+ * for stacked_bar vs "Stack series" for area), the default split
+ * (``stacked !== false`` vs ``Boolean(stacked)``), and the shared
+ * ``aria-label="Stack series"``. Mutations come from ``useWidgetMutations``.
+ */
+import Section from "@/components/reports/config/Section";
+import { useWidgetMutations } from "@/components/reports/config/useWidgetMutations";
+import type {
+  AreaConfig,
+  KPIConfig,
+  PieConfig,
+  StackedBarConfig,
+  Widget,
+} from "@/lib/reports/types";
+
+export default function StyleTab({
+  widget,
+  onUpdate,
+}: {
+  widget: Widget;
+  onUpdate: (next: Widget) => void;
+}) {
+  const { setTitle, setComparePrior, setTopN, setStacked } = useWidgetMutations(
+    widget,
+    onUpdate,
+  );
+
+  return (
+    <>
+      <Section label="Title">
+        <input
+          type="text"
+          value={widget.title}
+          onChange={(e) => setTitle(e.target.value)}
+          aria-label="Widget title"
+          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        />
+      </Section>
+
+      {widget.type === "kpi" && (
+        <Section label="Compare to prior period">
+          <label className="flex items-center gap-2 text-sm text-text-primary">
+            <input
+              type="checkbox"
+              checked={Boolean(
+                (widget.config as KPIConfig).compare_prior_period,
+              )}
+              onChange={(e) => setComparePrior(e.target.checked)}
+              aria-label="Compare to prior period"
+            />
+            <span>Show delta vs prior period</span>
+          </label>
+        </Section>
+      )}
+
+      {widget.type === "pie" && (
+        <Section label="Top N slices">
+          <input
+            type="number"
+            min={2}
+            max={20}
+            value={(widget.config as PieConfig).top_n ?? 8}
+            onChange={(e) => setTopN(Number(e.target.value) || 8)}
+            aria-label="Top N slices"
+            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+          />
+        </Section>
+      )}
+
+      {(widget.type === "area" || widget.type === "stacked_bar") && (
+        <Section label={widget.type === "stacked_bar" ? "Stack mode" : "Stack series"}>
+          <label className="flex items-center gap-2 text-sm text-text-primary">
+            <input
+              type="checkbox"
+              checked={
+                widget.type === "stacked_bar"
+                  ? (widget.config as StackedBarConfig).stacked !== false
+                  : Boolean((widget.config as AreaConfig).stacked)
+              }
+              onChange={(e) => setStacked(e.target.checked)}
+              aria-label="Stack series"
+            />
+            <span>Stack multiple series</span>
+          </label>
+        </Section>
+      )}
+    </>
+  );
+}

--- a/frontend/components/reports/config/controlConstants.ts
+++ b/frontend/components/reports/config/controlConstants.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared control constants + type guards for the widget editor.
+ *
+ * Extracted verbatim from ``ConfigRail.tsx`` so the popover tabs
+ * (``DataTab`` / ``StyleTab``), the measure/filter editors, and (in the
+ * extraction PR) ``ConfigRail`` itself all read from one source. Keeping
+ * these in one module means the picker options, the multi-series cap, and
+ * the single-agg lock can never drift between the rail and the popover.
+ */
+import type { HelpTooltipKey } from "@/lib/help/tooltips";
+import type {
+  AreaConfig,
+  Aggregation,
+  Dimension,
+  LineConfig,
+  MeasureField,
+  StackedBarConfig,
+  TableConfig,
+  Widget,
+} from "@/lib/reports/types";
+import { MEASURE_FIELD_LABELS } from "@/lib/reports/series";
+
+export const AGG_OPTIONS: Array<{ value: Aggregation; label: string }> = [
+  { value: "sum", label: "Sum" },
+  { value: "count", label: "Count" },
+  { value: "avg", label: "Average" },
+  { value: "distinct", label: "Distinct count" },
+];
+
+/** Tooltip key for each aggregation type (plain-language explainer). */
+export const AGG_HELP_KEY: Record<Aggregation, HelpTooltipKey> = {
+  sum: "reports.agg.sum",
+  count: "reports.agg.count",
+  avg: "reports.agg.avg",
+  distinct: "reports.agg.distinct",
+};
+
+// Derived from the shared measure-field label map so the editor picker,
+// chart tooltips, and CSV headers can never drift apart.
+export const FIELD_OPTIONS: Array<{ value: MeasureField; label: string }> = (
+  Object.keys(MEASURE_FIELD_LABELS) as MeasureField[]
+).map((value) => ({ value, label: MEASURE_FIELD_LABELS[value] }));
+
+export const DIMENSION_OPTIONS: Array<{ value: Dimension; label: string }> = [
+  { value: "category", label: "Category" },
+  { value: "category_master", label: "Master category" },
+  { value: "account", label: "Account" },
+  { value: "tag", label: "Tag" },
+  { value: "txn_type", label: "Transaction type" },
+  { value: "status", label: "Status" },
+  { value: "month", label: "Month" },
+  { value: "week", label: "Week" },
+  { value: "day", label: "Day" },
+];
+
+export const MAX_SERIES = 5;
+export const MAX_TABLE_COLUMNS = 5;
+
+/** Widget types that carry ``config.measures`` (multi-series). */
+export function isMultiSeries(
+  w: Widget,
+): w is Widget & { config: LineConfig | AreaConfig | StackedBarConfig | TableConfig } {
+  return (
+    w.type === "line" ||
+    w.type === "area" ||
+    w.type === "stacked_bar" ||
+    w.type === "table"
+  );
+}
+
+/** Widget types locked to a single dimension + single aggregation. */
+export function isSingleAggLocked(w: Widget): boolean {
+  return w.type === "pie" || w.type === "sparkline";
+}

--- a/frontend/components/reports/config/useWidgetMutations.ts
+++ b/frontend/components/reports/config/useWidgetMutations.ts
@@ -2,9 +2,12 @@
 
 /**
  * The widget-editor mutation closures, extracted verbatim from
- * ``ConfigRail`` into one shared hook so ``DataTab`` / ``StyleTab`` / the
- * popover and (during the extraction PR) ``ConfigRail`` itself all call the
- * identical logic. Each setter early-returns on the same type guards it did
+ * ``ConfigRail`` into one shared plain factory so ``DataTab`` / ``StyleTab``
+ * / the popover and (during the extraction PR) ``ConfigRail`` itself all
+ * call the identical logic. It calls no React hooks (callers invoke it
+ * unconditionally at render), so it is named ``build*`` rather than
+ * ``use*`` to keep the rules-of-hooks linter off a non-hook. Each setter
+ * early-returns on the same type guards it did
  * inline (these guards are load-bearing — e.g. ``setSingleMeasure``
  * early-returns on ``isMultiSeries`` and ``setSecondaryDimension``
  * early-returns on ``kpi`` / ``isSingleAggLocked``).
@@ -29,7 +32,7 @@ import type {
   WidgetFilters,
 } from "@/lib/reports/types";
 
-export function useWidgetMutations(
+export function buildWidgetMutations(
   widget: Widget,
   onUpdate: (next: Widget) => void,
 ) {

--- a/frontend/components/reports/config/useWidgetMutations.ts
+++ b/frontend/components/reports/config/useWidgetMutations.ts
@@ -1,0 +1,153 @@
+"use client";
+
+/**
+ * The widget-editor mutation closures, extracted verbatim from
+ * ``ConfigRail`` into one shared hook so ``DataTab`` / ``StyleTab`` / the
+ * popover and (during the extraction PR) ``ConfigRail`` itself all call the
+ * identical logic. Each setter early-returns on the same type guards it did
+ * inline (these guards are load-bearing — e.g. ``setSingleMeasure``
+ * early-returns on ``isMultiSeries`` and ``setSecondaryDimension``
+ * early-returns on ``kpi`` / ``isSingleAggLocked``).
+ */
+import {
+  isMultiSeries,
+  isSingleAggLocked,
+} from "@/components/reports/config/controlConstants";
+import type {
+  AreaConfig,
+  BarConfig,
+  Dimension,
+  KPIConfig,
+  LineConfig,
+  Measure,
+  PieConfig,
+  SeriesConfig,
+  SparklineConfig,
+  StackedBarConfig,
+  TableConfig,
+  Widget,
+  WidgetFilters,
+} from "@/lib/reports/types";
+
+export function useWidgetMutations(
+  widget: Widget,
+  onUpdate: (next: Widget) => void,
+) {
+  function setTitle(title: string) {
+    onUpdate({ ...widget, title });
+  }
+
+  function setFilters(nextFilters: WidgetFilters) {
+    const next = {
+      ...widget,
+      config: { ...widget.config, filters: nextFilters },
+    } as Widget;
+    onUpdate(next);
+  }
+
+  function setSingleMeasure(measure: Measure) {
+    if (isMultiSeries(widget)) return;
+    const next = {
+      ...widget,
+      config: {
+        ...(widget.config as KPIConfig | BarConfig | PieConfig | SparklineConfig),
+        measure,
+      },
+    } as Widget;
+    onUpdate(next);
+  }
+
+  function setSeries(measures: SeriesConfig[]) {
+    if (!isMultiSeries(widget)) return;
+    const next: Widget = {
+      ...widget,
+      config: { ...widget.config, measures },
+    } as Widget;
+    onUpdate(next);
+  }
+
+  function setPrimaryDimension(dim: Dimension) {
+    if (widget.type === "kpi") return; // KPI has no dimensions
+    const cfg = widget.config as
+      | BarConfig
+      | LineConfig
+      | AreaConfig
+      | PieConfig
+      | SparklineConfig
+      | StackedBarConfig
+      | TableConfig;
+    const dims = [...(cfg.dimensions ?? [])];
+    dims[0] = dim;
+    const next: Widget = {
+      ...widget,
+      config: { ...cfg, dimensions: dims },
+    } as Widget;
+    onUpdate(next);
+  }
+
+  function setSecondaryDimension(dim: Dimension | "") {
+    if (widget.type === "kpi" || isSingleAggLocked(widget)) return;
+    const cfg = widget.config as
+      | BarConfig
+      | LineConfig
+      | AreaConfig
+      | StackedBarConfig
+      | TableConfig;
+    const dims = [...(cfg.dimensions ?? [])];
+    if (dim === "") {
+      dims.splice(1, 1);
+    } else {
+      dims[1] = dim;
+    }
+    const next: Widget = {
+      ...widget,
+      config: { ...cfg, dimensions: dims },
+    } as Widget;
+    onUpdate(next);
+  }
+
+  function setComparePrior(value: boolean) {
+    if (widget.type !== "kpi") return;
+    const next: Widget = {
+      ...widget,
+      config: {
+        ...(widget.config as KPIConfig),
+        compare_prior_period: value,
+      },
+    };
+    onUpdate(next);
+  }
+
+  function setTopN(value: number) {
+    if (widget.type !== "pie") return;
+    const next: Widget = {
+      ...widget,
+      config: { ...(widget.config as PieConfig), top_n: value },
+    };
+    onUpdate(next);
+  }
+
+  function setStacked(value: boolean) {
+    if (widget.type !== "area" && widget.type !== "stacked_bar") return;
+    const next: Widget = {
+      ...widget,
+      config: {
+        ...(widget.config as AreaConfig | StackedBarConfig),
+        stacked: value,
+      },
+    } as Widget;
+    onUpdate(next);
+  }
+
+  return {
+    setTitle,
+    setFilters,
+    setSingleMeasure,
+    setSeries,
+    setPrimaryDimension,
+    setSecondaryDimension,
+    setComparePrior,
+    setTopN,
+    setStacked,
+  };
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@floating-ui/react": "^0.27.19",
         "@marsidev/react-turnstile": "^1.5.2",
         "lucide-react": "^1.7.0",
         "next": "16.2.4",
@@ -1099,6 +1100,59 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -8412,6 +8466,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
     "node_modules/tailwindcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@floating-ui/react": "^0.27.19",
     "@marsidev/react-turnstile": "^1.5.2",
     "lucide-react": "^1.7.0",
     "next": "16.2.4",

--- a/frontend/tests/components/reports/WidgetEditorPopover.test.tsx
+++ b/frontend/tests/components/reports/WidgetEditorPopover.test.tsx
@@ -15,6 +15,7 @@ import type {
   LineWidget,
   PieWidget,
   SparklineWidget,
+  StackedBarWidget,
   TableWidget,
   Widget,
 } from "@/lib/reports/types";
@@ -127,6 +128,20 @@ function makeTable(): TableWidget {
       dataset: "transactions",
       measures: [{ measure: { agg: "sum", field: "amount" } }],
       dimensions: ["category"],
+    },
+  };
+}
+
+function makeStacked(): StackedBarWidget {
+  return {
+    id: "w_stacked",
+    type: "stacked_bar",
+    title: "Stacked",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
     },
   };
 }
@@ -248,5 +263,103 @@ describe("WidgetEditorPopover", () => {
     renderPopover(makeBar(), { onClose });
     fireEvent.click(screen.getByRole("button", { name: /close/i }));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("renders nothing when anchorEl is null", () => {
+    renderWithSWR(
+      <WidgetEditorPopover
+        widget={makeBar()}
+        canvasFilters={{}}
+        anchorEl={null}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId("widget-editor-popover")).not.toBeInTheDocument();
+  });
+
+  it("closes when the anchor detaches (staleness guard)", () => {
+    const onClose = vi.fn();
+    const detached = document.createElement("div");
+    // Intentionally NOT appended to the document → not connected.
+    renderWithSWR(
+      <WidgetEditorPopover
+        widget={makeBar()}
+        canvasFilters={{}}
+        anchorEl={detached}
+        onUpdate={() => {}}
+        onClose={onClose}
+      />,
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("resets to the Data tab when the selected widget changes", () => {
+    const { rerender } = renderPopover(makeBar());
+    fireEvent.click(screen.getByRole("tab", { name: /style/i }));
+    expect(screen.getByLabelText("Widget title")).toBeInTheDocument();
+
+    rerender(
+      <WidgetEditorPopover
+        widget={makeKpi()}
+        canvasFilters={{}}
+        anchorEl={anchorEl}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    // Back on Data: the Style-only title input is gone, Data source is shown.
+    expect(screen.queryByLabelText("Widget title")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Data source")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /data/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("ArrowRight moves the tab selection (roving)", () => {
+    renderPopover(makeBar());
+    const dataTab = screen.getByRole("tab", { name: /data/i });
+    dataTab.focus();
+    fireEvent.keyDown(dataTab, { key: "ArrowRight" });
+    expect(screen.getByRole("tab", { name: /filters/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: /filters/i })).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
+    expect(dataTab).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("title edit on the Style tab fires onUpdate with the new title", () => {
+    const onUpdate = vi.fn();
+    renderPopover(makeBar(), { onUpdate });
+    fireEvent.click(screen.getByRole("tab", { name: /style/i }));
+    fireEvent.change(screen.getByLabelText("Widget title"), {
+      target: { value: "Spending" },
+    });
+    expect(onUpdate).toHaveBeenCalled();
+    const last = onUpdate.mock.calls.at(-1)?.[0] as Widget;
+    expect(last.title).toBe("Spending");
+  });
+
+  it("changing the aggregation on the Data tab fires onUpdate", () => {
+    const onUpdate = vi.fn();
+    renderPopover(makeBar(), { onUpdate });
+    fireEvent.change(screen.getByLabelText("Aggregation"), {
+      target: { value: "count" },
+    });
+    expect(onUpdate).toHaveBeenCalled();
+    const last = onUpdate.mock.calls.at(-1)?.[0] as BarWidget;
+    expect(last.config.measure).toEqual({ agg: "count", field: "amount" });
+  });
+
+  it("stacked_bar: Style tab shows the 'Stack mode' control", () => {
+    renderPopover(makeStacked());
+    fireEvent.click(screen.getByRole("tab", { name: /style/i }));
+    expect(screen.getByText("Stack mode")).toBeInTheDocument();
+    expect(screen.getByLabelText("Stack series")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/reports/WidgetEditorPopover.test.tsx
+++ b/frontend/tests/components/reports/WidgetEditorPopover.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * WidgetEditorPopover — the floating-ui shell with a 3-tab frame.
+ * Component-level mounts here are synchronous (anchorEl passed directly),
+ * so no waitFor is needed. ResizeObserver is polyfilled globally in
+ * vitest.setup.ts.
+ */
+import { renderWithSWR, fireEvent, screen } from "../../utils/render-with-swr";
+
+import WidgetEditorPopover from "@/components/reports/WidgetEditorPopover";
+import { apiFetch } from "@/lib/api";
+import type {
+  AreaWidget,
+  BarWidget,
+  KPIWidget,
+  LineWidget,
+  PieWidget,
+  SparklineWidget,
+  TableWidget,
+  Widget,
+} from "@/lib/reports/types";
+
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(apiFetch).mockReset();
+  vi.mocked(apiFetch).mockImplementation(
+    () => Promise.resolve([]) as Promise<unknown>,
+  );
+});
+
+let anchorEl: HTMLElement;
+beforeEach(() => {
+  anchorEl = document.createElement("div");
+  document.body.appendChild(anchorEl);
+});
+afterEach(() => {
+  anchorEl.remove();
+});
+
+function makeBar(): BarWidget {
+  return {
+    id: "w_bar",
+    type: "bar",
+    title: "Bar",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+    },
+  };
+}
+
+function makeKpi(): KPIWidget {
+  return {
+    id: "w_kpi",
+    type: "kpi",
+    title: "KPI",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config: { dataset: "transactions", measure: { agg: "sum", field: "amount" } },
+  };
+}
+
+function makePie(): PieWidget {
+  return {
+    id: "w_pie",
+    type: "pie",
+    title: "Pie",
+    grid: { x: 0, y: 0, w: 4, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+    },
+  };
+}
+
+function makeSparkline(): SparklineWidget {
+  return {
+    id: "w_spark",
+    type: "sparkline",
+    title: "Spark",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["month"],
+    },
+  };
+}
+
+function makeLine(): LineWidget {
+  return {
+    id: "w_line",
+    type: "line",
+    title: "Line",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+    },
+  };
+}
+
+function makeArea(): AreaWidget {
+  return {
+    id: "w_area",
+    type: "area",
+    title: "Area",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+    },
+  };
+}
+
+function makeTable(): TableWidget {
+  return {
+    id: "w_table",
+    type: "table",
+    title: "Table",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["category"],
+    },
+  };
+}
+
+function renderPopover(widget: Widget, props: Partial<{ onUpdate: (w: Widget) => void; onClose: () => void }> = {}) {
+  return renderWithSWR(
+    <WidgetEditorPopover
+      widget={widget}
+      canvasFilters={{}}
+      anchorEl={anchorEl}
+      onUpdate={props.onUpdate ?? (() => {})}
+      onClose={props.onClose ?? (() => {})}
+    />,
+  );
+}
+
+describe("WidgetEditorPopover", () => {
+  it("renders the dialog with the right role and aria-label", () => {
+    renderPopover(makeBar());
+    const dialog = screen.getByTestId("widget-editor-popover");
+    expect(dialog).toHaveAttribute("role", "dialog");
+    expect(dialog).toHaveAttribute("aria-label", "Widget settings");
+  });
+
+  it("defaults to the Data tab", () => {
+    renderPopover(makeBar());
+    expect(screen.getByLabelText("Data source")).toBeInTheDocument();
+    expect(screen.getByLabelText("Aggregation")).toBeInTheDocument();
+    // Style/Filters panels not visible: no title input, no Filters block.
+    expect(screen.queryByLabelText("Widget title")).not.toBeInTheDocument();
+  });
+
+  it("exposes three tabs with the active one selected", () => {
+    renderPopover(makeBar());
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(3);
+    expect(screen.getByRole("tab", { name: /data/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("clicking Style shows the title input; clicking Filters shows FilterEditor", () => {
+    renderPopover(makeBar());
+    fireEvent.click(screen.getByRole("tab", { name: /style/i }));
+    expect(screen.getByLabelText("Widget title")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /style/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    fireEvent.click(screen.getByRole("tab", { name: /filters/i }));
+    expect(screen.getByText("Filters (this widget)")).toBeInTheDocument();
+  });
+
+  it("kpi: no dimensions on Data, compare checkbox on Style", () => {
+    renderPopover(makeKpi());
+    expect(screen.queryByLabelText("Primary dimension")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: /style/i }));
+    expect(screen.getByLabelText("Compare to prior period")).toBeInTheDocument();
+  });
+
+  it("pie: single measure + primary, no secondary; Style top_n", () => {
+    renderPopover(makePie());
+    expect(screen.getByLabelText("Primary dimension")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Secondary dimension")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: /style/i }));
+    expect(screen.getByLabelText("Top N slices")).toBeInTheDocument();
+  });
+
+  it("sparkline: primary only, no secondary, no top_n", () => {
+    renderPopover(makeSparkline());
+    expect(screen.getByLabelText("Primary dimension")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Secondary dimension")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: /style/i }));
+    expect(screen.queryByLabelText("Top N slices")).not.toBeInTheDocument();
+  });
+
+  it("bar: primary + Break down by, no Style type-knob", () => {
+    renderPopover(makeBar());
+    expect(screen.getByLabelText("Break down by")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: /style/i }));
+    expect(screen.queryByLabelText("Top N slices")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Stack series")).not.toBeInTheDocument();
+  });
+
+  it("line: MeasuresEditor add/remove; no secondary", () => {
+    renderPopover(makeLine());
+    expect(screen.getByTestId("measure-add")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Secondary dimension")).not.toBeInTheDocument();
+  });
+
+  it("area: stacked checkbox on Style", () => {
+    renderPopover(makeArea());
+    fireEvent.click(screen.getByRole("tab", { name: /style/i }));
+    expect(screen.getByLabelText("Stack series")).toBeInTheDocument();
+  });
+
+  it("table: secondary dimension present", () => {
+    renderPopover(makeTable());
+    expect(screen.getByLabelText("Secondary dimension")).toBeInTheDocument();
+  });
+
+  it("Escape closes the popover", () => {
+    const onClose = vi.fn();
+    renderPopover(makeBar(), { onClose });
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("outside pointerdown closes the popover", () => {
+    const onClose = vi.fn();
+    renderPopover(makeBar(), { onClose });
+    fireEvent.pointerDown(document.body);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("the Close button calls onClose", () => {
+    const onClose = vi.fn();
+    renderPopover(makeBar(), { onClose });
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/components/reports/config/FilterEditor.test.tsx
+++ b/frontend/tests/components/reports/config/FilterEditor.test.tsx
@@ -53,7 +53,9 @@ function mockApi() {
       return Promise.resolve(ACCOUNTS) as Promise<unknown>;
     }
     if (String(path).startsWith("/api/v1/tags")) {
-      return Promise.resolve([]) as Promise<unknown>;
+      return Promise.resolve([
+        { id: 1, name: "groceries", name_normalized: "groceries", usage_count: 3 },
+      ]) as Promise<unknown>;
     }
     return Promise.resolve([]);
   });
@@ -117,5 +119,40 @@ describe("FilterEditor", () => {
       target: { value: "5" },
     });
     expect(calls.at(-1)?.amount_range).toEqual({ min: 5 });
+  });
+
+  it("merges amount max while preserving an existing min", async () => {
+    const calls: WidgetFilters[] = [];
+    render({ amount_range: { min: 5 } }, {}, (next) => calls.push(next));
+    await screen.findByTestId("category-picker");
+    fireEvent.change(screen.getByLabelText("Widget amount max"), {
+      target: { value: "20" },
+    });
+    expect(calls.at(-1)?.amount_range).toEqual({ min: 5, max: 20 });
+  });
+
+  it("reports the chosen txn_type on change", async () => {
+    const calls: WidgetFilters[] = [];
+    render({}, {}, (next) => calls.push(next));
+    await screen.findByTestId("category-picker");
+    fireEvent.click(screen.getByLabelText("Widget transaction type Expense"));
+    expect(calls.at(-1)?.txn_type).toBe("expense");
+  });
+
+  it("clears txn_type back to undefined when 'Any' is chosen", async () => {
+    const calls: WidgetFilters[] = [];
+    render({ txn_type: "expense" }, {}, (next) => calls.push(next));
+    await screen.findByTestId("category-picker");
+    fireEvent.click(screen.getByLabelText("Widget transaction type Any"));
+    expect(calls.at(-1)?.txn_type).toBeUndefined();
+  });
+
+  it("reports tag_names + tag_match when a tag chip is selected", async () => {
+    const calls: WidgetFilters[] = [];
+    render({}, {}, (next) => calls.push(next));
+    const chip = await screen.findByTestId("tag-filter-chip-groceries");
+    fireEvent.click(chip);
+    expect(calls.at(-1)?.tag_names).toEqual(["groceries"]);
+    expect(calls.at(-1)?.tag_match).toBe("all");
   });
 });

--- a/frontend/tests/components/reports/config/FilterEditor.test.tsx
+++ b/frontend/tests/components/reports/config/FilterEditor.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Per-widget FilterEditor extracted from ConfigRail. Pins the six filter
+ * fields render, the override-pill parity (driven by resolve.ts'
+ * isFieldOverridden, not reimplemented), and the amount-range merge.
+ */
+import { renderWithSWR, fireEvent, screen } from "../../../utils/render-with-swr";
+
+import FilterEditor from "@/components/reports/config/FilterEditor";
+import { apiFetch } from "@/lib/api";
+import type { CanvasFilters, WidgetFilters } from "@/lib/reports/types";
+import type { Account, Category } from "@/lib/types";
+
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const CATEGORIES: Category[] = [
+  {
+    id: 1,
+    name: "Food",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "food",
+    is_system: false,
+    transaction_count: 0,
+  },
+];
+
+const ACCOUNTS: Account[] = [
+  {
+    id: 1,
+    name: "Checking",
+    account_type_id: 1,
+    account_type_name: "Bank",
+    account_type_slug: "bank",
+    balance: 0,
+    currency: "USD",
+    is_active: true,
+    close_day: null,
+    is_default: true,
+  },
+];
+
+function mockApi() {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockImplementation((path) => {
+    if (String(path).startsWith("/api/v1/categories")) {
+      return Promise.resolve(CATEGORIES) as Promise<unknown>;
+    }
+    if (String(path).startsWith("/api/v1/accounts")) {
+      return Promise.resolve(ACCOUNTS) as Promise<unknown>;
+    }
+    if (String(path).startsWith("/api/v1/tags")) {
+      return Promise.resolve([]) as Promise<unknown>;
+    }
+    return Promise.resolve([]);
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(apiFetch).mockReset();
+  mockApi();
+});
+
+function render(
+  filters: WidgetFilters,
+  canvasFilters: CanvasFilters,
+  onChange: (next: WidgetFilters) => void = () => {},
+) {
+  return renderWithSWR(
+    <FilterEditor
+      filters={filters}
+      canvasFilters={canvasFilters}
+      onChange={onChange}
+    />,
+  );
+}
+
+describe("FilterEditor", () => {
+  it("renders all six filter fields", async () => {
+    render({}, {});
+    await screen.findByTestId("category-picker");
+    expect(screen.getByText("Date range")).toBeInTheDocument();
+    expect(screen.getByText("Accounts")).toBeInTheDocument();
+    expect(screen.getByText("Categories")).toBeInTheDocument();
+    expect(screen.getByText("Transaction type")).toBeInTheDocument();
+    expect(screen.getByLabelText("Widget amount min")).toBeInTheDocument();
+    expect(screen.getByLabelText("Widget amount max")).toBeInTheDocument();
+    expect(screen.getByTestId("account-filter")).toBeInTheDocument();
+  });
+
+  it("shows the override pill when the widget date range differs from canvas", async () => {
+    render(
+      { date_range: { start: "2026-01-01", end: "2026-01-31" } },
+      { date_range: { start: "2026-02-01", end: "2026-02-28" } },
+    );
+    await screen.findByTestId("category-picker");
+    expect(screen.getAllByTestId("override-pill").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not show the override pill when the date range matches canvas", async () => {
+    render(
+      { date_range: { start: "2026-01-01", end: "2026-01-31" } },
+      { date_range: { start: "2026-01-01", end: "2026-01-31" } },
+    );
+    await screen.findByTestId("category-picker");
+    expect(screen.queryAllByTestId("override-pill").length).toBe(0);
+  });
+
+  it("merges amount min into amount_range on change", async () => {
+    const calls: WidgetFilters[] = [];
+    render({}, {}, (next) => calls.push(next));
+    await screen.findByTestId("category-picker");
+    fireEvent.change(screen.getByLabelText("Widget amount min"), {
+      target: { value: "5" },
+    });
+    expect(calls.at(-1)?.amount_range).toEqual({ min: 5 });
+  });
+});

--- a/frontend/tests/components/reports/config/controlConstants.test.ts
+++ b/frontend/tests/components/reports/config/controlConstants.test.ts
@@ -3,22 +3,72 @@
  */
 import {
   AGG_OPTIONS,
+  AGG_HELP_KEY,
   DIMENSION_OPTIONS,
   MAX_SERIES,
   MAX_TABLE_COLUMNS,
+  isMultiSeries,
+  isSingleAggLocked,
 } from "@/components/reports/config/controlConstants";
+import type { Widget } from "@/lib/reports/types";
 
 describe("widget-config control constants", () => {
-  it("exposes nine dimension options", () => {
-    expect(DIMENSION_OPTIONS.length).toBe(9);
+  it("exposes the four aggregation values sum/count/avg/distinct", () => {
+    expect(AGG_OPTIONS.map((o) => o.value)).toEqual([
+      "sum",
+      "count",
+      "avg",
+      "distinct",
+    ]);
   });
 
-  it("exposes four aggregation options", () => {
-    expect(AGG_OPTIONS.length).toBe(4);
+  it("maps every aggregation value to a help-tooltip key", () => {
+    for (const { value } of AGG_OPTIONS) {
+      expect(AGG_HELP_KEY[value]).toBe(`reports.agg.${value}`);
+    }
+  });
+
+  it("exposes the nine expected dimension keys in order", () => {
+    expect(DIMENSION_OPTIONS.map((o) => o.value)).toEqual([
+      "category",
+      "category_master",
+      "account",
+      "tag",
+      "txn_type",
+      "status",
+      "month",
+      "week",
+      "day",
+    ]);
   });
 
   it("caps series and table columns at five", () => {
     expect(MAX_SERIES).toBe(5);
     expect(MAX_TABLE_COLUMNS).toBe(5);
+  });
+
+  it("isMultiSeries is true only for line/area/stacked_bar/table", () => {
+    const base = { id: "w", title: "", grid: { x: 0, y: 0, w: 1, h: 1 } };
+    const multi = ["line", "area", "stacked_bar", "table"];
+    const single = ["bar", "kpi", "pie", "sparkline"];
+    for (const type of multi) {
+      expect(isMultiSeries({ ...base, type } as unknown as Widget)).toBe(true);
+    }
+    for (const type of single) {
+      expect(isMultiSeries({ ...base, type } as unknown as Widget)).toBe(false);
+    }
+  });
+
+  it("isSingleAggLocked is true only for pie/sparkline", () => {
+    const base = { id: "w", title: "", grid: { x: 0, y: 0, w: 1, h: 1 } };
+    expect(
+      isSingleAggLocked({ ...base, type: "pie" } as unknown as Widget),
+    ).toBe(true);
+    expect(
+      isSingleAggLocked({ ...base, type: "sparkline" } as unknown as Widget),
+    ).toBe(true);
+    expect(
+      isSingleAggLocked({ ...base, type: "bar" } as unknown as Widget),
+    ).toBe(false);
   });
 });

--- a/frontend/tests/components/reports/config/controlConstants.test.ts
+++ b/frontend/tests/components/reports/config/controlConstants.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Locks the move of the widget-config control constants out of ConfigRail.
+ */
+import {
+  AGG_OPTIONS,
+  DIMENSION_OPTIONS,
+  MAX_SERIES,
+  MAX_TABLE_COLUMNS,
+} from "@/components/reports/config/controlConstants";
+
+describe("widget-config control constants", () => {
+  it("exposes nine dimension options", () => {
+    expect(DIMENSION_OPTIONS.length).toBe(9);
+  });
+
+  it("exposes four aggregation options", () => {
+    expect(AGG_OPTIONS.length).toBe(4);
+  });
+
+  it("caps series and table columns at five", () => {
+    expect(MAX_SERIES).toBe(5);
+    expect(MAX_TABLE_COLUMNS).toBe(5);
+  });
+});

--- a/frontend/tests/components/reports/config/data-tab-secondary-dimension.test.tsx
+++ b/frontend/tests/components/reports/config/data-tab-secondary-dimension.test.tsx
@@ -1,15 +1,18 @@
 /**
- * Secondary dimension picker visibility.
+ * Secondary dimension picker visibility (re-homed from
+ * config-rail-secondary-dimension onto the extracted ``DataTab``, which
+ * owns the primary/secondary dimension selects and their per-type
+ * visibility).
  *
- * The "Secondary dimension" picker is Table-only. The bar widget now
- * exposes a "Break down by" picker that slices each total bar into
- * stacked, per-secondary-value colored segments (e.g. per account).
- * line / area / stacked-bar / kpi / pie / sparkline still only consume
+ * The "Secondary dimension" picker is Table-only. The bar widget exposes
+ * a "Break down by" picker that slices each total bar into stacked,
+ * per-secondary-value colored segments (e.g. per account). line / area /
+ * stacked-bar / kpi / pie / sparkline still only consume
  * ``dimensions[0]``, so they expose no secondary picker.
  */
-import { renderWithSWR, fireEvent, screen } from "../../utils/render-with-swr";
+import { renderWithSWR, fireEvent, screen } from "../../../utils/render-with-swr";
 
-import ConfigRail from "@/components/reports/ConfigRail";
+import DataTab from "@/components/reports/config/DataTab";
 import { apiFetch } from "@/lib/api";
 import type {
   AreaWidget,
@@ -154,17 +157,10 @@ const HIDDEN_CASES: Array<{ name: string; widget: Widget }> = [
   { name: "sparkline", widget: makeSparkline() },
 ];
 
-describe("ConfigRail — secondary dimension picker visibility", () => {
+describe("DataTab — secondary dimension picker visibility", () => {
   for (const { name, widget } of HIDDEN_CASES) {
     it(`does NOT render the secondary dimension picker for ${name}`, () => {
-      renderWithSWR(
-        <ConfigRail
-          widget={widget}
-          canvasFilters={{}}
-          onUpdate={() => {}}
-          onClose={() => {}}
-        />,
-      );
+      renderWithSWR(<DataTab widget={widget} onUpdate={() => {}} />);
       expect(
         screen.queryByLabelText("Secondary dimension"),
       ).not.toBeInTheDocument();
@@ -172,28 +168,14 @@ describe("ConfigRail — secondary dimension picker visibility", () => {
   }
 
   it("DOES render the secondary dimension picker for table", () => {
-    renderWithSWR(
-      <ConfigRail
-        widget={makeTable()}
-        canvasFilters={{}}
-        onUpdate={() => {}}
-        onClose={() => {}}
-      />,
-    );
+    renderWithSWR(<DataTab widget={makeTable()} onUpdate={() => {}} />);
     expect(
       screen.getByLabelText("Secondary dimension"),
     ).toBeInTheDocument();
   });
 
   it("DOES render the 'Break down by' picker for bar", () => {
-    renderWithSWR(
-      <ConfigRail
-        widget={makeBar()}
-        canvasFilters={{}}
-        onUpdate={() => {}}
-        onClose={() => {}}
-      />,
-    );
+    renderWithSWR(<DataTab widget={makeBar()} onUpdate={() => {}} />);
     expect(screen.getByLabelText("Break down by")).toBeInTheDocument();
     // The bar picker is NOT labeled "Secondary dimension" (table-only).
     expect(
@@ -205,12 +187,7 @@ describe("ConfigRail — secondary dimension picker visibility", () => {
     const updates: Widget[] = [];
     const bar = makeBar();
     const { rerender } = renderWithSWR(
-      <ConfigRail
-        widget={bar}
-        canvasFilters={{}}
-        onUpdate={(w) => updates.push(w)}
-        onClose={() => {}}
-      />,
+      <DataTab widget={bar} onUpdate={(w) => updates.push(w)} />,
     );
 
     fireEvent.change(screen.getByLabelText("Break down by"), {
@@ -219,14 +196,7 @@ describe("ConfigRail — secondary dimension picker visibility", () => {
     const afterSet = updates.at(-1) as BarWidget;
     expect(afterSet.config.dimensions).toEqual(["category", "account"]);
 
-    rerender(
-      <ConfigRail
-        widget={afterSet}
-        canvasFilters={{}}
-        onUpdate={(w) => updates.push(w)}
-        onClose={() => {}}
-      />,
-    );
+    rerender(<DataTab widget={afterSet} onUpdate={(w) => updates.push(w)} />);
 
     fireEvent.change(screen.getByLabelText("Break down by"), {
       target: { value: "" },

--- a/frontend/tests/components/reports/config/data-tab-secondary-dimension.test.tsx
+++ b/frontend/tests/components/reports/config/data-tab-secondary-dimension.test.tsx
@@ -205,3 +205,54 @@ describe("DataTab — secondary dimension picker visibility", () => {
     expect(afterClear.config.dimensions).toEqual(["category"]);
   });
 });
+
+describe("DataTab — measure editor + dimension by widget type", () => {
+  // Multi-series types render the MeasuresEditor (with the add button);
+  // single-measure types render SingleMeasureEditor (no add button).
+  const MULTI: Array<{ name: string; widget: Widget }> = [
+    { name: "line", widget: makeLine() },
+    { name: "area", widget: makeArea() },
+    { name: "stacked_bar", widget: makeStacked() },
+    { name: "table", widget: makeTable() },
+  ];
+
+  for (const { name, widget } of MULTI) {
+    it(`renders the multi-series MeasuresEditor for ${name}`, () => {
+      renderWithSWR(<DataTab widget={widget} onUpdate={() => {}} />);
+      expect(screen.getByTestId("measure-add")).toBeInTheDocument();
+    });
+  }
+
+  it("renders a single measure editor (no add button) for bar", () => {
+    renderWithSWR(<DataTab widget={makeBar()} onUpdate={() => {}} />);
+    expect(screen.getByLabelText("Aggregation")).toBeInTheDocument();
+    expect(screen.queryByTestId("measure-add")).not.toBeInTheDocument();
+  });
+
+  it("renders no dimension control for kpi", () => {
+    renderWithSWR(<DataTab widget={makeKpi()} onUpdate={() => {}} />);
+    expect(
+      screen.queryByLabelText("Primary dimension"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Secondary dimension"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Break down by")).not.toBeInTheDocument();
+  });
+
+  for (const { name, widget } of [
+    { name: "pie", widget: makePie() },
+    { name: "sparkline", widget: makeSparkline() },
+  ]) {
+    it(`renders only a single (primary) dimension for ${name}`, () => {
+      renderWithSWR(<DataTab widget={widget} onUpdate={() => {}} />);
+      expect(screen.getByLabelText("Primary dimension")).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Secondary dimension"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Break down by")).not.toBeInTheDocument();
+      // single-measure: no add-series button
+      expect(screen.queryByTestId("measure-add")).not.toBeInTheDocument();
+    });
+  }
+});

--- a/frontend/tests/components/reports/config/data-tab-tooltips.test.tsx
+++ b/frontend/tests/components/reports/config/data-tab-tooltips.test.tsx
@@ -1,15 +1,18 @@
 /**
- * ConfigRail help tooltips (Reports v2 polish).
+ * Widget-editor help tooltips (re-homed from config-rail-tooltips).
  *
- * Jargon in the widget config rail gets inline ``HelpTooltip`` info
+ * Jargon in the widget config controls gets inline ``HelpTooltip`` info
  * icons: the aggregation selector explains Sum / Count / Average /
  * Distinct, and the dimension labels carry the master-category
- * explainer. We assert the tooltip triggers render (by their ARIA
- * label from the content map) rather than driving the portal open.
+ * explainer. These now live on the extracted ``DataTab`` (agg + dimension
+ * tooltips) and ``MeasuresEditor`` (per-series agg tooltip). We assert the
+ * tooltip triggers render (by their ARIA label from the content map)
+ * rather than driving the portal open.
  */
-import { renderWithSWR, fireEvent, screen } from "../../utils/render-with-swr";
+import { renderWithSWR, fireEvent, screen } from "../../../utils/render-with-swr";
 
-import ConfigRail from "@/components/reports/ConfigRail";
+import DataTab from "@/components/reports/config/DataTab";
+import MeasuresEditor from "@/components/reports/config/MeasuresEditor";
 import { apiFetch } from "@/lib/api";
 import { HELP_TOOLTIPS } from "@/lib/help/tooltips";
 import type { BarWidget, LineWidget } from "@/lib/reports/types";
@@ -53,16 +56,9 @@ function makeLine(): LineWidget {
   };
 }
 
-describe("ConfigRail — help tooltips", () => {
+describe("Widget editor — help tooltips", () => {
   it("renders the aggregation tooltip trigger for a single-measure widget", () => {
-    renderWithSWR(
-      <ConfigRail
-        widget={makeBar()}
-        canvasFilters={{}}
-        onUpdate={() => {}}
-        onClose={() => {}}
-      />,
-    );
+    renderWithSWR(<DataTab widget={makeBar()} onUpdate={() => {}} />);
     // Bar defaults to Sum → the Sum explainer trigger is present.
     expect(
       screen.getByRole("button", {
@@ -74,11 +70,9 @@ describe("ConfigRail — help tooltips", () => {
   it("swaps the aggregation tooltip to match the selected aggregation", () => {
     const updates: BarWidget[] = [];
     renderWithSWR(
-      <ConfigRail
+      <DataTab
         widget={makeBar()}
-        canvasFilters={{}}
         onUpdate={(w) => updates.push(w as BarWidget)}
-        onClose={() => {}}
       />,
     );
     fireEvent.change(screen.getByLabelText("Aggregation"), {
@@ -89,14 +83,7 @@ describe("ConfigRail — help tooltips", () => {
   });
 
   it("renders the master-category explainer next to the dimension label", () => {
-    renderWithSWR(
-      <ConfigRail
-        widget={makeBar()}
-        canvasFilters={{}}
-        onUpdate={() => {}}
-        onClose={() => {}}
-      />,
-    );
+    renderWithSWR(<DataTab widget={makeBar()} onUpdate={() => {}} />);
     // Bar exposes both the Primary dimension and the Break-down (optional)
     // labels, so the master-category explainer renders on each.
     expect(
@@ -107,13 +94,9 @@ describe("ConfigRail — help tooltips", () => {
   });
 
   it("renders a per-series aggregation tooltip for multi-series widgets", () => {
+    const line = makeLine();
     renderWithSWR(
-      <ConfigRail
-        widget={makeLine()}
-        canvasFilters={{}}
-        onUpdate={() => {}}
-        onClose={() => {}}
-      />,
+      <MeasuresEditor widget={line} onChange={() => {}} />,
     );
     // The line series defaults to Distinct count → its explainer shows.
     expect(

--- a/frontend/tests/components/reports/config/filter-editor-override-pill.test.tsx
+++ b/frontend/tests/components/reports/config/filter-editor-override-pill.test.tsx
@@ -1,16 +1,16 @@
 /**
  * Regression: the "Overrides canvas" pill fires when the widget-level
  * filter actually DIFFERS from the canvas-level value (and never when
- * they match). PR2 fixed the equality bug for the comma-list inputs;
- * PR3 swaps those for picker components. The pickers feed the same
- * ``WidgetFilters`` shape — these tests pin the equality semantics
- * survive the swap.
+ * they match). Re-homed from override-pill-pickers onto the extracted
+ * ``FilterEditor``, which owns the override pill and the picker filters.
+ * The pickers feed the same ``WidgetFilters`` shape — these tests pin the
+ * equality semantics survive on the extracted component.
  */
-import { renderWithSWR, fireEvent, screen } from "../../utils/render-with-swr";
+import { renderWithSWR, screen } from "../../../utils/render-with-swr";
 
-import ConfigRail from "@/components/reports/ConfigRail";
+import FilterEditor from "@/components/reports/config/FilterEditor";
 import { apiFetch } from "@/lib/api";
-import type { BarWidget } from "@/lib/reports/types";
+import type { CanvasFilters, WidgetFilters } from "@/lib/reports/types";
 import type { Category, Account } from "@/lib/types";
 
 vi.mock("@/lib/api", () => ({
@@ -57,24 +57,6 @@ const ACCOUNTS: Account[] = [
   },
 ];
 
-function makeWidget(filters: BarWidget["config"]["filters"] = undefined): BarWidget {
-  return {
-    id: "w_bar",
-    type: "bar",
-    title: "Spend by category",
-    grid: { x: 0, y: 0, w: 6, h: 4 },
-    config: {
-      dataset: "transactions",
-      measure: { agg: "sum", field: "amount" },
-      dimensions: ["category"],
-      sort: { by: "value", dir: "desc" },
-      limit: 10,
-      format: "currency",
-      filters,
-    },
-  };
-}
-
 function mockApi() {
   const apiFetchMock = vi.mocked(apiFetch);
   apiFetchMock.mockImplementation((path) => {
@@ -91,6 +73,20 @@ function mockApi() {
   });
 }
 
+function renderEditor(
+  filters: WidgetFilters,
+  canvasFilters: CanvasFilters,
+  onChange: (next: WidgetFilters) => void = () => {},
+) {
+  return renderWithSWR(
+    <FilterEditor
+      filters={filters}
+      canvasFilters={canvasFilters}
+      onChange={onChange}
+    />,
+  );
+}
+
 describe("Override pill — picker-based filters", () => {
   beforeEach(() => {
     vi.mocked(apiFetch).mockReset();
@@ -98,14 +94,7 @@ describe("Override pill — picker-based filters", () => {
   });
 
   it("does NOT show the pill when the widget category selection matches the canvas selection", async () => {
-    renderWithSWR(
-      <ConfigRail
-        widget={makeWidget({ category_ids: [1, 2] })}
-        canvasFilters={{ category_ids: [2, 1] }}
-        onUpdate={() => {}}
-        onClose={() => {}}
-      />,
-    );
+    renderEditor({ category_ids: [1, 2] }, { category_ids: [2, 1] });
 
     // Wait a tick for the SWR fetches to resolve so the picker has
     // populated the tree (pill renders synchronously off the prop
@@ -118,59 +107,32 @@ describe("Override pill — picker-based filters", () => {
   });
 
   it("DOES show the pill when the widget category selection differs from the canvas", async () => {
-    renderWithSWR(
-      <ConfigRail
-        widget={makeWidget({ category_ids: [1] })}
-        canvasFilters={{ category_ids: [2] }}
-        onUpdate={() => {}}
-        onClose={() => {}}
-      />,
-    );
+    renderEditor({ category_ids: [1] }, { category_ids: [2] });
     await screen.findByTestId("category-picker");
     const pills = screen.queryAllByTestId("override-pill");
     expect(pills.length).toBeGreaterThanOrEqual(1);
   });
 
   it("does NOT show the pill when the widget account selection matches the canvas selection", async () => {
-    renderWithSWR(
-      <ConfigRail
-        widget={makeWidget({ account_ids: [1] })}
-        canvasFilters={{ account_ids: [1] }}
-        onUpdate={() => {}}
-        onClose={() => {}}
-      />,
-    );
+    renderEditor({ account_ids: [1] }, { account_ids: [1] });
     await screen.findByTestId("account-filter");
     const pills = screen.queryAllByTestId("override-pill");
     expect(pills.length).toBe(0);
   });
 
-  it("DOES show the pill once the user toggles a different account chip", async () => {
-    const onUpdate = vi.fn();
-    const { rerender } = renderWithSWR(
-      <ConfigRail
-        widget={makeWidget({ account_ids: [1] })}
-        canvasFilters={{ account_ids: [1] }}
-        onUpdate={onUpdate}
-        onClose={() => {}}
-      />,
-    );
+  it("keeps the pill off when widget account_ids is empty (inherit)", async () => {
+    const onChange = vi.fn();
+    const { rerender } = renderEditor({ account_ids: [1] }, { account_ids: [1] }, onChange);
 
     await screen.findByTestId("account-filter");
-    // Deselect the matching account — now widget=[] (inherit, no pill)
-    // and then re-select but with a different list. Simulate the
-    // "different list" case directly by rerendering with the updated
-    // widget value, since picker click → onUpdate flows through the
-    // parent in real use.
+    // Empty widget account_ids means inherit — pill stays off.
     rerender(
-      <ConfigRail
-        widget={makeWidget({ account_ids: [] })}
+      <FilterEditor
+        filters={{ account_ids: [] }}
         canvasFilters={{ account_ids: [1] }}
-        onUpdate={onUpdate}
-        onClose={() => {}}
+        onChange={onChange}
       />,
     );
-    // Empty widget account_ids means inherit — pill stays off.
     expect(screen.queryAllByTestId("override-pill").length).toBe(0);
   });
 });

--- a/frontend/tests/components/reports/config/filter-editor-override-pill.test.tsx
+++ b/frontend/tests/components/reports/config/filter-editor-override-pill.test.tsx
@@ -120,6 +120,13 @@ describe("Override pill — picker-based filters", () => {
     expect(pills.length).toBe(0);
   });
 
+  it("DOES show the pill when the widget account selection differs from the canvas", async () => {
+    renderEditor({ account_ids: [2] }, { account_ids: [1] });
+    await screen.findByTestId("account-filter");
+    const pills = screen.queryAllByTestId("override-pill");
+    expect(pills.length).toBeGreaterThanOrEqual(1);
+  });
+
   it("keeps the pill off when widget account_ids is empty (inherit)", async () => {
     const onChange = vi.fn();
     const { rerender } = renderEditor({ account_ids: [1] }, { account_ids: [1] }, onChange);

--- a/frontend/tests/components/reports/config/measure-editors.test.tsx
+++ b/frontend/tests/components/reports/config/measure-editors.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Single- and multi-series measure editors extracted from ConfigRail.
+ * These pin the onChange payloads and the add/remove/cap behaviour that
+ * downstream tabs (and the old rail) depend on.
+ */
+import { renderWithSWR, fireEvent, screen } from "../../../utils/render-with-swr";
+
+import SingleMeasureEditor from "@/components/reports/config/SingleMeasureEditor";
+import MeasuresEditor from "@/components/reports/config/MeasuresEditor";
+import type {
+  LineWidget,
+  Measure,
+  SeriesConfig,
+  TableWidget,
+} from "@/lib/reports/types";
+
+function makeLine(measures: SeriesConfig[]): LineWidget {
+  return {
+    id: "w_line",
+    type: "line",
+    title: "Line",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: { dataset: "transactions", measures, dimensions: ["month"] },
+  };
+}
+
+function makeTable(measures: SeriesConfig[]): TableWidget {
+  return {
+    id: "w_table",
+    type: "table",
+    title: "Table",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: { dataset: "transactions", measures, dimensions: ["category"] },
+  };
+}
+
+describe("SingleMeasureEditor", () => {
+  it("changing Aggregation reports the new agg, keeping the field", () => {
+    const calls: Measure[] = [];
+    renderWithSWR(
+      <SingleMeasureEditor
+        measure={{ agg: "sum", field: "amount" }}
+        onChange={(m) => calls.push(m)}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Aggregation"), {
+      target: { value: "count" },
+    });
+    expect(calls.at(-1)).toEqual({ agg: "count", field: "amount" });
+  });
+
+  it("changing Field reports the new field, keeping the agg", () => {
+    const calls: Measure[] = [];
+    renderWithSWR(
+      <SingleMeasureEditor
+        measure={{ agg: "sum", field: "amount" }}
+        onChange={(m) => calls.push(m)}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Field"), {
+      target: { value: "id" },
+    });
+    expect(calls.at(-1)).toEqual({ agg: "sum", field: "id" });
+  });
+});
+
+describe("MeasuresEditor", () => {
+  it("appends a default series via measure-add", () => {
+    const calls: SeriesConfig[][] = [];
+    renderWithSWR(
+      <MeasuresEditor
+        widget={makeLine([
+          { measure: { agg: "sum", field: "amount" } },
+          { measure: { agg: "avg", field: "amount" } },
+        ])}
+        onChange={(m) => calls.push(m)}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("measure-add"));
+    expect(calls.at(-1)).toEqual([
+      { measure: { agg: "sum", field: "amount" } },
+      { measure: { agg: "avg", field: "amount" } },
+      { measure: { agg: "sum", field: "amount" } },
+    ]);
+  });
+
+  it("removes a series by index via measure-remove-1", () => {
+    const calls: SeriesConfig[][] = [];
+    renderWithSWR(
+      <MeasuresEditor
+        widget={makeLine([
+          { measure: { agg: "sum", field: "amount" } },
+          { measure: { agg: "avg", field: "amount" } },
+        ])}
+        onChange={(m) => calls.push(m)}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("measure-remove-1"));
+    expect(calls.at(-1)).toEqual([{ measure: { agg: "sum", field: "amount" } }]);
+  });
+
+  it("hides remove when only one series remains", () => {
+    renderWithSWR(
+      <MeasuresEditor
+        widget={makeLine([{ measure: { agg: "sum", field: "amount" } }])}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId("measure-remove-0")).not.toBeInTheDocument();
+  });
+
+  it("hides add once the series cap is reached", () => {
+    const five: SeriesConfig[] = Array.from({ length: 5 }, () => ({
+      measure: { agg: "sum", field: "amount" },
+    }));
+    renderWithSWR(
+      <MeasuresEditor widget={makeLine(five)} onChange={() => {}} />,
+    );
+    expect(screen.queryByTestId("measure-add")).not.toBeInTheDocument();
+  });
+
+  it("labels table rows as Column N and caps at five columns", () => {
+    const five: SeriesConfig[] = Array.from({ length: 5 }, () => ({
+      measure: { agg: "sum", field: "amount" },
+    }));
+    renderWithSWR(
+      <MeasuresEditor widget={makeTable(five)} onChange={() => {}} />,
+    );
+    expect(screen.getByText("Column 1")).toBeInTheDocument();
+    expect(screen.queryByTestId("measure-add")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/reports/config/tabs.test.tsx
+++ b/frontend/tests/components/reports/config/tabs.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * DataTab / StyleTab composers — covers the per-type visibility matrix and
+ * the two verbatim transcription hotspots (the measure cast-and-extract and
+ * the area/stacked_bar stacked label+default split).
+ */
+import { renderWithSWR, fireEvent, screen } from "../../../utils/render-with-swr";
+
+import DataTab from "@/components/reports/config/DataTab";
+import StyleTab from "@/components/reports/config/StyleTab";
+import { apiFetch } from "@/lib/api";
+import type {
+  AreaWidget,
+  BarWidget,
+  KPIWidget,
+  PieWidget,
+  StackedBarWidget,
+  TableWidget,
+  Widget,
+} from "@/lib/reports/types";
+
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(apiFetch).mockReset();
+  vi.mocked(apiFetch).mockImplementation(
+    () => Promise.resolve([]) as Promise<unknown>,
+  );
+});
+
+function makeBar(): BarWidget {
+  return {
+    id: "w_bar",
+    type: "bar",
+    title: "Bar",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+    },
+  };
+}
+
+function makeKpi(): KPIWidget {
+  return {
+    id: "w_kpi",
+    type: "kpi",
+    title: "KPI",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config: { dataset: "transactions", measure: { agg: "sum", field: "amount" } },
+  };
+}
+
+function makePie(): PieWidget {
+  return {
+    id: "w_pie",
+    type: "pie",
+    title: "Pie",
+    grid: { x: 0, y: 0, w: 4, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+    },
+  };
+}
+
+function makeTable(): TableWidget {
+  return {
+    id: "w_table",
+    type: "table",
+    title: "Table",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["category"],
+    },
+  };
+}
+
+function makeArea(stacked?: boolean): AreaWidget {
+  return {
+    id: "w_area",
+    type: "area",
+    title: "Area",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+      ...(stacked === undefined ? {} : { stacked }),
+    },
+  };
+}
+
+function makeStacked(stacked?: boolean): StackedBarWidget {
+  return {
+    id: "w_stacked",
+    type: "stacked_bar",
+    title: "Stacked",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+      ...(stacked === undefined ? {} : { stacked }),
+    },
+  };
+}
+
+function renderData(widget: Widget, onUpdate: (w: Widget) => void = () => {}) {
+  return renderWithSWR(<DataTab widget={widget} onUpdate={onUpdate} />);
+}
+
+function renderStyle(widget: Widget, onUpdate: (w: Widget) => void = () => {}) {
+  return renderWithSWR(<StyleTab widget={widget} onUpdate={onUpdate} />);
+}
+
+describe("DataTab", () => {
+  it("renders single measure + primary + secondary for bar", () => {
+    renderData(makeBar());
+    expect(screen.getByLabelText("Data source")).toBeInTheDocument();
+    expect(screen.getByLabelText("Aggregation")).toBeInTheDocument();
+    expect(screen.getByLabelText("Primary dimension")).toBeInTheDocument();
+    expect(screen.getByLabelText("Break down by")).toBeInTheDocument();
+  });
+
+  it("hides dimensions entirely for kpi", () => {
+    renderData(makeKpi());
+    expect(screen.getByLabelText("Aggregation")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Primary dimension")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Break down by")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Secondary dimension")).not.toBeInTheDocument();
+  });
+
+  it("shows primary but no secondary for pie", () => {
+    renderData(makePie());
+    expect(screen.getByLabelText("Primary dimension")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Secondary dimension")).not.toBeInTheDocument();
+  });
+
+  it("shows MeasuresEditor and a table secondary for table", () => {
+    renderData(makeTable());
+    expect(screen.getByTestId("measure-add")).toBeInTheDocument();
+    expect(screen.getByLabelText("Secondary dimension")).toBeInTheDocument();
+  });
+});
+
+describe("StyleTab", () => {
+  it("renders the title for every type", () => {
+    renderStyle(makeBar());
+    expect(screen.getByLabelText("Widget title")).toBeInTheDocument();
+  });
+
+  it("shows the compare checkbox only for kpi", () => {
+    renderStyle(makeKpi());
+    expect(screen.getByLabelText("Compare to prior period")).toBeInTheDocument();
+  });
+
+  it("shows top_n only for pie", () => {
+    renderStyle(makePie());
+    expect(screen.getByLabelText("Top N slices")).toBeInTheDocument();
+  });
+
+  it("stacked_bar uses the 'Stack mode' label and defaults checked", () => {
+    renderStyle(makeStacked());
+    expect(screen.getByText("Stack mode")).toBeInTheDocument();
+    const cb = screen.getByLabelText("Stack series") as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+  });
+
+  it("stacked_bar with stacked:false is unchecked", () => {
+    renderStyle(makeStacked(false));
+    const cb = screen.getByLabelText("Stack series") as HTMLInputElement;
+    expect(cb.checked).toBe(false);
+  });
+
+  it("area uses the 'Stack series' label and defaults unchecked", () => {
+    renderStyle(makeArea());
+    expect(screen.getByText("Stack series")).toBeInTheDocument();
+    const cb = screen.getByLabelText("Stack series") as HTMLInputElement;
+    expect(cb.checked).toBe(false);
+  });
+
+  it("area with stacked:true is checked", () => {
+    renderStyle(makeArea(true));
+    const cb = screen.getByLabelText("Stack series") as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+  });
+});

--- a/frontend/tests/components/reports/config/useWidgetMutations.test.tsx
+++ b/frontend/tests/components/reports/config/useWidgetMutations.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * The extracted mutation closures must produce the SAME onUpdate payloads
+ * they did inline in ConfigRail. Renders a tiny harness that calls the
+ * setters and records every payload.
+ */
+import { renderWithSWR, fireEvent, screen } from "../../../utils/render-with-swr";
+
+import { useWidgetMutations } from "@/components/reports/config/useWidgetMutations";
+import type { BarWidget, Widget } from "@/lib/reports/types";
+
+function Harness({
+  widget,
+  onUpdate,
+}: {
+  widget: Widget;
+  onUpdate: (next: Widget) => void;
+}) {
+  const m = useWidgetMutations(widget, onUpdate);
+  return (
+    <div>
+      <button onClick={() => m.setTitle("Renamed")}>title</button>
+      <button onClick={() => m.setSecondaryDimension("")}>clear-secondary</button>
+      <button onClick={() => m.setSecondaryDimension("account")}>set-secondary</button>
+    </div>
+  );
+}
+
+function makeBar(): BarWidget {
+  return {
+    id: "w_bar",
+    type: "bar",
+    title: "Bar",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category", "account"],
+    },
+  };
+}
+
+describe("useWidgetMutations", () => {
+  it("setTitle replaces the widget title", () => {
+    const updates: Widget[] = [];
+    renderWithSWR(<Harness widget={makeBar()} onUpdate={(w) => updates.push(w)} />);
+    fireEvent.click(screen.getByText("title"));
+    expect(updates.at(-1)?.title).toBe("Renamed");
+  });
+
+  it("setSecondaryDimension('') splices dimensions[1]", () => {
+    const updates: Widget[] = [];
+    renderWithSWR(<Harness widget={makeBar()} onUpdate={(w) => updates.push(w)} />);
+    fireEvent.click(screen.getByText("clear-secondary"));
+    expect((updates.at(-1) as BarWidget).config.dimensions).toEqual(["category"]);
+  });
+
+  it("setSecondaryDimension('account') sets dimensions[1]", () => {
+    const updates: Widget[] = [];
+    const bar = makeBar();
+    bar.config.dimensions = ["category"];
+    renderWithSWR(<Harness widget={bar} onUpdate={(w) => updates.push(w)} />);
+    fireEvent.click(screen.getByText("set-secondary"));
+    expect((updates.at(-1) as BarWidget).config.dimensions).toEqual([
+      "category",
+      "account",
+    ]);
+  });
+});

--- a/frontend/tests/components/reports/config/useWidgetMutations.test.tsx
+++ b/frontend/tests/components/reports/config/useWidgetMutations.test.tsx
@@ -1,12 +1,22 @@
 /**
  * The extracted mutation closures must produce the SAME onUpdate payloads
  * they did inline in ConfigRail. Renders a tiny harness that calls the
- * setters and records every payload.
+ * setters and records every payload. ``buildWidgetMutations`` is a plain
+ * factory (no React hooks) — the harness invokes it unconditionally per
+ * render, exactly like every real caller.
  */
 import { renderWithSWR, fireEvent, screen } from "../../../utils/render-with-swr";
 
-import { useWidgetMutations } from "@/components/reports/config/useWidgetMutations";
-import type { BarWidget, Widget } from "@/lib/reports/types";
+import { buildWidgetMutations } from "@/components/reports/config/useWidgetMutations";
+import type {
+  AreaWidget,
+  BarWidget,
+  KPIWidget,
+  LineWidget,
+  PieWidget,
+  StackedBarWidget,
+  Widget,
+} from "@/lib/reports/types";
 
 function Harness({
   widget,
@@ -15,17 +25,34 @@ function Harness({
   widget: Widget;
   onUpdate: (next: Widget) => void;
 }) {
-  const m = useWidgetMutations(widget, onUpdate);
+  const m = buildWidgetMutations(widget, onUpdate);
   return (
     <div>
       <button onClick={() => m.setTitle("Renamed")}>title</button>
+      <button onClick={() => m.setPrimaryDimension("account")}>set-primary</button>
       <button onClick={() => m.setSecondaryDimension("")}>clear-secondary</button>
       <button onClick={() => m.setSecondaryDimension("account")}>set-secondary</button>
+      <button onClick={() => m.setComparePrior(true)}>compare-prior</button>
+      <button onClick={() => m.setTopN(12)}>top-n</button>
+      <button onClick={() => m.setStacked(true)}>stacked</button>
+      <button onClick={() => m.setSingleMeasure({ agg: "count", field: "id" })}>
+        single-measure
+      </button>
+      <button
+        onClick={() =>
+          m.setSeries([
+            { measure: { agg: "sum", field: "amount" } },
+            { measure: { agg: "avg", field: "amount" } },
+          ])
+        }
+      >
+        set-series
+      </button>
     </div>
   );
 }
 
-function makeBar(): BarWidget {
+function makeBar(dimensions: BarWidget["config"]["dimensions"] = ["category", "account"]): BarWidget {
   return {
     id: "w_bar",
     type: "bar",
@@ -34,35 +61,171 @@ function makeBar(): BarWidget {
     config: {
       dataset: "transactions",
       measure: { agg: "sum", field: "amount" },
-      dimensions: ["category", "account"],
+      dimensions,
     },
   };
 }
 
-describe("useWidgetMutations", () => {
+function makeKpi(): KPIWidget {
+  return {
+    id: "w_kpi",
+    type: "kpi",
+    title: "KPI",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config: { dataset: "transactions", measure: { agg: "sum", field: "amount" } },
+  };
+}
+
+function makePie(): PieWidget {
+  return {
+    id: "w_pie",
+    type: "pie",
+    title: "Pie",
+    grid: { x: 0, y: 0, w: 4, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+    },
+  };
+}
+
+function makeArea(): AreaWidget {
+  return {
+    id: "w_area",
+    type: "area",
+    title: "Area",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+    },
+  };
+}
+
+function makeStacked(): StackedBarWidget {
+  return {
+    id: "w_stacked",
+    type: "stacked_bar",
+    title: "Stacked",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+    },
+  };
+}
+
+function makeLine(): LineWidget {
+  return {
+    id: "w_line",
+    type: "line",
+    title: "Line",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+    },
+  };
+}
+
+function renderHarness(widget: Widget) {
+  const updates: Widget[] = [];
+  renderWithSWR(<Harness widget={widget} onUpdate={(w) => updates.push(w)} />);
+  return updates;
+}
+
+describe("buildWidgetMutations", () => {
   it("setTitle replaces the widget title", () => {
-    const updates: Widget[] = [];
-    renderWithSWR(<Harness widget={makeBar()} onUpdate={(w) => updates.push(w)} />);
+    const updates = renderHarness(makeBar());
     fireEvent.click(screen.getByText("title"));
     expect(updates.at(-1)?.title).toBe("Renamed");
   });
 
+  it("setPrimaryDimension overwrites dimensions[0]", () => {
+    const updates = renderHarness(makeBar(["category", "tag"]));
+    fireEvent.click(screen.getByText("set-primary"));
+    expect((updates.at(-1) as BarWidget).config.dimensions).toEqual([
+      "account",
+      "tag",
+    ]);
+  });
+
   it("setSecondaryDimension('') splices dimensions[1]", () => {
-    const updates: Widget[] = [];
-    renderWithSWR(<Harness widget={makeBar()} onUpdate={(w) => updates.push(w)} />);
+    const updates = renderHarness(makeBar());
     fireEvent.click(screen.getByText("clear-secondary"));
     expect((updates.at(-1) as BarWidget).config.dimensions).toEqual(["category"]);
   });
 
   it("setSecondaryDimension('account') sets dimensions[1]", () => {
-    const updates: Widget[] = [];
-    const bar = makeBar();
-    bar.config.dimensions = ["category"];
-    renderWithSWR(<Harness widget={bar} onUpdate={(w) => updates.push(w)} />);
+    const updates = renderHarness(makeBar(["category"]));
     fireEvent.click(screen.getByText("set-secondary"));
     expect((updates.at(-1) as BarWidget).config.dimensions).toEqual([
       "category",
       "account",
     ]);
+  });
+
+  it("setComparePrior toggles the KPI compare flag", () => {
+    const updates = renderHarness(makeKpi());
+    fireEvent.click(screen.getByText("compare-prior"));
+    expect((updates.at(-1) as KPIWidget).config.compare_prior_period).toBe(true);
+  });
+
+  it("setComparePrior is a no-op on a non-KPI widget", () => {
+    const updates = renderHarness(makeBar());
+    fireEvent.click(screen.getByText("compare-prior"));
+    expect(updates).toHaveLength(0);
+  });
+
+  it("setTopN sets the pie top_n", () => {
+    const updates = renderHarness(makePie());
+    fireEvent.click(screen.getByText("top-n"));
+    expect((updates.at(-1) as PieWidget).config.top_n).toBe(12);
+  });
+
+  it("setStacked sets the stacked flag on area", () => {
+    const updates = renderHarness(makeArea());
+    fireEvent.click(screen.getByText("stacked"));
+    expect((updates.at(-1) as AreaWidget).config.stacked).toBe(true);
+  });
+
+  it("setStacked sets the stacked flag on stacked_bar", () => {
+    const updates = renderHarness(makeStacked());
+    fireEvent.click(screen.getByText("stacked"));
+    expect((updates.at(-1) as StackedBarWidget).config.stacked).toBe(true);
+  });
+
+  it("setSingleMeasure replaces the measure on a single-series widget", () => {
+    const updates = renderHarness(makeBar());
+    fireEvent.click(screen.getByText("single-measure"));
+    expect((updates.at(-1) as BarWidget).config.measure).toEqual({
+      agg: "count",
+      field: "id",
+    });
+  });
+
+  it("setSingleMeasure is a no-op on a multi-series widget", () => {
+    const updates = renderHarness(makeLine());
+    fireEvent.click(screen.getByText("single-measure"));
+    expect(updates).toHaveLength(0);
+  });
+
+  it("setSeries replaces the measures on a multi-series widget", () => {
+    const updates = renderHarness(makeLine());
+    fireEvent.click(screen.getByText("set-series"));
+    expect((updates.at(-1) as LineWidget).config.measures).toEqual([
+      { measure: { agg: "sum", field: "amount" } },
+      { measure: { agg: "avg", field: "amount" } },
+    ]);
+  });
+
+  it("setSeries is a no-op on a single-series widget", () => {
+    const updates = renderHarness(makeBar());
+    fireEvent.click(screen.getByText("set-series"));
+    expect(updates).toHaveLength(0);
   });
 });

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -80,3 +80,12 @@ vi.mock("@/components/notifications/NotificationBell", () => ({
 vi.mock("@/lib/hooks/use-ai-status", () => ({
   useAiStatus: () => undefined,
 }));
+
+// floating-ui's autoUpdate calls ResizeObserver; jsdom 26 has none.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}

--- a/specs/2026-06-12-reports-v3-phase4a-popover-plan.md
+++ b/specs/2026-06-12-reports-v3-phase4a-popover-plan.md
@@ -1,0 +1,701 @@
+# Reports v3 Phase 4a — Widget Editor Popover (TDD Implementation Plan)
+
+Date: 2026-06-12
+Author: frontend architect
+Status: ready to implement (subagent-driven, single coherent PR)
+
+---
+
+## Goal
+
+Replace the 320 px right-hand `ConfigRail` sidebar with an **anchored floating
+popover** that floats *over* the canvas, anchored to the selected widget's DOM
+element. The popover must NOT consume flex width, so the canvas no longer
+reflows (narrows / re-clamps RGL columns) when a widget is selected. This
+reflow is the concrete bug being fixed: today
+`app/reports/[id]/page.tsx` mounts `<ConfigRail>` as a flex sibling
+(`flex-1` canvas column + `w-80 shrink-0` rail), so selecting a widget
+shrinks the canvas from full width and RGL re-clamps to a narrower
+breakpoint.
+
+The popover reorganizes the **exact same controls** into **3 tabs
+(Data · Filters · Style)** so a long scroll is avoided. This is a
+**re-housing + reorganization, not a logic rewrite**: every existing
+`onUpdate(nextWidget)` mutation in `ConfigRail` is preserved verbatim by
+extracting `ConfigRail`'s sub-blocks into reusable pieces the popover
+composes.
+
+## Architecture
+
+```
+app/reports/[id]/page.tsx
+  editModeActive && selectedWidget
+    → renders <WidgetEditorPopover>  (NOT in the flex row; portaled)
+    → passes the selected widget's anchor element (a ref/getter) so
+      floating-ui can position against it
+
+components/reports/
+  WidgetEditorPopover.tsx        NEW — floating-ui shell + 3-tab frame
+  config/
+    DataTab.tsx                  NEW — source + measure(s) + dimensions
+    StyleTab.tsx                 NEW — title + widget-specific knobs + format
+    FilterEditor.tsx             NEW — EXTRACTED verbatim from ConfigRail
+    MeasuresEditor.tsx           NEW — EXTRACTED verbatim from ConfigRail
+    SingleMeasureEditor.tsx      NEW — EXTRACTED verbatim from ConfigRail
+    controlConstants.ts          NEW — AGG_OPTIONS / FIELD_OPTIONS / DIMENSION_OPTIONS / helpers
+  WidgetShell.tsx                MODIFIED — expose the shell DOM node to the page for anchoring
+  Canvas.tsx                     UNCHANGED (must not reflow)
+  CanvasFiltersBar.tsx           UNCHANGED (filter model frozen in 4a)
+  ConfigRail.tsx                 DELETED (its logic moves into the extracted pieces + tabs)
+```
+
+The popover owns: positioning (`useFloating` + `autoUpdate`), dismissal
+(`useDismiss` outside-click + Escape), focus management
+(`FloatingFocusManager`), the `role`/`aria` contract (`useRole`), tab state,
+and which tabs/sub-controls a given widget type shows. It delegates every
+*mutation* to the extracted control components, which call the page's
+existing `updateWidget` (via the `onUpdate` prop) untouched.
+
+## Tech Stack
+
+- **NEW dep:** `@floating-ui/react` (latest). Confirmed absent today —
+  `frontend/package.json` has no `@floating-ui/*`, no `@radix-ui/*`, no
+  `@headlessui/*`. Provides `useFloating`, `autoUpdate`, `offset`, `flip`,
+  `shift`, `useDismiss`, `useRole`, `useInteractions`, `FloatingPortal`,
+  `FloatingFocusManager`.
+- Existing: React 19, Next 16 App Router, Tailwind v4 (theme tokens only —
+  `No Off-Token` rule), `lucide-react`, vitest 3 + jsdom + Testing Library.
+- Test harness: `renderWithSWR` from `tests/utils/render-with-swr.tsx`
+  (re-exports `screen`, `fireEvent`, `waitFor`, `within`, `act`).
+
+---
+
+## Non-goals (deferred to Phase 4b — DO NOT do in 4a)
+
+These are explicitly **out of scope** and must be left exactly as today:
+
+1. **Filter model is frozen.** Canvas filters stay `date_range` +
+   `account_ids` + `category_ids` (`CanvasFiltersBar.tsx`); per-widget
+   overrides stay the full `WidgetFilters` shape; the cascade in
+   `lib/reports/resolve.ts` is untouched. Do NOT change `resolveFilters` /
+   `isFieldOverridden`.
+2. **Do NOT shrink the canvas toolbar to date-only.** `CanvasFiltersBar`
+   keeps all three controls.
+3. **Do NOT add canvas filter chips.** The "active filter pills" toolbar is 4b.
+4. **No source/dataset widening.** The "Data source" select stays a
+   *disabled* `Transactions` select exactly as today (enum widening is
+   Phase 5).
+5. **No auto-save.** Explicit Save semantics (`handleSave`) are preserved.
+6. **No new widget knobs** beyond the ones ConfigRail already renders.
+
+4a is **popover + control re-housing + reflow fix ONLY.**
+
+---
+
+## File Structure
+
+### New files
+
+| File | Purpose |
+| --- | --- |
+| `components/reports/WidgetEditorPopover.tsx` | floating-ui shell, 3-tab frame, a11y wiring, tab-visibility-by-widget-type logic |
+| `components/reports/config/controlConstants.ts` | `AGG_OPTIONS`, `AGG_HELP_KEY`, `FIELD_OPTIONS`, `DIMENSION_OPTIONS`, `MAX_SERIES`, `MAX_TABLE_COLUMNS`, `isMultiSeries`, `isSingleAggLocked` — lifted verbatim from `ConfigRail.tsx` |
+| `components/reports/config/SingleMeasureEditor.tsx` | extracted `SingleMeasureEditor` (Aggregation + Field selects) |
+| `components/reports/config/MeasuresEditor.tsx` | extracted `MeasuresEditor` (multi-series add/remove rows) |
+| `components/reports/config/FilterEditor.tsx` | extracted `FilterEditor` + `TxnTypeRadioRow` + `OverridePill` (verbatim) |
+| `components/reports/config/DataTab.tsx` | composes source select + measure editor + primary/secondary dimension selects |
+| `components/reports/config/StyleTab.tsx` | composes title input + KPI compare / Pie top_n / Area+StackedBar stacked / Line smooth / format select |
+| `tests/components/reports/WidgetEditorPopover.test.tsx` | popover behavior: tab switching, per-type tab/control visibility, dismiss/Escape, a11y, anchoring smoke |
+| `tests/components/reports/config/FilterEditor.test.tsx` | extracted-filter parity: override pill, all six filter fields wired |
+| `tests/components/reports/config/measure-editors.test.tsx` | single + multi-series measure mutation parity |
+
+### Modified files
+
+| File | Change |
+| --- | --- |
+| `app/reports/[id]/page.tsx` | remove `<ConfigRail>` from the `flex flex-1` row; the canvas column becomes the *only* flex child (no width steal). Mount `<WidgetEditorPopover>` outside the flex row, pass the selected widget's anchor element. Update `import`. |
+| `components/reports/WidgetShell.tsx` | accept an optional `onShellRef`/`anchorRef` (or keep the existing `data-widget-shell={id}` attribute as the anchor selector — see Task 5) so the page can resolve the selected widget's DOM node. |
+| `package.json` | add `@floating-ui/react` to `dependencies` |
+| `package-lock.json` | regenerate (via the frontend container) |
+| `tests/app/reports-editor-page.test.tsx` | update every `config-rail` reference (lines ~236-238, ~390-394, ~902). These break and MUST be migrated to the popover testid. Add a **reflow-invariance** test (canvas container width unaffected on open). |
+| `ConfigRail.tsx` | **DELETE** after extraction is complete and all references move. |
+
+### ConfigRail control inventory (what must be preserved)
+
+Every control below currently lives in `ConfigRail.tsx` and its
+`onUpdate(nextWidget)` logic must be carried over **unchanged**:
+
+| Control | ConfigRail fn | Tab in 4a | Widget types |
+| --- | --- | --- | --- |
+| Title input | `setTitle` | **Style** | all |
+| Data source (disabled `Transactions`) | none (disabled) | **Data** | all |
+| Single measure: Aggregation + Field | `setSingleMeasure` via `SingleMeasureEditor` | **Data** | kpi, bar, pie, sparkline |
+| Multi-series: per-series label/agg/field + Add/Remove (cap 5; table cap 5 cols) | `setSeries` via `MeasuresEditor` | **Data** | line, area, stacked_bar, table |
+| Primary dimension select | `setPrimaryDimension` | **Data** | all except kpi |
+| Secondary dimension select ("Break down by" / "Secondary dimension") | `setSecondaryDimension` | **Data** | bar, table only |
+| KPI "Compare to prior period" checkbox | `setComparePrior` | **Style** | kpi |
+| Pie "Top N slices" number | `setTopN` | **Style** | pie |
+| Area/StackedBar "Stack series" checkbox | `setStacked` | **Style** | area, stacked_bar |
+| FilterEditor (date/accounts/categories/txn_type/amount_range/tags + override pills) | `setFilters` | **Filters** | all |
+
+> **Deviation flagged (read the Self-Review + final report):** ConfigRail does
+> **NOT** currently render a `Line.smooth` toggle nor a `format` select, even
+> though both exist in the type model (`LineConfig.smooth`,
+> `*.format`). The instructions list "Line smooth" and "format" as Style knobs.
+> **Decision:** to keep 4a a strict re-housing with zero new behavior, port
+> ONLY the controls ConfigRail renders today. `Line.smooth` and `format`
+> selects are **NOT added in 4a** (they would be new logic / new knobs, which
+> the non-goals forbid). They are noted as a fast-follow. The Style tab is
+> still correct: it shows title + whatever per-type knob(s) ConfigRail had.
+
+---
+
+## Floating-UI wiring (the genuinely new/tricky part)
+
+`WidgetEditorPopover` props:
+
+```ts
+interface Props {
+  widget: Widget;
+  canvasFilters: CanvasFilters;
+  anchorEl: HTMLElement | null;   // the selected widget's shell DOM node
+  onUpdate: (next: Widget) => void;
+  onClose: () => void;
+}
+```
+
+Core hook setup:
+
+```tsx
+import {
+  useFloating, autoUpdate, offset, flip, shift,
+  useDismiss, useRole, useInteractions,
+  FloatingPortal, FloatingFocusManager,
+} from "@floating-ui/react";
+
+const { refs, floatingStyles, context } = useFloating({
+  open: true,                     // mounted only while a widget is selected
+  onOpenChange: (next) => { if (!next) onClose(); },
+  placement: "right-start",       // flips to left/bottom via middleware when clipped
+  middleware: [offset(8), flip({ padding: 8 }), shift({ padding: 8 })],
+  whileElementsMounted: autoUpdate, // reposition on scroll/resize/widget-move
+});
+
+// Anchor to the selected widget element (external reference element).
+useEffect(() => {
+  refs.setReference(anchorEl);
+}, [anchorEl, refs]);
+
+const dismiss = useDismiss(context, {
+  outsidePress: true,             // close on outside-click
+  escapeKey: true,                // close on Escape
+});
+const role = useRole(context, { role: "dialog" });
+const { getFloatingProps } = useInteractions([dismiss, role]);
+```
+
+Render with portal + focus trap:
+
+```tsx
+return (
+  <FloatingPortal>
+    <FloatingFocusManager context={context} modal={false} initialFocus={-1}>
+      <div
+        ref={refs.setFloating}
+        style={floatingStyles}
+        {...getFloatingProps()}
+        data-testid="widget-editor-popover"
+        role="dialog"
+        aria-label="Widget settings"
+        className="z-50 flex max-h-[80vh] w-80 flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-lg"
+      >
+        {/* header (title + Close), tablist, active tab panel */}
+      </div>
+    </FloatingFocusManager>
+  </FloatingPortal>
+);
+```
+
+Key points for the implementer:
+
+- **`modal={false}`** so the popover doesn't trap the whole page (the user can
+  still see/scroll the canvas behind it). Focus is still *managed* — initial
+  focus and Escape/return work — without a hard modal trap, matching the
+  non-blocking menu pattern in `OverflowMenu.tsx`.
+- **Anchor via `refs.setReference(anchorEl)`**, NOT a trigger ref. The
+  reference element is the *selected widget shell*, resolved by the page (see
+  Task 5). When `anchorEl` is `null` the popover should not render (page
+  already gates on `selectedWidget`, but guard anyway).
+- **`autoUpdate`** (via `whileElementsMounted`) keeps the popover glued to the
+  widget as the user scrolls the canvas, resizes the window, or drags the
+  widget. This is what makes "anchored, floats over" feel correct.
+- **No canvas reflow:** the popover is in a `FloatingPortal` (renders at the
+  document body, `position: fixed`/absolute via `floatingStyles`), so it is
+  never a flex sibling of the canvas. This is the structural fix.
+
+### jsdom test handling for floating-ui
+
+floating-ui calls `getBoundingClientRect` / `ResizeObserver` /
+`requestAnimationFrame`; jsdom returns zeros and lacks `ResizeObserver`.
+Strategy (mirrors how `Canvas` is stubbed in the existing editor test):
+
+- In `WidgetEditorPopover.test.tsx`, provide a `ResizeObserver` polyfill in a
+  `beforeEach` (`global.ResizeObserver = class { observe(){} unobserve(){}
+  disconnect(){} }`). jsdom 26 has no `ResizeObserver`.
+- Do **not** assert pixel coordinates in jsdom (they'll be 0). Assert
+  structure/behavior instead: the popover renders, the right tab panel shows,
+  Escape closes, outside-press closes, `role="dialog"` + `aria-label` present,
+  tab `aria-selected` toggles.
+- `FloatingPortal` renders into `document.body`; query with `screen.*` (which
+  searches the whole document), not `within(container)`.
+- For the **page-level reflow test**, stub the popover's positioning is not
+  needed — assert the *canvas container* width/structure is unchanged. Since
+  the editor test already mocks `@/components/reports/Canvas`, the cleanest
+  assertion is: the canvas column is the sole flex child and no `w-80` rail
+  sibling exists when the popover is open (see Task 8).
+
+---
+
+## TDD Task Breakdown
+
+> **Single PR.** 4a is large but cohesive; it lands as ONE PR. Internal
+> ordering below keeps each step independently testable. Run the **full**
+> vitest suite (not single files) before opening the PR (project rule —
+> see `reference_frontend_full_suite_verification.md`).
+>
+> Commands (run inside the frontend container; for parallel-agent sessions use
+> an isolated compose project per CLAUDE.md):
+> - Single file: `docker compose exec -T frontend npx vitest run <path>`
+> - Full suite: `docker compose exec -T frontend npx vitest run`
+> - Type-check: `docker compose exec -T frontend npx tsc --noEmit`
+
+Commit after each task (no AI attribution in messages per user rule).
+
+---
+
+### Task 1 — Add the `@floating-ui/react` dependency
+
+**Files:** `package.json`, `package-lock.json`
+
+No test (dependency-only). Verification is install + import resolves.
+
+1. Add `"@floating-ui/react": "^0.27.0"` (or current latest) to
+   `dependencies` in `package.json`.
+2. Regenerate the lockfile **inside the container** so the platform-correct
+   tree lands:
+   `docker compose exec -T frontend npm install`
+   (this updates `package-lock.json`; commit both files).
+3. **Rebuild note:** the dev image COPYs `package.json`/lockfile but a running
+   container won't have the new dep until rebuilt:
+   `docker compose up --build -d frontend`. (See
+   `reference_dockerfile_dev_install.md` / dev-unmounted-files gotcha — a
+   stale image will fail `import` resolution locally while CI is green.)
+4. Verify: `docker compose exec -T frontend node -e "require.resolve('@floating-ui/react')"`.
+
+**Commit:** `build(reports): add @floating-ui/react for widget editor popover`
+
+---
+
+### Task 2 — Extract control constants + helpers (no behavior change)
+
+**Files:** `components/reports/config/controlConstants.ts` (new)
+
+**Failing test:** none required (pure constant move); covered transitively by
+Task 3/4 tests. Optionally add a trivial `tests/components/reports/config/controlConstants.test.ts`
+asserting `DIMENSION_OPTIONS.length === 9` and `AGG_OPTIONS.length === 4` to
+lock the move.
+
+**Implement:** copy verbatim from `ConfigRail.tsx`:
+`AGG_OPTIONS`, `AGG_HELP_KEY`, `FIELD_OPTIONS` (built from
+`MEASURE_FIELD_LABELS` in `lib/reports/series.ts`), `DIMENSION_OPTIONS`,
+`MAX_SERIES`, `MAX_TABLE_COLUMNS`, `isMultiSeries`, `isSingleAggLocked`.
+Export each. Keep the `HelpTooltipKey` typing.
+
+**Run-to-pass:** `docker compose exec -T frontend npx tsc --noEmit`
+
+**Commit:** `refactor(reports): extract widget-config control constants`
+
+---
+
+### Task 3 — Extract measure editors (single + multi-series)
+
+**Files:** `components/reports/config/SingleMeasureEditor.tsx`,
+`components/reports/config/MeasuresEditor.tsx` (both new),
+`tests/components/reports/config/measure-editors.test.tsx` (new)
+
+**Failing test first** (`measure-editors.test.tsx`):
+- `SingleMeasureEditor`: rendering a measure `{agg:"sum",field:"amount"}`,
+  changing the **Aggregation** select to `count` calls `onChange` with
+  `{agg:"count",field:"amount"}`; changing **Field** to `id` calls with
+  `{agg:"sum",field:"id"}`. Query by the existing `aria-label="Aggregation"` /
+  `"Field"`.
+- `MeasuresEditor`: with a `line` widget (2 series), `data-testid="measure-add"`
+  appends a `{measure:{agg:"sum",field:"amount"}}` row; `measure-remove-1`
+  removes index 1; remove is hidden when only one series; cap respected at
+  `MAX_SERIES`; a `table` widget caps at `MAX_TABLE_COLUMNS` and labels rows
+  "Column N".
+
+Run-to-fail: `docker compose exec -T frontend npx vitest run tests/components/reports/config/measure-editors.test.tsx`
+
+**Implement:** move `SingleMeasureEditor` and `MeasuresEditor` verbatim from
+`ConfigRail.tsx` into their own files, importing from `controlConstants.ts`
+and reusing the same `Section`/`HelpTooltip` markup. Keep all `data-testid`s
+(`measure-row-N`, `measure-add`, `measure-remove-N`) and `aria-label`s
+identical — downstream tests and parity depend on them.
+
+Run-to-pass: same vitest path, then `npx tsc --noEmit`.
+
+**Commit:** `refactor(reports): extract single/multi-series measure editors`
+
+---
+
+### Task 4 — Extract FilterEditor verbatim
+
+**Files:** `components/reports/config/FilterEditor.tsx` (new — includes
+`FilterEditor`, `TxnTypeRadioRow`, `OverridePill`),
+`tests/components/reports/config/FilterEditor.test.tsx` (new)
+
+**Failing test first** (`FilterEditor.test.tsx`):
+- Renders all six fields: Date range (`DatePresetChips`), Accounts
+  (`AccountFilter`), Categories (`CategoryPicker`), Transaction type radios,
+  Amount min/max (`aria-label="Widget amount min"` / `"...max"`), Tags
+  (`TagFilter`).
+- **Override pill parity:** given widget `filters.date_range` differing from
+  `canvasFilters.date_range`, `data-testid="override-pill"` renders next to the
+  Date range label (drives through `isFieldOverridden` from `resolve.ts` —
+  do NOT reimplement it).
+- Changing amount min calls `onChange` with the merged `amount_range`.
+
+> Mock `AccountFilter`/`CategoryPicker`/`TagFilter`/`DatePresetChips` if they
+> fetch on mount (AccountFilter/CategoryPicker hit the org API). The existing
+> editor test renders the full page without mocking these, so they're
+> jsdom-safe; prefer rendering them real first and only mock if a fetch throws.
+
+Run-to-fail: `docker compose exec -T frontend npx vitest run tests/components/reports/config/FilterEditor.test.tsx`
+
+**Implement:** move `FilterEditor`, `TxnTypeRadioRow`, `OverridePill` verbatim.
+Keep `isFieldOverridden` import from `@/lib/reports/resolve`. No logic change.
+
+Run-to-pass + `tsc --noEmit`.
+
+**Commit:** `refactor(reports): extract per-widget FilterEditor`
+
+---
+
+### Task 5 — Expose the widget shell DOM node for anchoring
+
+**Files:** `components/reports/WidgetShell.tsx`, `app/reports/[id]/page.tsx`
+(read path only here), test added in Task 8.
+
+**Decision (anchor mechanism):** `WidgetShell` already renders
+`data-widget-shell={widgetId}` on its root `div`. The simplest, lowest-risk
+anchor is to resolve the selected widget's node by that attribute in the page:
+
+```ts
+const anchorEl = selectedWidgetId
+  ? (document.querySelector(`[data-widget-shell="${selectedWidgetId}"]`) as HTMLElement | null)
+  : null;
+```
+
+Compute it in an effect/state so it updates after the widget mounts and after
+re-selection. To make this robust against re-render timing, store it in state
+set from a `useEffect` keyed on `selectedWidgetId` + `layout.widgets`:
+
+```ts
+const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+useEffect(() => {
+  if (!editModeActive || !selectedWidgetId) { setAnchorEl(null); return; }
+  setAnchorEl(
+    document.querySelector(`[data-widget-shell="${selectedWidgetId}"]`) as HTMLElement | null,
+  );
+}, [editModeActive, selectedWidgetId, layout.widgets]);
+```
+
+> Rationale: avoids threading a ref callback through `Canvas`'s
+> `renderWidget` → `WidgetShell` plumbing (which would touch the frozen
+> `Canvas` contract). `data-widget-shell` already exists for exactly this
+> kind of lookup. If a later phase needs sub-pixel precision, switch to a ref
+> callback on `WidgetShell` then; for 4a the attribute query is sufficient and
+> keeps `Canvas` untouched.
+
+**WidgetShell change:** add `aria-expanded` + `aria-haspopup="dialog"` to the
+selectable root (or to a future explicit trigger) so the selected widget
+announces it controls a dialog (a11y must-flag #5). Set
+`aria-expanded={selected}` on the shell root and keep `onClick={onSelect}`.
+
+No standalone test here (covered by Task 8). `tsc --noEmit` must pass.
+
+**Commit:** `feat(reports): expose widget shell node + aria for popover anchor`
+
+---
+
+### Task 6 — Data + Style tab composers
+
+**Files:** `components/reports/config/DataTab.tsx`,
+`components/reports/config/StyleTab.tsx` (new). Tested via the popover test
+(Task 7), but a focused tab unit test is encouraged.
+
+**Implement `DataTab`** — composes, using `widget` + `onUpdate`:
+- Data source: disabled `Transactions` select (verbatim from ConfigRail).
+- Measures: `isMultiSeries(widget) ? <MeasuresEditor> : <SingleMeasureEditor>`
+  wired to `setSeries` / `setSingleMeasure` (port these mutation fns from
+  ConfigRail into `DataTab` or a shared `useWidgetMutations(widget,onUpdate)`
+  helper — see note below).
+- Primary dimension select (hidden for `kpi`), `setPrimaryDimension`.
+- Secondary dimension select (only `bar`/`table`), `setSecondaryDimension`.
+
+**Implement `StyleTab`** — composes:
+- Title input (`setTitle`).
+- KPI: compare_prior_period checkbox (`setComparePrior`).
+- Pie: top_n number (`setTopN`).
+- Area/StackedBar: stacked checkbox (`setStacked`).
+- (NOT Line.smooth / format — see deviation note above.)
+
+> **Mutation-fn placement:** the `setTitle/setSingleMeasure/setSeries/
+> setPrimaryDimension/setSecondaryDimension/setComparePrior/setTopN/setStacked/
+> setFilters` closures are currently local to `ConfigRail`. Port them into a
+> small shared hook `useWidgetMutations(widget, onUpdate)` in
+> `components/reports/config/useWidgetMutations.ts` (NEW, optional 9th file)
+> OR inline them per-tab. Hook is preferred: one home, identical logic, both
+> tabs + the filter tab consume it. Either way the bodies are **copied
+> verbatim** — no logic change.
+
+`tsc --noEmit` must pass.
+
+**Commit:** `feat(reports): add Data and Style tab composers for widget editor`
+
+---
+
+### Task 7 — WidgetEditorPopover shell (floating-ui + tabs + a11y)
+
+**Files:** `components/reports/WidgetEditorPopover.tsx` (new),
+`tests/components/reports/WidgetEditorPopover.test.tsx` (new)
+
+**Failing test first** (`WidgetEditorPopover.test.tsx`), with the
+`ResizeObserver` polyfill in `beforeEach`:
+
+1. Renders `data-testid="widget-editor-popover"` with `role="dialog"` and
+   `aria-label="Widget settings"` when given a non-null `anchorEl`
+   (use `document.createElement("div")` appended to body as the anchor).
+2. **Default tab = Data:** the Data panel (data-source select + measure
+   controls) is visible; Filters/Style panels are not.
+3. **Tablist a11y:** three tabs with `role="tab"`, the active tab has
+   `aria-selected="true"`, tabpanels labelled via `aria-labelledby`. Clicking
+   "Filters" shows the FilterEditor; clicking "Style" shows the title input.
+4. **Per-type visibility:**
+   - `kpi`: Data tab shows measure + source but **no** primary/secondary
+     dimension; Style shows compare checkbox.
+   - `pie`/`sparkline`: single measure, primary dimension present, **no**
+     secondary dimension; Style shows top_n only for pie.
+   - `bar`: primary + secondary ("Break down by") dimension; Style has none of
+     the type knobs.
+   - `line`/`area`/`stacked_bar`/`table`: `MeasuresEditor` (add/remove);
+     `table`+`bar` show secondary dimension; area/stacked_bar show "Stack
+     series" in Style.
+5. **Dismiss:** pressing `Escape` calls `onClose`; clicking outside the
+   popover (mousedown on `document.body`) calls `onClose`.
+6. **aria-expanded** is asserted at the page level (Task 8), not here.
+
+Run-to-fail: `docker compose exec -T frontend npx vitest run tests/components/reports/WidgetEditorPopover.test.tsx`
+
+**Implement:** the floating-ui shell exactly as in the "Floating-UI wiring"
+section. Header: `<h2>Widget settings</h2>` + a `Close` button
+(`onClick={onClose}`) mirroring ConfigRail's header. Tablist:
+
+```tsx
+const [tab, setTab] = useState<"data" | "filters" | "style">("data");
+// role="tablist" with three role="tab" buttons; arrow-key roving optional
+// for 4a (Tab/click is enough), but wire aria-selected + aria-controls +
+// id/aria-labelledby on each tab/panel pair.
+```
+
+Tab panels:
+- Data → `<DataTab widget onUpdate />`
+- Filters → `<FilterEditor filters={widget.config.filters ?? {}} canvasFilters onChange={setFilters} />`
+- Style → `<StyleTab widget onUpdate />`
+
+Per-type sub-control visibility lives inside `DataTab`/`StyleTab` (they already
+branch on `widget.type`); the popover just always renders all three tabs (each
+tab is meaningful for every type: Data always has source+measure, Filters
+always applies, Style always has title).
+
+Run-to-pass + `tsc --noEmit`.
+
+**Commit:** `feat(reports): widget editor popover shell with tabs and a11y`
+
+---
+
+### Task 8 — Wire the popover into the page + delete ConfigRail + reflow test
+
+**Files:** `app/reports/[id]/page.tsx`,
+`tests/app/reports-editor-page.test.tsx`, delete `ConfigRail.tsx`.
+
+**Failing tests first** (update + add in `reports-editor-page.test.tsx`):
+
+a. **Migrate the three `config-rail` references** to
+   `widget-editor-popover`:
+   - "adds a KPI widget…" (~line 236): after adding a KPI it's selected →
+     assert `screen.getByTestId("widget-editor-popover")` instead of
+     `config-rail`.
+   - "shows the 'Overrides canvas' pill…" (~line 390): after selecting the
+     widget, the popover mounts; **switch to the Filters tab** before asserting
+     `override-pill` (the pill now lives in the Filters tab, not an
+     always-visible rail). Add `fireEvent.click(screen.getByRole("tab",
+     {name:/filters/i}))`.
+   - "after a successful save lands on the read-only view…" (~line 902):
+     `queryByTestId("config-rail")` → `queryByTestId("widget-editor-popover")`
+     must be null in view mode.
+
+b. **NEW reflow-invariance test** — "opening the widget editor popover does
+   not reflow the canvas":
+   - Load `REPORT_WITH_WIDGET`, enter edit mode, capture the canvas column.
+     Because the canvas is mocked (no real width), assert *structure* not
+     pixels: the flex row (`report-editor`'s inner `flex flex-1` container) has
+     exactly **one** flex child (the canvas column) both before and after the
+     widget is selected — i.e. selecting a widget does NOT insert a `w-80`
+     sibling. Concretely:
+     - Give the canvas column a stable testid (add `data-testid="report-canvas-column"`
+       to the `flex-1` div in `page.tsx`).
+     - Before select: `report-canvas-column` is the only element-child of the
+       flex row.
+     - Click the widget → `widget-editor-popover` appears (in the portal,
+       i.e. NOT inside `report-canvas-column`).
+     - After select: `report-canvas-column` is **still** the only
+       element-child of the flex row (the popover is portaled to body, not a
+       sibling). This is the regression guard for the reflow bug.
+
+Run-to-fail: `docker compose exec -T frontend npx vitest run tests/app/reports-editor-page.test.tsx`
+
+**Implement `page.tsx` changes:**
+1. Replace `import ConfigRail` with
+   `import WidgetEditorPopover from "@/components/reports/WidgetEditorPopover";`
+2. Add the `anchorEl` state + effect from Task 5.
+3. In the `flex flex-1 overflow-hidden` row: keep ONLY the canvas column
+   (`flex-1 overflow-y-auto …`), add `data-testid="report-canvas-column"`.
+   **Remove the `{editModeActive && selectedWidget && (<ConfigRail …/>)}`
+   block from inside the flex row.**
+4. After the flex row (sibling, still inside `report-editor`), mount:
+   ```tsx
+   {editModeActive && selectedWidget && anchorEl && (
+     <WidgetEditorPopover
+       widget={selectedWidget}
+       canvasFilters={canvasFilters}
+       anchorEl={anchorEl}
+       onUpdate={updateWidget}
+       onClose={() => setSelectedWidgetId(null)}
+     />
+   )}
+   ```
+5. Delete `components/reports/ConfigRail.tsx`.
+
+Run-to-pass on the page test, then `tsc --noEmit`.
+
+**Commit:** `feat(reports): mount widget editor popover, remove ConfigRail rail`
+
+---
+
+### Task 9 — Full-suite green + type-check + cleanup
+
+**Files:** none (verification gate).
+
+1. `docker compose exec -T frontend npx tsc --noEmit` → clean.
+2. `docker compose exec -T frontend npx vitest run` → **entire** suite green
+   (project rule: never trust single-file runs; a cross-file rename can pass
+   the touched file and break another — see
+   `reference_frontend_full_suite_verification.md`).
+3. Grep for stragglers:
+   `grep -rn "config-rail\|ConfigRail" frontend/` → should return zero hits
+   (component deleted, all testids migrated).
+4. Confirm `Canvas.tsx` and `CanvasFiltersBar.tsx` are untouched in the diff
+   (`git diff --stat`).
+
+**Commit (if any cleanup):** fold into the prior commit or
+`test(reports): migrate editor tests off ConfigRail to popover`.
+
+---
+
+## Must-flag list (implementer: handle each explicitly)
+
+1. **`@floating-ui/react` dep + lockfile via the container.** Add to
+   `package.json`, run `npm install` **inside** the frontend container so the
+   lockfile matches the container platform, then `up --build -d frontend` —
+   a running dev container will otherwise fail to resolve the new import even
+   though CI (fresh build) is green (dev-unmounted/stale-image gotcha).
+2. **Existing `config-rail` testid references break.** Three spots in
+   `tests/app/reports-editor-page.test.tsx` (~236, ~390, ~902) reference
+   `data-testid="config-rail"`. All must move to `widget-editor-popover`, and
+   the override-pill test must first click the **Filters tab** (the pill is no
+   longer always-visible).
+3. **Page flex-container change.** Remove `<ConfigRail>` from the
+   `flex flex-1 overflow-hidden` row so the canvas column is the sole flex
+   child; the popover is portaled, never a flex sibling. Tag the canvas column
+   `data-testid="report-canvas-column"` for the reflow test.
+4. **Tab state + per-type control visibility.** Default tab = Data. Tabs are
+   always all three. Within Data/Style, branch on `widget.type`:
+   - `kpi`: no primary/secondary dimension (Data); compare checkbox (Style).
+   - `pie`/`sparkline`: single measure + single primary dimension, **no**
+     secondary dimension; pie also gets top_n (Style); sparkline gets nothing
+     extra in Style.
+   - `bar`: primary + secondary ("Break down by"); no Style knob.
+   - `table`: multi-series (columns, cap 5) + primary + secondary.
+   - `line`/`area`/`stacked_bar`: multi-series (cap 5); area/stacked_bar get
+     "Stack series" (Style); stacked_bar's checkbox defaults checked
+     (`stacked !== false`).
+5. **A11y:** `FloatingFocusManager` manages focus (modal={false},
+   `initialFocus={-1}` so focus lands on the dialog, not the first input);
+   Escape + outside-press close via `useDismiss`; `role="dialog"` +
+   `aria-label` via `useRole`; the selected widget shell gets
+   `aria-haspopup="dialog"` + `aria-expanded={selected}`; the tablist uses
+   `role="tablist"`/`role="tab"`/`role="tabpanel"` with
+   `aria-selected`/`aria-controls`/`aria-labelledby`. Touch-target floor for
+   the Close + tab buttons per DESIGN.md.
+6. **Reflow invariance test (the core regression guard):** assert the canvas
+   column remains the **sole element-child** of the flex row when the popover
+   opens (popover is portaled to body), so canvas geometry can't change on
+   select. This is the test that proves the bug is fixed.
+7. **`No Off-Token` design rule:** every color must come from theme tokens
+   (`border-border`, `bg-surface`, `text-text-*`, `ring-accent`, etc.) — reuse
+   ConfigRail's exact classes. `frontend/scripts/check-design-tokens.sh`
+   CI-blocks raw Tailwind palette colors.
+8. **Frozen surfaces:** do NOT edit `Canvas.tsx`, `CanvasFiltersBar.tsx`,
+   `lib/reports/resolve.ts`, or the filter model. Confirm via `git diff --stat`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Popover replaces ConfigRail, floats over canvas, anchored to widget via
+  `data-widget-shell` lookup → Tasks 5, 7, 8. ✔
+- floating-ui `useFloating`+`autoUpdate`+`useDismiss`+`useRole`+
+  `FloatingFocusManager` wiring spelled out → "Floating-UI wiring". ✔
+- 3 tabs Data/Filters/Style, default Data → Task 7. ✔
+- Data tab = disabled source + measure(s) + primary/optional-secondary
+  dimension; Filters = verbatim FilterEditor; Style = title + per-type knobs →
+  Tasks 4, 6. ✔
+- ALL ConfigRail controls + their `onUpdate` logic preserved by extraction →
+  Tasks 2-4, 6 (verbatim ports). ✔
+- Canvas does not reflow; ConfigRail removed from flex row; popover portaled →
+  Task 8 + reflow test. ✔
+- Page still gates on `editModeActive && selectedWidget` → Task 8 mount guard. ✔
+- Real test commands + full-suite gate → every task + Task 9. ✔
+- Must-flag list (8 items incl. dep/lockfile, broken testids, flex change, tab
+  state, a11y, reflow test) → present. ✔
+- Single coherent PR with internal ordering → stated; 9 tasks. ✔
+
+**Placeholder scan:** no `TODO`/`FIXME`/`...`-as-stub left in the plan; every
+new file has a concrete purpose and at least one test path. The optional
+`useWidgetMutations.ts` is called out as optional, not a dangling reference.
+
+**Type consistency:** all types referenced (`Widget`, `CanvasFilters`,
+`WidgetFilters`, `Measure`, `SeriesConfig`, `Dimension`, `KPIConfig`/
+`BarConfig`/`PieConfig`/`SparklineConfig`/`LineConfig`/`AreaConfig`/
+`StackedBarConfig`/`TableConfig`) exist in `lib/reports/types.ts` as read.
+`anchorEl: HTMLElement | null` matches floating-ui's external-reference
+contract. `useReportQuery`/SWR untouched. `tsc --noEmit` is a gate in Tasks
+2-9.
+
+**Known deviation (also in the final report):** ConfigRail renders **no**
+`Line.smooth` and **no** `format` control today; the brief listed both as Style
+knobs. To honor "re-housing, not logic rewrite" + the no-new-knobs non-goal,
+4a ports only existing controls and defers `smooth`/`format` to a fast-follow.

--- a/specs/2026-06-12-reports-v3-phase4a-popover-plan.md
+++ b/specs/2026-06-12-reports-v3-phase4a-popover-plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-12
 Author: frontend architect
-Status: ready to implement (subagent-driven, single coherent PR)
+Status: ready to implement (subagent-driven, **two-PR split** per architect review)
 
 ---
 
@@ -12,11 +12,21 @@ Replace the 320 px right-hand `ConfigRail` sidebar with an **anchored floating
 popover** that floats *over* the canvas, anchored to the selected widget's DOM
 element. The popover must NOT consume flex width, so the canvas no longer
 reflows (narrows / re-clamps RGL columns) when a widget is selected. This
-reflow is the concrete bug being fixed: today
-`app/reports/[id]/page.tsx` mounts `<ConfigRail>` as a flex sibling
-(`flex-1` canvas column + `w-80 shrink-0` rail), so selecting a widget
-shrinks the canvas from full width and RGL re-clamps to a narrower
-breakpoint.
+reflow is the concrete bug being fixed: today **both** report editor pages
+mount `<ConfigRail>` as a flex sibling inside an identical
+`flex flex-1 overflow-hidden` row (`flex-1` canvas column + ConfigRail's
+`w-80 shrink-0` rail), so selecting a widget shrinks the canvas from full
+width and RGL re-clamps to a narrower breakpoint:
+
+- `app/reports/[id]/page.tsx` — saved-report editor. Flex row ~line 751;
+  `<ConfigRail>` rendered ~822-829 gated on `editModeActive && selectedWidget`.
+- `app/reports/new/page.tsx` — unsaved-draft editor. Flex row ~line 266;
+  `<ConfigRail>` rendered ~310-317 gated on `selectedWidget` **only** (the
+  draft page is always in edit mode, there is no `editModeActive` flag).
+
+**Both pages have the identical reflow bug and both must get the identical
+migration.** Deleting `ConfigRail` without migrating `new/page.tsx` breaks the
+build.
 
 The popover reorganizes the **exact same controls** into **3 tabs
 (Data · Filters · Style)** so a long scroll is avoided. This is a
@@ -28,33 +38,36 @@ composes.
 ## Architecture
 
 ```
-app/reports/[id]/page.tsx
-  editModeActive && selectedWidget
-    → renders <WidgetEditorPopover>  (NOT in the flex row; portaled)
-    → passes the selected widget's anchor element (a ref/getter) so
-      floating-ui can position against it
+app/reports/[id]/page.tsx   (editModeActive && selectedWidget)
+app/reports/new/page.tsx    (selectedWidget)
+  → each resolves the selected widget's shell DOM node into `anchorEl`
+    state via a useEffect keyed on the selected-widget id (the node is
+    found by the existing `data-widget-shell={id}` attribute)
+  → renders <WidgetEditorPopover anchorEl=…>  (NOT in the flex row; portaled)
 
 components/reports/
-  WidgetEditorPopover.tsx        NEW — floating-ui shell + 3-tab frame
+  WidgetEditorPopover.tsx        NEW (PR1, built+unit-tested; wired in PR2)
   config/
-    DataTab.tsx                  NEW — source + measure(s) + dimensions
-    StyleTab.tsx                 NEW — title + widget-specific knobs + format
-    FilterEditor.tsx             NEW — EXTRACTED verbatim from ConfigRail
-    MeasuresEditor.tsx           NEW — EXTRACTED verbatim from ConfigRail
-    SingleMeasureEditor.tsx      NEW — EXTRACTED verbatim from ConfigRail
-    controlConstants.ts          NEW — AGG_OPTIONS / FIELD_OPTIONS / DIMENSION_OPTIONS / helpers
-  WidgetShell.tsx                MODIFIED — expose the shell DOM node to the page for anchoring
+    controlConstants.ts          NEW (PR1) — AGG_OPTIONS / FIELD_OPTIONS / DIMENSION_OPTIONS / caps / helpers
+    SingleMeasureEditor.tsx      NEW (PR1) — EXTRACTED verbatim from ConfigRail
+    MeasuresEditor.tsx           NEW (PR1) — EXTRACTED verbatim from ConfigRail
+    FilterEditor.tsx             NEW (PR1) — EXTRACTED verbatim (FilterEditor + TxnTypeRadioRow + OverridePill + Section)
+    useWidgetMutations.ts        NEW (PR1) — EXTRACTED verbatim mutation closures
+    DataTab.tsx                  NEW (PR1) — source + measure(s) + dimensions
+    StyleTab.tsx                 NEW (PR1) — title + widget-specific knobs
+  ConfigRail.tsx                 PR1: KEEPS RENDERING the extracted pieces (zero behavior change)
+                                 PR2: DELETED
+  WidgetShell.tsx                PR2 — add aria-haspopup/aria-expanded; node already carries data-widget-shell
   Canvas.tsx                     UNCHANGED (must not reflow)
   CanvasFiltersBar.tsx           UNCHANGED (filter model frozen in 4a)
-  ConfigRail.tsx                 DELETED (its logic moves into the extracted pieces + tabs)
 ```
 
 The popover owns: positioning (`useFloating` + `autoUpdate`), dismissal
-(`useDismiss` outside-click + Escape), focus management
+(`useDismiss` outside-press + Escape), focus management
 (`FloatingFocusManager`), the `role`/`aria` contract (`useRole`), tab state,
 and which tabs/sub-controls a given widget type shows. It delegates every
-*mutation* to the extracted control components, which call the page's
-existing `updateWidget` (via the `onUpdate` prop) untouched.
+*mutation* to the extracted control components, which call the page's existing
+`updateWidget` (via the `onUpdate` prop) untouched.
 
 ## Tech Stack
 
@@ -67,6 +80,9 @@ existing `updateWidget` (via the `onUpdate` prop) untouched.
   `No Off-Token` rule), `lucide-react`, vitest 3 + jsdom + Testing Library.
 - Test harness: `renderWithSWR` from `tests/utils/render-with-swr.tsx`
   (re-exports `screen`, `fireEvent`, `waitFor`, `within`, `act`).
+- Vitest setup: `frontend/vitest.setup.ts` (registered in `vitest.config.ts`
+  `setupFiles`). It currently has **no `ResizeObserver` polyfill** — PR1 adds
+  it globally here (see Task 1b).
 
 ---
 
@@ -82,71 +98,85 @@ These are explicitly **out of scope** and must be left exactly as today:
 2. **Do NOT shrink the canvas toolbar to date-only.** `CanvasFiltersBar`
    keeps all three controls.
 3. **Do NOT add canvas filter chips.** The "active filter pills" toolbar is 4b.
-4. **No source/dataset widening.** The "Data source" select stays a
-   *disabled* `Transactions` select exactly as today (enum widening is
-   Phase 5).
-5. **No auto-save.** Explicit Save semantics (`handleSave`) are preserved.
-6. **No new widget knobs** beyond the ones ConfigRail already renders.
+4. **No source/dataset widening.** The "Data source" select stays a *disabled*
+   `Transactions` select exactly as today (enum widening is Phase 5).
+5. **No auto-save.** Explicit Save semantics are preserved on both pages.
+6. **No new widget knobs** beyond the ones ConfigRail already renders. In
+   particular `Line.smooth` and a `format` select are **NOT added** — see the
+   "Known deviation" note in Self-Review.
 
 4a is **popover + control re-housing + reflow fix ONLY.**
 
 ---
 
-## File Structure
+## ConfigRail control inventory (what must be preserved verbatim)
 
-### New files
-
-| File | Purpose |
-| --- | --- |
-| `components/reports/WidgetEditorPopover.tsx` | floating-ui shell, 3-tab frame, a11y wiring, tab-visibility-by-widget-type logic |
-| `components/reports/config/controlConstants.ts` | `AGG_OPTIONS`, `AGG_HELP_KEY`, `FIELD_OPTIONS`, `DIMENSION_OPTIONS`, `MAX_SERIES`, `MAX_TABLE_COLUMNS`, `isMultiSeries`, `isSingleAggLocked` — lifted verbatim from `ConfigRail.tsx` |
-| `components/reports/config/SingleMeasureEditor.tsx` | extracted `SingleMeasureEditor` (Aggregation + Field selects) |
-| `components/reports/config/MeasuresEditor.tsx` | extracted `MeasuresEditor` (multi-series add/remove rows) |
-| `components/reports/config/FilterEditor.tsx` | extracted `FilterEditor` + `TxnTypeRadioRow` + `OverridePill` (verbatim) |
-| `components/reports/config/DataTab.tsx` | composes source select + measure editor + primary/secondary dimension selects |
-| `components/reports/config/StyleTab.tsx` | composes title input + KPI compare / Pie top_n / Area+StackedBar stacked / Line smooth / format select |
-| `tests/components/reports/WidgetEditorPopover.test.tsx` | popover behavior: tab switching, per-type tab/control visibility, dismiss/Escape, a11y, anchoring smoke |
-| `tests/components/reports/config/FilterEditor.test.tsx` | extracted-filter parity: override pill, all six filter fields wired |
-| `tests/components/reports/config/measure-editors.test.tsx` | single + multi-series measure mutation parity |
-
-### Modified files
-
-| File | Change |
-| --- | --- |
-| `app/reports/[id]/page.tsx` | remove `<ConfigRail>` from the `flex flex-1` row; the canvas column becomes the *only* flex child (no width steal). Mount `<WidgetEditorPopover>` outside the flex row, pass the selected widget's anchor element. Update `import`. |
-| `components/reports/WidgetShell.tsx` | accept an optional `onShellRef`/`anchorRef` (or keep the existing `data-widget-shell={id}` attribute as the anchor selector — see Task 5) so the page can resolve the selected widget's DOM node. |
-| `package.json` | add `@floating-ui/react` to `dependencies` |
-| `package-lock.json` | regenerate (via the frontend container) |
-| `tests/app/reports-editor-page.test.tsx` | update every `config-rail` reference (lines ~236-238, ~390-394, ~902). These break and MUST be migrated to the popover testid. Add a **reflow-invariance** test (canvas container width unaffected on open). |
-| `ConfigRail.tsx` | **DELETE** after extraction is complete and all references move. |
-
-### ConfigRail control inventory (what must be preserved)
-
-Every control below currently lives in `ConfigRail.tsx` and its
-`onUpdate(nextWidget)` logic must be carried over **unchanged**:
+Every control below currently lives in `ConfigRail.tsx`; its
+`onUpdate(nextWidget)` logic must be carried over **unchanged**. Line numbers
+reference the current `ConfigRail.tsx`.
 
 | Control | ConfigRail fn | Tab in 4a | Widget types |
 | --- | --- | --- | --- |
-| Title input | `setTitle` | **Style** | all |
-| Data source (disabled `Transactions`) | none (disabled) | **Data** | all |
-| Single measure: Aggregation + Field | `setSingleMeasure` via `SingleMeasureEditor` | **Data** | kpi, bar, pie, sparkline |
-| Multi-series: per-series label/agg/field + Add/Remove (cap 5; table cap 5 cols) | `setSeries` via `MeasuresEditor` | **Data** | line, area, stacked_bar, table |
-| Primary dimension select | `setPrimaryDimension` | **Data** | all except kpi |
-| Secondary dimension select ("Break down by" / "Secondary dimension") | `setSecondaryDimension` | **Data** | bar, table only |
-| KPI "Compare to prior period" checkbox | `setComparePrior` | **Style** | kpi |
-| Pie "Top N slices" number | `setTopN` | **Style** | pie |
-| Area/StackedBar "Stack series" checkbox | `setStacked` | **Style** | area, stacked_bar |
-| FilterEditor (date/accounts/categories/txn_type/amount_range/tags + override pills) | `setFilters` | **Filters** | all |
+| Title input | `setTitle` (122-124) | **Style** | all |
+| Data source (disabled `Transactions`) | none (disabled, 256-265) | **Data** | all |
+| Single measure: Aggregation + Field | `setSingleMeasure` (134-144) via `SingleMeasureEditor` (431-474) | **Data** | kpi, bar, pie, sparkline |
+| Multi-series rows + Add/Remove (cap 5; table cap 5 cols) | `setSeries` (146-153) via `MeasuresEditor` (476-598) | **Data** | line, area, stacked_bar, table |
+| Primary dimension select | `setPrimaryDimension` (155-172) | **Data** | all except kpi |
+| Secondary dimension select | `setSecondaryDimension` (174-193) | **Data** | bar, table only |
+| KPI "Compare to prior period" checkbox | `setComparePrior` (195-205) | **Style** | kpi |
+| Pie "Top N slices" number | `setTopN` (207-214) | **Style** | pie |
+| Area/StackedBar stacked checkbox | `setStacked` (216-226) | **Style** | area, stacked_bar |
+| FilterEditor (date/accounts/categories/txn_type/amount_range/tags + override pills) | `setFilters` (126-132) via `FilterEditor` (600-731) | **Filters** | all |
 
-> **Deviation flagged (read the Self-Review + final report):** ConfigRail does
-> **NOT** currently render a `Line.smooth` toggle nor a `format` select, even
-> though both exist in the type model (`LineConfig.smooth`,
-> `*.format`). The instructions list "Line smooth" and "format" as Style knobs.
-> **Decision:** to keep 4a a strict re-housing with zero new behavior, port
-> ONLY the controls ConfigRail renders today. `Line.smooth` and `format`
-> selects are **NOT added in 4a** (they would be new logic / new knobs, which
-> the non-goals forbid). They are noted as a fast-follow. The Style tab is
-> still correct: it shows title + whatever per-type knob(s) ConfigRail had.
+### Verbatim branches that MUST be named explicitly (transcription-bug hotspots)
+
+These are the two spots where a silent copy error would hide. Move them
+**character-for-character**:
+
+1. **Measure branch (ConfigRail ~270-283)** — into `DataTab`:
+   ```tsx
+   {isMultiSeries(widget) ? (
+     <MeasuresEditor widget={widget} onChange={setSeries} />
+   ) : (
+     <SingleMeasureEditor
+       measure={
+         (widget.config as KPIConfig | BarConfig | PieConfig | SparklineConfig)
+           .measure
+       }
+       onChange={setSingleMeasure}
+     />
+   )}
+   ```
+   The `(widget.config as KPIConfig | BarConfig | PieConfig | SparklineConfig).measure`
+   cast-and-extract is the load-bearing part — keep the union and the `.measure`
+   access exactly.
+
+2. **Stacked Style branch (ConfigRail ~372-388)** — into `StyleTab`. BOTH the
+   label branch AND the default branch differ between `area` and `stacked_bar`
+   and must be preserved verbatim:
+   ```tsx
+   {(widget.type === "area" || widget.type === "stacked_bar") && (
+     <Section label={widget.type === "stacked_bar" ? "Stack mode" : "Stack series"}>
+       <label ...>
+         <input
+           type="checkbox"
+           checked={
+             widget.type === "stacked_bar"
+               ? (widget.config as StackedBarConfig).stacked !== false   // default ON
+               : Boolean((widget.config as AreaConfig).stacked)          // default OFF
+           }
+           onChange={(e) => setStacked(e.target.checked)}
+           aria-label="Stack series"   // <-- aria-label is "Stack series" for BOTH types
+         />
+         <span>Stack multiple series</span>
+       </label>
+     </Section>
+   )}
+   ```
+   Note the asymmetry: `stacked_bar` label is **"Stack mode"** and default is
+   `stacked !== false` (checked unless explicitly false); `area` label is
+   **"Stack series"** and default is `Boolean(stacked)` (unchecked unless set).
+   The `aria-label` is `"Stack series"` for both. Keep all three facts.
 
 ---
 
@@ -187,14 +217,14 @@ useEffect(() => {
 }, [anchorEl, refs]);
 
 const dismiss = useDismiss(context, {
-  outsidePress: true,             // close on outside-click
+  outsidePress: true,             // close on outside pointerdown
   escapeKey: true,                // close on Escape
 });
 const role = useRole(context, { role: "dialog" });
 const { getFloatingProps } = useInteractions([dismiss, role]);
 ```
 
-Render with portal + focus trap:
+Render with portal + focus manager:
 
 ```tsx
 return (
@@ -223,93 +253,168 @@ Key points for the implementer:
   focus and Escape/return work — without a hard modal trap, matching the
   non-blocking menu pattern in `OverflowMenu.tsx`.
 - **Anchor via `refs.setReference(anchorEl)`**, NOT a trigger ref. The
-  reference element is the *selected widget shell*, resolved by the page (see
-  Task 5). When `anchorEl` is `null` the popover should not render (page
-  already gates on `selectedWidget`, but guard anyway).
+  reference element is the *selected widget shell*, resolved by the page. When
+  `anchorEl` is `null` the page does not render the popover (it's gated on
+  `anchorEl` truthiness), but guard inside as well.
 - **`autoUpdate`** (via `whileElementsMounted`) keeps the popover glued to the
   widget as the user scrolls the canvas, resizes the window, or drags the
-  widget. This is what makes "anchored, floats over" feel correct.
+  widget.
 - **No canvas reflow:** the popover is in a `FloatingPortal` (renders at the
-  document body, `position: fixed`/absolute via `floatingStyles`), so it is
-  never a flex sibling of the canvas. This is the structural fix.
+  document body, positioned via `floatingStyles`), so it is never a flex
+  sibling of the canvas. This is the structural fix.
+- **querySelector anchor staleness guard:** because `anchorEl` is resolved by a
+  `document.querySelector` lookup (not a live ref), the node can go stale —
+  e.g. the widget is removed, or the canvas re-renders the shell. If the
+  resolved node detaches, the popover would float against a dead element. Guard
+  it: when `anchorEl` becomes disconnected, close (deselect):
+  ```tsx
+  useEffect(() => {
+    if (anchorEl && !anchorEl.isConnected) onClose();
+  }, [anchorEl, onClose]);
+  ```
+  Note the timing: `anchorEl` is set by the page in a post-commit `useEffect`
+  keyed on the selected id, so on the render that re-selects a widget the
+  popover mounts on the **second** render (after the effect runs and sets
+  state). Tests must account for this (see Test timing below).
+
+### Test timing — popover mounts on a SECOND render
+
+The page computes `anchorEl` in a `useEffect` keyed on the selected-widget id,
+so selecting a widget does NOT mount the popover synchronously — it mounts on
+the next render after the effect resolves the node and sets state. **Every
+popover-presence assertion at the page level MUST be async:**
+
+```tsx
+await waitFor(() => screen.getByTestId("widget-editor-popover"));
+```
+
+Never assert the popover synchronously with `getByTestId` immediately after the
+selecting click — it will not be in the DOM yet on the first render.
 
 ### jsdom test handling for floating-ui
 
 floating-ui calls `getBoundingClientRect` / `ResizeObserver` /
-`requestAnimationFrame`; jsdom returns zeros and lacks `ResizeObserver`.
-Strategy (mirrors how `Canvas` is stubbed in the existing editor test):
+`requestAnimationFrame`; jsdom returns all-zero rects and lacks
+`ResizeObserver`. Important facts:
 
-- In `WidgetEditorPopover.test.tsx`, provide a `ResizeObserver` polyfill in a
-  `beforeEach` (`global.ResizeObserver = class { observe(){} unobserve(){}
-  disconnect(){} }`). jsdom 26 has no `ResizeObserver`.
-- Do **not** assert pixel coordinates in jsdom (they'll be 0). Assert
-  structure/behavior instead: the popover renders, the right tab panel shows,
-  Escape closes, outside-press closes, `role="dialog"` + `aria-label` present,
-  tab `aria-selected` toggles.
-- `FloatingPortal` renders into `document.body`; query with `screen.*` (which
-  searches the whole document), not `within(container)`.
-- For the **page-level reflow test**, stub the popover's positioning is not
-  needed — assert the *canvas container* width/structure is unchanged. Since
-  the editor test already mocks `@/components/reports/Canvas`, the cleanest
-  assertion is: the canvas column is the sole flex child and no `w-80` rail
-  sibling exists when the popover is open (see Task 8).
-
----
-
-## TDD Task Breakdown
-
-> **Single PR.** 4a is large but cohesive; it lands as ONE PR. Internal
-> ordering below keeps each step independently testable. Run the **full**
-> vitest suite (not single files) before opening the PR (project rule —
-> see `reference_frontend_full_suite_verification.md`).
->
-> Commands (run inside the frontend container; for parallel-agent sessions use
-> an isolated compose project per CLAUDE.md):
-> - Single file: `docker compose exec -T frontend npx vitest run <path>`
-> - Full suite: `docker compose exec -T frontend npx vitest run`
-> - Type-check: `docker compose exec -T frontend npx tsc --noEmit`
-
-Commit after each task (no AI attribution in messages per user rule).
+- **`ResizeObserver` polyfill goes in `vitest.setup.ts` (GLOBAL, not
+  per-file).** jsdom 26 has no `ResizeObserver`; floating-ui's `autoUpdate`
+  needs it. Add it once in setup (Task 1b) so every test that ever portals a
+  floating element is covered, not just this file.
+- **floating-ui renders and positions fine in jsdom.** All-zero rects collapse
+  to `translate(0, 0)`, so the popover element really mounts and is queryable —
+  these are **real tests, not hollow ones.** Do not skip popover tests as
+  "can't test positioning"; assert structure/behavior (the popover renders, the
+  right tab panel shows, Escape closes, `role`/`aria` present, `aria-selected`
+  toggles).
+- **Dismiss assertions:** prefer **Escape** as the primary, unambiguous close
+  test (`fireEvent.keyDown(document, { key: "Escape" })` →`onClose`). If you
+  also test outside-press, use **`fireEvent.pointerDown(document.body)`** —
+  floating-ui's `useDismiss` listens on **pointerdown**, NOT mousedown; a
+  `mouseDown` will not trigger dismissal and the test will falsely fail.
+- **`FloatingPortal` renders into `document.body`;** query with `screen.*`
+  (whole-document search), not `within(container)`.
 
 ---
 
-### Task 1 — Add the `@floating-ui/react` dependency
+## TDD ground rules (both PRs)
+
+Commands (run inside the frontend container; for parallel-agent sessions use an
+isolated compose project per CLAUDE.md — `docker compose -p team-<name> …` on
+**every** call):
+
+- Single file: `docker compose exec -T frontend npx vitest run <path>`
+- Full suite: `docker compose exec -T frontend npx vitest run`
+- Type-check: `docker compose exec -T frontend npx tsc --noEmit`
+- Lint (CI gate): `docker compose exec -T frontend npx eslint . --quiet`
+
+Commit after each task (no AI attribution in messages, no Co-Authored-By, per
+user rule). PR titles are conventional-commit (squash-merge → PR title is the
+release subject).
+
+**Full-suite rule:** never trust single-file runs; a cross-file rename can pass
+the touched file and break another (see
+`reference_frontend_full_suite_verification.md`). Each PR's final gate runs the
+**entire** vitest suite + `tsc` + `eslint`.
+
+---
+
+# PR 1 — Extraction refactor (ZERO behavior change)
+
+**Theme:** add the dependency, extract every ConfigRail sub-block into
+reusable components, build + unit-test `WidgetEditorPopover` — but **leave
+`ConfigRail.tsx` rendering the extracted pieces** so both pages and all
+existing tests stay green. The popover is built and unit-tested here but is
+**NOT yet wired into either page.** Re-home the 3 component test files onto the
+extracted components in this PR.
+
+PR title: `refactor(reports): extract ConfigRail into reusable widget-editor pieces`
+
+---
+
+### Task 1a — Add the `@floating-ui/react` dependency
 
 **Files:** `package.json`, `package-lock.json`
 
 No test (dependency-only). Verification is install + import resolves.
 
-1. Add `"@floating-ui/react": "^0.27.0"` (or current latest) to
-   `dependencies` in `package.json`.
+1. Add `"@floating-ui/react": "^0.27.0"` (or current latest) to `dependencies`
+   in `package.json`.
 2. Regenerate the lockfile **inside the container** so the platform-correct
-   tree lands:
-   `docker compose exec -T frontend npm install`
-   (this updates `package-lock.json`; commit both files).
+   tree lands: `docker compose exec -T frontend npm install` (updates
+   `package-lock.json`; commit both files).
 3. **Rebuild note:** the dev image COPYs `package.json`/lockfile but a running
    container won't have the new dep until rebuilt:
-   `docker compose up --build -d frontend`. (See
-   `reference_dockerfile_dev_install.md` / dev-unmounted-files gotcha — a
-   stale image will fail `import` resolution locally while CI is green.)
+   `docker compose up --build -d frontend`. A stale image fails `import`
+   resolution locally while CI (fresh build) is green (dev-unmounted/stale-image
+   gotcha — `reference_dockerfile_dev_install.md`).
 4. Verify: `docker compose exec -T frontend node -e "require.resolve('@floating-ui/react')"`.
 
 **Commit:** `build(reports): add @floating-ui/react for widget editor popover`
 
 ---
 
-### Task 2 — Extract control constants + helpers (no behavior change)
+### Task 1b — Global `ResizeObserver` polyfill in vitest setup
+
+**Files:** `frontend/vitest.setup.ts`
+
+`vitest.setup.ts` currently has no `ResizeObserver`. floating-ui's `autoUpdate`
+needs it. Add it **once, globally** (not per test file).
+
+**Implement:** append to `vitest.setup.ts`:
+```ts
+// floating-ui's autoUpdate calls ResizeObserver; jsdom 26 has none.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+```
+
+**Run-to-pass:** `docker compose exec -T frontend npx vitest run` (suite still
+green; this is additive). `npx tsc --noEmit`.
+
+**Commit:** `test(reports): add global ResizeObserver polyfill for floating-ui`
+
+---
+
+### Task 2 — Extract control constants + helpers
 
 **Files:** `components/reports/config/controlConstants.ts` (new)
 
-**Failing test:** none required (pure constant move); covered transitively by
-Task 3/4 tests. Optionally add a trivial `tests/components/reports/config/controlConstants.test.ts`
+**Failing test:** optional `tests/components/reports/config/controlConstants.test.ts`
 asserting `DIMENSION_OPTIONS.length === 9` and `AGG_OPTIONS.length === 4` to
-lock the move.
+lock the move. (Otherwise covered transitively by Task 3/4 tests.)
 
-**Implement:** copy verbatim from `ConfigRail.tsx`:
-`AGG_OPTIONS`, `AGG_HELP_KEY`, `FIELD_OPTIONS` (built from
-`MEASURE_FIELD_LABELS` in `lib/reports/series.ts`), `DIMENSION_OPTIONS`,
-`MAX_SERIES`, `MAX_TABLE_COLUMNS`, `isMultiSeries`, `isSingleAggLocked`.
-Export each. Keep the `HelpTooltipKey` typing.
+**Implement:** copy **verbatim** from `ConfigRail.tsx`: `AGG_OPTIONS` (61-66),
+`AGG_HELP_KEY` (69-74), `FIELD_OPTIONS` (78-80, built from
+`MEASURE_FIELD_LABELS` in `lib/reports/series.ts`), `DIMENSION_OPTIONS`
+(82-92), `MAX_SERIES`/`MAX_TABLE_COLUMNS` (94-95), `isMultiSeries` (98-107),
+`isSingleAggLocked` (110-112). Export each; keep `HelpTooltipKey` typing.
+Also extract the small `Section` presentational component (ConfigRail 399-418)
+here (or a shared `Section.tsx`) since every extracted piece uses it.
 
 **Run-to-pass:** `docker compose exec -T frontend npx tsc --noEmit`
 
@@ -324,24 +429,22 @@ Export each. Keep the `HelpTooltipKey` typing.
 `tests/components/reports/config/measure-editors.test.tsx` (new)
 
 **Failing test first** (`measure-editors.test.tsx`):
-- `SingleMeasureEditor`: rendering a measure `{agg:"sum",field:"amount"}`,
-  changing the **Aggregation** select to `count` calls `onChange` with
-  `{agg:"count",field:"amount"}`; changing **Field** to `id` calls with
-  `{agg:"sum",field:"id"}`. Query by the existing `aria-label="Aggregation"` /
-  `"Field"`.
+- `SingleMeasureEditor`: rendering `{agg:"sum",field:"amount"}`, changing
+  **Aggregation** to `count` calls `onChange` with `{agg:"count",field:"amount"}`;
+  changing **Field** to `id` calls with `{agg:"sum",field:"id"}`. Query by the
+  existing `aria-label="Aggregation"` / `"Field"`.
 - `MeasuresEditor`: with a `line` widget (2 series), `data-testid="measure-add"`
-  appends a `{measure:{agg:"sum",field:"amount"}}` row; `measure-remove-1`
-  removes index 1; remove is hidden when only one series; cap respected at
-  `MAX_SERIES`; a `table` widget caps at `MAX_TABLE_COLUMNS` and labels rows
-  "Column N".
+  appends `{measure:{agg:"sum",field:"amount"}}`; `measure-remove-1` removes
+  index 1; remove is hidden when only one series; cap respected at `MAX_SERIES`;
+  a `table` widget caps at `MAX_TABLE_COLUMNS` and labels rows "Column N".
 
 Run-to-fail: `docker compose exec -T frontend npx vitest run tests/components/reports/config/measure-editors.test.tsx`
 
-**Implement:** move `SingleMeasureEditor` and `MeasuresEditor` verbatim from
-`ConfigRail.tsx` into their own files, importing from `controlConstants.ts`
-and reusing the same `Section`/`HelpTooltip` markup. Keep all `data-testid`s
-(`measure-row-N`, `measure-add`, `measure-remove-N`) and `aria-label`s
-identical — downstream tests and parity depend on them.
+**Implement:** move `SingleMeasureEditor` (ConfigRail 431-474) and
+`MeasuresEditor` (476-598) verbatim into their own files, importing from
+`controlConstants.ts` and the shared `Section`/`HelpTooltip`. Keep ALL
+`data-testid`s (`measure-row-N`, `measure-add`, `measure-remove-N`) and
+`aria-label`s identical — downstream tests and parity depend on them.
 
 Run-to-pass: same vitest path, then `npx tsc --noEmit`.
 
@@ -362,19 +465,20 @@ Run-to-pass: same vitest path, then `npx tsc --noEmit`.
   (`TagFilter`).
 - **Override pill parity:** given widget `filters.date_range` differing from
   `canvasFilters.date_range`, `data-testid="override-pill"` renders next to the
-  Date range label (drives through `isFieldOverridden` from `resolve.ts` —
-  do NOT reimplement it).
+  Date range label (drives through `isFieldOverridden` from `resolve.ts` — do
+  NOT reimplement it).
 - Changing amount min calls `onChange` with the merged `amount_range`.
 
-> Mock `AccountFilter`/`CategoryPicker`/`TagFilter`/`DatePresetChips` if they
-> fetch on mount (AccountFilter/CategoryPicker hit the org API). The existing
-> editor test renders the full page without mocking these, so they're
-> jsdom-safe; prefer rendering them real first and only mock if a fetch throws.
+> Mock `@/lib/api`'s `apiFetch` the way the existing
+> `override-pill-pickers.test.tsx` does (route `/categories`, `/accounts`,
+> `/tags` to fixtures) so `AccountFilter`/`CategoryPicker`/`TagFilter` don't
+> hang on mount. Mirror that file's `mockApi()` helper.
 
 Run-to-fail: `docker compose exec -T frontend npx vitest run tests/components/reports/config/FilterEditor.test.tsx`
 
-**Implement:** move `FilterEditor`, `TxnTypeRadioRow`, `OverridePill` verbatim.
-Keep `isFieldOverridden` import from `@/lib/reports/resolve`. No logic change.
+**Implement:** move `FilterEditor` (600-731), `TxnTypeRadioRow` (733-766),
+`OverridePill` (420-429) verbatim. Keep `isFieldOverridden` import from
+`@/lib/reports/resolve`. No logic change.
 
 Run-to-pass + `tsc --noEmit`.
 
@@ -382,83 +486,60 @@ Run-to-pass + `tsc --noEmit`.
 
 ---
 
-### Task 5 — Expose the widget shell DOM node for anchoring
+### Task 5 — Extract the mutation closures into `useWidgetMutations`
 
-**Files:** `components/reports/WidgetShell.tsx`, `app/reports/[id]/page.tsx`
-(read path only here), test added in Task 8.
+**Files:** `components/reports/config/useWidgetMutations.ts` (new)
 
-**Decision (anchor mechanism):** `WidgetShell` already renders
-`data-widget-shell={widgetId}` on its root `div`. The simplest, lowest-risk
-anchor is to resolve the selected widget's node by that attribute in the page:
+The `setTitle / setFilters / setSingleMeasure / setSeries / setPrimaryDimension
+/ setSecondaryDimension / setComparePrior / setTopN / setStacked` closures are
+currently local to `ConfigRail` (lines 122-226). Port them **verbatim** into a
+shared hook `useWidgetMutations(widget, onUpdate)` that returns the same named
+functions. One home, identical logic, consumed by `DataTab`/`StyleTab`/popover
+and (in PR1) by `ConfigRail` itself.
 
-```ts
-const anchorEl = selectedWidgetId
-  ? (document.querySelector(`[data-widget-shell="${selectedWidgetId}"]`) as HTMLElement | null)
-  : null;
-```
+**Failing test:** optional focused unit test asserting each setter produces the
+same `onUpdate` payload it does today (e.g. `setSecondaryDimension("")` splices
+`dimensions[1]`). Otherwise covered by Tasks 3/6 + the unchanged ConfigRail
+tests.
 
-Compute it in an effect/state so it updates after the widget mounts and after
-re-selection. To make this robust against re-render timing, store it in state
-set from a `useEffect` keyed on `selectedWidgetId` + `layout.widgets`:
+**Implement:** copy each closure body **character-for-character** (the casts and
+the `isMultiSeries`/`isSingleAggLocked` guards inside them are load-bearing —
+e.g. `setSingleMeasure` early-returns on `isMultiSeries`, `setSecondaryDimension`
+early-returns on `kpi`/`isSingleAggLocked`). Import the helpers from
+`controlConstants.ts`.
 
-```ts
-const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-useEffect(() => {
-  if (!editModeActive || !selectedWidgetId) { setAnchorEl(null); return; }
-  setAnchorEl(
-    document.querySelector(`[data-widget-shell="${selectedWidgetId}"]`) as HTMLElement | null,
-  );
-}, [editModeActive, selectedWidgetId, layout.widgets]);
-```
+Run-to-pass: `tsc --noEmit`.
 
-> Rationale: avoids threading a ref callback through `Canvas`'s
-> `renderWidget` → `WidgetShell` plumbing (which would touch the frozen
-> `Canvas` contract). `data-widget-shell` already exists for exactly this
-> kind of lookup. If a later phase needs sub-pixel precision, switch to a ref
-> callback on `WidgetShell` then; for 4a the attribute query is sufficient and
-> keeps `Canvas` untouched.
-
-**WidgetShell change:** add `aria-expanded` + `aria-haspopup="dialog"` to the
-selectable root (or to a future explicit trigger) so the selected widget
-announces it controls a dialog (a11y must-flag #5). Set
-`aria-expanded={selected}` on the shell root and keep `onClick={onSelect}`.
-
-No standalone test here (covered by Task 8). `tsc --noEmit` must pass.
-
-**Commit:** `feat(reports): expose widget shell node + aria for popover anchor`
+**Commit:** `refactor(reports): extract widget mutation closures into a hook`
 
 ---
 
 ### Task 6 — Data + Style tab composers
 
 **Files:** `components/reports/config/DataTab.tsx`,
-`components/reports/config/StyleTab.tsx` (new). Tested via the popover test
-(Task 7), but a focused tab unit test is encouraged.
+`components/reports/config/StyleTab.tsx` (new). Focused tab unit tests
+encouraged; also covered by the popover test (Task 7).
 
-**Implement `DataTab`** — composes, using `widget` + `onUpdate`:
-- Data source: disabled `Transactions` select (verbatim from ConfigRail).
-- Measures: `isMultiSeries(widget) ? <MeasuresEditor> : <SingleMeasureEditor>`
-  wired to `setSeries` / `setSingleMeasure` (port these mutation fns from
-  ConfigRail into `DataTab` or a shared `useWidgetMutations(widget,onUpdate)`
-  helper — see note below).
-- Primary dimension select (hidden for `kpi`), `setPrimaryDimension`.
-- Secondary dimension select (only `bar`/`table`), `setSecondaryDimension`.
+**Implement `DataTab`** — consumes `widget` + `useWidgetMutations`:
+- Data source: disabled `Transactions` select (verbatim, ConfigRail 256-265).
+- Measures: the **verbatim measure branch** named above (ConfigRail ~270-283) —
+  `isMultiSeries(widget) ? <MeasuresEditor onChange={setSeries}/> :
+  <SingleMeasureEditor measure={(widget.config as KPIConfig|BarConfig|PieConfig|SparklineConfig).measure} onChange={setSingleMeasure}/>`.
+- Primary dimension select (hidden for `kpi`), `setPrimaryDimension`
+  (ConfigRail 285-302).
+- Secondary dimension select (only `bar`/`table`), `setSecondaryDimension`
+  (ConfigRail 304-340 — keep the `bar`→"Break down by (optional)" /
+  `table`→"Secondary dimension (optional)" label split and the matching
+  `aria-label`s "Break down by" / "Secondary dimension").
 
-**Implement `StyleTab`** — composes:
-- Title input (`setTitle`).
-- KPI: compare_prior_period checkbox (`setComparePrior`).
-- Pie: top_n number (`setTopN`).
-- Area/StackedBar: stacked checkbox (`setStacked`).
-- (NOT Line.smooth / format — see deviation note above.)
-
-> **Mutation-fn placement:** the `setTitle/setSingleMeasure/setSeries/
-> setPrimaryDimension/setSecondaryDimension/setComparePrior/setTopN/setStacked/
-> setFilters` closures are currently local to `ConfigRail`. Port them into a
-> small shared hook `useWidgetMutations(widget, onUpdate)` in
-> `components/reports/config/useWidgetMutations.ts` (NEW, optional 9th file)
-> OR inline them per-tab. Hook is preferred: one home, identical logic, both
-> tabs + the filter tab consume it. Either way the bodies are **copied
-> verbatim** — no logic change.
+**Implement `StyleTab`** — consumes `widget` + `useWidgetMutations`:
+- Title input, `setTitle` (ConfigRail 246-254).
+- KPI: compare_prior_period checkbox, `setComparePrior` (342-356).
+- Pie: top_n number, `setTopN` (358-370).
+- Area/StackedBar: the **verbatim stacked branch** named above (372-388) — keep
+  the "Stack mode"/"Stack series" label split, the `stacked !== false` vs
+  `Boolean(stacked)` default split, and the shared `aria-label="Stack series"`.
+- (NOT `Line.smooth` / `format` — see deviation note in Self-Review.)
 
 `tsc --noEmit` must pass.
 
@@ -471,53 +552,55 @@ No standalone test here (covered by Task 8). `tsc --noEmit` must pass.
 **Files:** `components/reports/WidgetEditorPopover.tsx` (new),
 `tests/components/reports/WidgetEditorPopover.test.tsx` (new)
 
-**Failing test first** (`WidgetEditorPopover.test.tsx`), with the
-`ResizeObserver` polyfill in `beforeEach`:
+> `ResizeObserver` is already global from Task 1b — no per-file polyfill.
+
+**Failing test first** (`WidgetEditorPopover.test.tsx`). Render with a non-null
+`anchorEl` (`const el = document.createElement("div"); document.body.appendChild(el)`):
 
 1. Renders `data-testid="widget-editor-popover"` with `role="dialog"` and
-   `aria-label="Widget settings"` when given a non-null `anchorEl`
-   (use `document.createElement("div")` appended to body as the anchor).
+   `aria-label="Widget settings"`.
 2. **Default tab = Data:** the Data panel (data-source select + measure
    controls) is visible; Filters/Style panels are not.
-3. **Tablist a11y:** three tabs with `role="tab"`, the active tab has
-   `aria-selected="true"`, tabpanels labelled via `aria-labelledby`. Clicking
+3. **Tablist a11y:** three `role="tab"` buttons; active tab has
+   `aria-selected="true"`; tabpanels labelled via `aria-labelledby`. Clicking
    "Filters" shows the FilterEditor; clicking "Style" shows the title input.
 4. **Per-type visibility:**
-   - `kpi`: Data tab shows measure + source but **no** primary/secondary
-     dimension; Style shows compare checkbox.
-   - `pie`/`sparkline`: single measure, primary dimension present, **no**
-     secondary dimension; Style shows top_n only for pie.
-   - `bar`: primary + secondary ("Break down by") dimension; Style has none of
-     the type knobs.
+   - `kpi`: Data shows measure + source but **no** primary/secondary dimension;
+     Style shows compare checkbox.
+   - `pie`/`sparkline`: single measure + primary dimension, **no** secondary;
+     Style shows top_n only for pie.
+   - `bar`: primary + secondary ("Break down by"); no Style type-knob.
    - `line`/`area`/`stacked_bar`/`table`: `MeasuresEditor` (add/remove);
-     `table`+`bar` show secondary dimension; area/stacked_bar show "Stack
-     series" in Style.
-5. **Dismiss:** pressing `Escape` calls `onClose`; clicking outside the
-   popover (mousedown on `document.body`) calls `onClose`.
-6. **aria-expanded** is asserted at the page level (Task 8), not here.
+     `table`+`bar` show secondary dimension; area/stacked_bar show the stacked
+     checkbox in Style.
+5. **Dismiss:** `fireEvent.keyDown(document, { key: "Escape" })` calls
+   `onClose`; `fireEvent.pointerDown(document.body)` (NOT mouseDown) calls
+   `onClose`.
+
+> Component-level mount here is synchronous (you pass `anchorEl` directly), so
+> these in-component assertions need NOT `waitFor`. The second-render timing
+> only applies to the page-level tests in PR2 (where the page computes
+> `anchorEl` in an effect).
 
 Run-to-fail: `docker compose exec -T frontend npx vitest run tests/components/reports/WidgetEditorPopover.test.tsx`
 
-**Implement:** the floating-ui shell exactly as in the "Floating-UI wiring"
-section. Header: `<h2>Widget settings</h2>` + a `Close` button
-(`onClick={onClose}`) mirroring ConfigRail's header. Tablist:
+**Implement:** the floating-ui shell exactly as in "Floating-UI wiring",
+including the `!anchorEl.isConnected` staleness guard effect. Header:
+`<h2>Widget settings</h2>` + a `Close` button (`onClick={onClose}`) mirroring
+ConfigRail's header (230-244). Tablist:
 
 ```tsx
 const [tab, setTab] = useState<"data" | "filters" | "style">("data");
-// role="tablist" with three role="tab" buttons; arrow-key roving optional
-// for 4a (Tab/click is enough), but wire aria-selected + aria-controls +
-// id/aria-labelledby on each tab/panel pair.
+// role="tablist" with three role="tab" buttons; wire aria-selected +
+// aria-controls + id/aria-labelledby on each tab/panel pair. Arrow-key roving
+// is optional for 4a (Tab/click is enough).
 ```
 
-Tab panels:
-- Data → `<DataTab widget onUpdate />`
-- Filters → `<FilterEditor filters={widget.config.filters ?? {}} canvasFilters onChange={setFilters} />`
-- Style → `<StyleTab widget onUpdate />`
-
-Per-type sub-control visibility lives inside `DataTab`/`StyleTab` (they already
-branch on `widget.type`); the popover just always renders all three tabs (each
-tab is meaningful for every type: Data always has source+measure, Filters
-always applies, Style always has title).
+Tab panels: Data → `<DataTab>`, Filters →
+`<FilterEditor filters={widget.config.filters ?? {}} canvasFilters onChange={setFilters}/>`,
+Style → `<StyleTab>`. Per-type sub-control visibility lives inside
+`DataTab`/`StyleTab` (they branch on `widget.type`); the popover always renders
+all three tabs (every tab is meaningful for every type).
 
 Run-to-pass + `tsc --noEmit`.
 
@@ -525,55 +608,185 @@ Run-to-pass + `tsc --noEmit`.
 
 ---
 
-### Task 8 — Wire the popover into the page + delete ConfigRail + reflow test
+### Task 8 — Re-point ConfigRail at the extracted pieces (keep it rendering)
+
+**Files:** `components/reports/ConfigRail.tsx` (modified, NOT deleted in PR1)
+
+**Goal:** `ConfigRail.tsx` now *imports and renders* the extracted pieces
+(`Section`, `SingleMeasureEditor`, `MeasuresEditor`, `FilterEditor`,
+`controlConstants`, `useWidgetMutations`) instead of defining them inline. Its
+external behavior, markup, `data-testid="config-rail"`, every `aria-label`, and
+every `onUpdate` payload stay **byte-identical** so both pages and ALL existing
+ConfigRail tests stay green untouched.
+
+**No new failing test** — the regression bar is the **existing** ConfigRail
+suite passing unchanged:
+- `tests/components/reports/config-rail-tooltips.test.tsx`
+- `tests/components/reports/override-pill-pickers.test.tsx`
+- `tests/components/reports/config-rail-secondary-dimension.test.tsx`
+- the `config-rail` assertions in `tests/app/reports-editor-page.test.tsx`
+
+**Implement:** replace ConfigRail's inline definitions with imports of the
+extracted modules; have ConfigRail compose `useWidgetMutations` + the tab pieces
+(or simply render the same Sections via the extracted components). Keep the
+`<aside data-testid="config-rail" className="… w-80 shrink-0 …">` wrapper.
+
+Run-to-pass (all four existing suites):
+`docker compose exec -T frontend npx vitest run tests/components/reports/config-rail-tooltips.test.tsx tests/components/reports/override-pill-pickers.test.tsx tests/components/reports/config-rail-secondary-dimension.test.tsx tests/app/reports-editor-page.test.tsx`
+then `tsc --noEmit`.
+
+**Commit:** `refactor(reports): ConfigRail renders the extracted widget-editor pieces`
+
+---
+
+### Task 9 — Re-home the three orphaned component test files
+
+**Files:**
+`tests/components/reports/config-rail-tooltips.test.tsx`,
+`tests/components/reports/override-pill-pickers.test.tsx`,
+`tests/components/reports/config-rail-secondary-dimension.test.tsx`
+
+These three files import `@/components/reports/ConfigRail` directly and render
+it 4× / 5× / 5× respectively (~538 lines of coverage total). They will fail to
+compile the moment `ConfigRail` is deleted in PR2. **Re-home each onto the
+extracted component that now owns the behavior under test** — do NOT silently
+drop them. Re-point them in **PR1** (while both ConfigRail and the extracted
+pieces exist) so the coverage migrates cleanly and PR2 only deletes the
+component.
+
+- `config-rail-tooltips.test.tsx` → re-point at the **extracted Sections that
+  bear the `HelpTooltip`** (the aggregation explainer lives in
+  `SingleMeasureEditor`/`MeasuresEditor`; the master-category explainer lives on
+  the primary/secondary dimension Sections in `DataTab`). Render `DataTab`
+  (covers both the agg tooltip and the dimension master-category tooltips) and/or
+  the measure editors directly. Keep the same `HELP_TOOLTIPS[...].triggerLabel`
+  assertions.
+- `override-pill-pickers.test.tsx` → re-point at the extracted **`FilterEditor`**
+  (it owns the override pill + the picker filters). Swap
+  `<ConfigRail widget=… canvasFilters=… onUpdate=… onClose=…/>` for
+  `<FilterEditor filters={widget.config.filters ?? {}} canvasFilters=… onChange=…/>`.
+  Keep the `override-pill` presence/absence equality assertions.
+- `config-rail-secondary-dimension.test.tsx` → re-point at the extracted
+  **`DataTab`** (it owns the primary/secondary dimension selects and their
+  per-type visibility). Keep the "Break down by" / "Secondary dimension"
+  `getByLabelText` visibility matrix and the `dimensions[1]` set/clear assertion.
+
+Rename the files to match their new subjects (e.g.
+`tests/components/reports/config/data-tab-tooltips.test.tsx`,
+`.../config/filter-editor-override-pill.test.tsx`,
+`.../config/data-tab-secondary-dimension.test.tsx`) so no test still references
+ConfigRail by name after PR2.
+
+Run-to-pass: run all three migrated files, then `tsc --noEmit`.
+
+**Commit:** `test(reports): re-home ConfigRail component tests onto extracted pieces`
+
+---
+
+### Task 10 — PR1 pre-PR gate (eslint + tsc + FULL vitest)
+
+**Files:** none (verification gate).
+
+1. `docker compose exec -T frontend npx eslint . --quiet` → clean.
+2. `docker compose exec -T frontend npx tsc --noEmit` → clean.
+3. `docker compose exec -T frontend npx vitest run` → **entire** suite green
+   (cross-file rename safety — `reference_frontend_full_suite_verification.md`).
+4. Confirm **both pages still render `<ConfigRail>` unchanged** (PR1 wires
+   nothing into pages): `git diff --stat` shows no change to
+   `app/reports/[id]/page.tsx` or `app/reports/new/page.tsx`.
+5. Confirm `Canvas.tsx` and `CanvasFiltersBar.tsx` untouched.
+
+PR1 is openable once 1-4 are green.
+
+---
+
+# PR 2 — Wire-up + delete ConfigRail
+
+**Theme:** mount `WidgetEditorPopover` into **BOTH** pages, remove ConfigRail
+from both flex rows, add the `anchorEl` effect + staleness guard, **DELETE
+`ConfigRail.tsx`**, migrate the page tests to the popover (`waitFor` + Escape),
+and add the reflow-invariance regression test for **both** pages.
+
+PR title: `feat(reports): replace ConfigRail with anchored widget editor popover`
+
+---
+
+### Task 11 — Anchor the popover + WidgetShell a11y
+
+**Files:** `components/reports/WidgetShell.tsx`
+
+**Decision (anchor mechanism):** `WidgetShell` already renders
+`data-widget-shell={widgetId}` on its root `div` (line 35). The lowest-risk
+anchor is to resolve the selected widget's node by that attribute in each page
+(see Tasks 12/13). This avoids threading a ref callback through `Canvas`'s
+frozen `renderWidget`→`WidgetShell` plumbing.
+
+**WidgetShell change (a11y):** add `aria-haspopup="dialog"` and
+`aria-expanded={selected}` to the selectable root `div` so the selected widget
+announces it controls a dialog. Keep `onClick={onSelect}` and all existing
+attributes/classes.
+
+No standalone test (covered by Tasks 12/13). `tsc --noEmit` must pass.
+
+**Commit:** `feat(reports): widget shell announces it anchors the editor dialog`
+
+---
+
+### Task 12 — Wire popover into `[id]/page.tsx` + migrate its tests + reflow test
 
 **Files:** `app/reports/[id]/page.tsx`,
-`tests/app/reports-editor-page.test.tsx`, delete `ConfigRail.tsx`.
+`tests/app/reports-editor-page.test.tsx`
 
-**Failing tests first** (update + add in `reports-editor-page.test.tsx`):
+**Failing tests first** (update + add in `reports-editor-page.test.tsx`). Note
+the **second-render timing**: every popover-presence assertion is `await
+waitFor(...)`, never synchronous.
 
-a. **Migrate the three `config-rail` references** to
-   `widget-editor-popover`:
-   - "adds a KPI widget…" (~line 236): after adding a KPI it's selected →
-     assert `screen.getByTestId("widget-editor-popover")` instead of
-     `config-rail`.
-   - "shows the 'Overrides canvas' pill…" (~line 390): after selecting the
-     widget, the popover mounts; **switch to the Filters tab** before asserting
-     `override-pill` (the pill now lives in the Filters tab, not an
-     always-visible rail). Add `fireEvent.click(screen.getByRole("tab",
-     {name:/filters/i}))`.
-   - "after a successful save lands on the read-only view…" (~line 902):
+a. **Migrate the three `config-rail` references** to `widget-editor-popover`:
+   - ~line 237 ("adds a KPI widget…"): after adding a KPI it's selected →
+     `await waitFor(() => screen.getByTestId("widget-editor-popover"))` instead
+     of `getByTestId("config-rail")`.
+   - ~line 391 ("shows the 'Overrides canvas' pill…"): after selecting the
+     widget, `await waitFor(() => screen.getByTestId("widget-editor-popover"))`,
+     then **switch to the Filters tab** before asserting `override-pill` (the
+     pill now lives in the Filters tab, not an always-visible rail):
+     `fireEvent.click(screen.getByRole("tab", { name: /filters/i }))`.
+   - ~line 902 ("after a successful save lands on the read-only view…"):
      `queryByTestId("config-rail")` → `queryByTestId("widget-editor-popover")`
      must be null in view mode.
 
-b. **NEW reflow-invariance test** — "opening the widget editor popover does
-   not reflow the canvas":
-   - Load `REPORT_WITH_WIDGET`, enter edit mode, capture the canvas column.
-     Because the canvas is mocked (no real width), assert *structure* not
-     pixels: the flex row (`report-editor`'s inner `flex flex-1` container) has
-     exactly **one** flex child (the canvas column) both before and after the
-     widget is selected — i.e. selecting a widget does NOT insert a `w-80`
-     sibling. Concretely:
-     - Give the canvas column a stable testid (add `data-testid="report-canvas-column"`
-       to the `flex-1` div in `page.tsx`).
-     - Before select: `report-canvas-column` is the only element-child of the
-       flex row.
-     - Click the widget → `widget-editor-popover` appears (in the portal,
-       i.e. NOT inside `report-canvas-column`).
-     - After select: `report-canvas-column` is **still** the only
-       element-child of the flex row (the popover is portaled to body, not a
-       sibling). This is the regression guard for the reflow bug.
+b. **NEW reflow-invariance test** — "opening the widget editor popover does not
+   reflow the canvas (saved editor)":
+   - Load the report-with-widget fixture, enter edit mode. Add
+     `data-testid="report-canvas-column"` to the `flex-1` canvas column div
+     (page line 752) so it's addressable.
+   - Before select: `report-canvas-column` is the **only** element-child of the
+     `flex flex-1 overflow-hidden` row (line 751).
+   - Click the widget → `await waitFor(() => screen.getByTestId("widget-editor-popover"))`
+     (it appears in the portal at `document.body`, NOT inside
+     `report-canvas-column`).
+   - After select: `report-canvas-column` is **still** the only element-child of
+     the flex row (popover portaled to body, never a `w-80` sibling). This is
+     the regression guard for the reflow bug.
 
 Run-to-fail: `docker compose exec -T frontend npx vitest run tests/app/reports-editor-page.test.tsx`
 
-**Implement `page.tsx` changes:**
-1. Replace `import ConfigRail` with
+**Implement `[id]/page.tsx`:**
+1. Replace `import ConfigRail` (line 51) with
    `import WidgetEditorPopover from "@/components/reports/WidgetEditorPopover";`
-2. Add the `anchorEl` state + effect from Task 5.
-3. In the `flex flex-1 overflow-hidden` row: keep ONLY the canvas column
-   (`flex-1 overflow-y-auto …`), add `data-testid="report-canvas-column"`.
-   **Remove the `{editModeActive && selectedWidget && (<ConfigRail …/>)}`
-   block from inside the flex row.**
+2. Add `anchorEl` state + effect keyed on `editModeActive` + `selectedWidgetId`
+   + `layout.widgets`:
+   ```tsx
+   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+   useEffect(() => {
+     if (!editModeActive || !selectedWidgetId) { setAnchorEl(null); return; }
+     setAnchorEl(
+       document.querySelector(`[data-widget-shell="${selectedWidgetId}"]`) as HTMLElement | null,
+     );
+   }, [editModeActive, selectedWidgetId, layout.widgets]);
+   ```
+3. In the `flex flex-1 overflow-hidden` row (751): keep ONLY the canvas column
+   (752), add `data-testid="report-canvas-column"` to it. **Remove the
+   `{editModeActive && selectedWidget && (<ConfigRail …/>)}` block (822-829).**
 4. After the flex row (sibling, still inside `report-editor`), mount:
    ```tsx
    {editModeActive && selectedWidget && anchorEl && (
@@ -586,116 +799,192 @@ Run-to-fail: `docker compose exec -T frontend npx vitest run tests/app/reports-e
      />
    )}
    ```
-5. Delete `components/reports/ConfigRail.tsx`.
 
 Run-to-pass on the page test, then `tsc --noEmit`.
 
-**Commit:** `feat(reports): mount widget editor popover, remove ConfigRail rail`
+**Commit:** `feat(reports): mount widget editor popover in saved report editor`
 
 ---
 
-### Task 9 — Full-suite green + type-check + cleanup
+### Task 13 — Wire popover into `new/page.tsx` + reflow test
+
+**Files:** `app/reports/new/page.tsx`, plus a draft-page test
+(extend an existing draft test file, or add
+`tests/app/reports-draft-popover.test.tsx`)
+
+> **The draft page gates differently:** `new/page.tsx` is **always** in edit
+> mode — there is NO `editModeActive` flag. Today it renders ConfigRail on
+> `selectedWidget` alone (lines 310-317). The popover gate is
+> `selectedWidget && anchorEl` (no `editModeActive`). The `anchorEl` effect
+> likewise omits `editModeActive`.
+
+**Failing test first** (draft page):
+- After adding/selecting a widget,
+  `await waitFor(() => screen.getByTestId("widget-editor-popover"))`.
+- **Reflow-invariance (draft):** the `flex flex-1 overflow-hidden` row (line
+  266) has exactly one element-child (`report-canvas-column`, added to the
+  `flex-1` div at line 267) both before and after a widget is selected.
+
+Run-to-fail on that test path.
+
+**Implement `new/page.tsx`:**
+1. Replace `import ConfigRail` (line 34) with the `WidgetEditorPopover` import.
+2. Add `anchorEl` state + effect keyed on `selectedWidgetId` + `layout?.widgets`
+   (NO `editModeActive`):
+   ```tsx
+   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+   useEffect(() => {
+     if (!selectedWidgetId) { setAnchorEl(null); return; }
+     setAnchorEl(
+       document.querySelector(`[data-widget-shell="${selectedWidgetId}"]`) as HTMLElement | null,
+     );
+   }, [selectedWidgetId, layout?.widgets]);
+   ```
+3. In the flex row (266): keep ONLY the canvas column (267), add
+   `data-testid="report-canvas-column"`. **Remove the
+   `{selectedWidget && (<ConfigRail …/>)}` block (310-317).**
+4. After the flex row, mount the popover gated on
+   `selectedWidget && anchorEl` (NOT `editModeActive`):
+   ```tsx
+   {selectedWidget && anchorEl && (
+     <WidgetEditorPopover
+       widget={selectedWidget}
+       canvasFilters={canvasFilters}
+       anchorEl={anchorEl}
+       onUpdate={updateWidget}
+       onClose={() => setSelectedWidgetId(null)}
+     />
+   )}
+   ```
+
+Run-to-pass + `tsc --noEmit`.
+
+**Commit:** `feat(reports): mount widget editor popover in draft report editor`
+
+---
+
+### Task 14 — Delete ConfigRail
+
+**Files:** delete `components/reports/ConfigRail.tsx`
+
+By now nothing imports it: both pages use the popover (Tasks 12/13) and all
+three component tests were re-homed in PR1 (Task 9). Delete the file.
+
+Run-to-pass: `tsc --noEmit` (no dangling import).
+
+**Commit:** `refactor(reports): delete ConfigRail`
+
+---
+
+### Task 15 — PR2 pre-PR gate (eslint + tsc + FULL vitest + grep gate)
 
 **Files:** none (verification gate).
 
-1. `docker compose exec -T frontend npx tsc --noEmit` → clean.
-2. `docker compose exec -T frontend npx vitest run` → **entire** suite green
-   (project rule: never trust single-file runs; a cross-file rename can pass
-   the touched file and break another — see
-   `reference_frontend_full_suite_verification.md`).
-3. Grep for stragglers:
-   `grep -rn "config-rail\|ConfigRail" frontend/` → should return zero hits
-   (component deleted, all testids migrated).
-4. Confirm `Canvas.tsx` and `CanvasFiltersBar.tsx` are untouched in the diff
-   (`git diff --stat`).
+1. `docker compose exec -T frontend npx eslint . --quiet` → clean.
+2. `docker compose exec -T frontend npx tsc --noEmit` → clean.
+3. `docker compose exec -T frontend npx vitest run` → **entire** suite green.
+4. **Grep gate (must be zero across BOTH pages and all tests):**
+   `grep -rn "config-rail\|ConfigRail" frontend/` → **zero hits**. This proves:
+   the component is deleted, `[id]/page.tsx` AND `new/page.tsx` both dropped
+   their imports, and no orphaned test import survives.
+5. Confirm `Canvas.tsx`, `CanvasFiltersBar.tsx`, and `lib/reports/resolve.ts`
+   are untouched in the diff (`git diff --stat`).
 
-**Commit (if any cleanup):** fold into the prior commit or
-`test(reports): migrate editor tests off ConfigRail to popover`.
+PR2 is openable once 1-5 are green.
 
 ---
 
 ## Must-flag list (implementer: handle each explicitly)
 
-1. **`@floating-ui/react` dep + lockfile via the container.** Add to
-   `package.json`, run `npm install` **inside** the frontend container so the
-   lockfile matches the container platform, then `up --build -d frontend` —
-   a running dev container will otherwise fail to resolve the new import even
-   though CI (fresh build) is green (dev-unmounted/stale-image gotcha).
-2. **Existing `config-rail` testid references break.** Three spots in
-   `tests/app/reports-editor-page.test.tsx` (~236, ~390, ~902) reference
-   `data-testid="config-rail"`. All must move to `widget-editor-popover`, and
-   the override-pill test must first click the **Filters tab** (the pill is no
-   longer always-visible).
-3. **Page flex-container change.** Remove `<ConfigRail>` from the
-   `flex flex-1 overflow-hidden` row so the canvas column is the sole flex
-   child; the popover is portaled, never a flex sibling. Tag the canvas column
-   `data-testid="report-canvas-column"` for the reflow test.
-4. **Tab state + per-type control visibility.** Default tab = Data. Tabs are
-   always all three. Within Data/Style, branch on `widget.type`:
-   - `kpi`: no primary/secondary dimension (Data); compare checkbox (Style).
-   - `pie`/`sparkline`: single measure + single primary dimension, **no**
-     secondary dimension; pie also gets top_n (Style); sparkline gets nothing
-     extra in Style.
-   - `bar`: primary + secondary ("Break down by"); no Style knob.
-   - `table`: multi-series (columns, cap 5) + primary + secondary.
-   - `line`/`area`/`stacked_bar`: multi-series (cap 5); area/stacked_bar get
-     "Stack series" (Style); stacked_bar's checkbox defaults checked
-     (`stacked !== false`).
-5. **A11y:** `FloatingFocusManager` manages focus (modal={false},
-   `initialFocus={-1}` so focus lands on the dialog, not the first input);
-   Escape + outside-press close via `useDismiss`; `role="dialog"` +
-   `aria-label` via `useRole`; the selected widget shell gets
-   `aria-haspopup="dialog"` + `aria-expanded={selected}`; the tablist uses
-   `role="tablist"`/`role="tab"`/`role="tabpanel"` with
-   `aria-selected`/`aria-controls`/`aria-labelledby`. Touch-target floor for
-   the Close + tab buttons per DESIGN.md.
-6. **Reflow invariance test (the core regression guard):** assert the canvas
-   column remains the **sole element-child** of the flex row when the popover
-   opens (popover is portaled to body), so canvas geometry can't change on
-   select. This is the test that proves the bug is fixed.
-7. **`No Off-Token` design rule:** every color must come from theme tokens
-   (`border-border`, `bg-surface`, `text-text-*`, `ring-accent`, etc.) — reuse
+1. **Second ConfigRail consumer — `new/page.tsx`.** Both `[id]/page.tsx` AND
+   `new/page.tsx` mount ConfigRail in an identical `flex flex-1 overflow-hidden`
+   row and BOTH must migrate. Deleting ConfigRail without wiring `new/page.tsx`
+   breaks the build. **Gate difference:** the draft page is always in edit mode
+   — its popover gate is `selectedWidget && anchorEl` (no `editModeActive`), and
+   its `anchorEl` effect omits `editModeActive`. (PR2 Tasks 12 vs 13.)
+2. **Three orphaned component test files re-homed, not dropped** (~538 lines):
+   `config-rail-tooltips` → DataTab/measure editors; `override-pill-pickers` →
+   `FilterEditor`; `config-rail-secondary-dimension` → `DataTab`. Re-pointed in
+   **PR1 Task 9** while both old and new components exist; renamed off the
+   `config-rail` name so the PR2 grep gate passes.
+3. **Second-render test timing.** `anchorEl` is computed in a `useEffect` keyed
+   on the selected id, so the popover mounts on the **second** render after
+   selection. ALL page-level popover-presence assertions use
+   `await waitFor(() => screen.getByTestId("widget-editor-popover"))`, never
+   synchronous `getByTestId`. (Component-level tests in PR1 Task 7 pass
+   `anchorEl` directly and are synchronous.)
+4. **querySelector anchor staleness guard.** The popover `onClose`s when the
+   resolved node detaches: `useEffect(() => { if (anchorEl && !anchorEl.isConnected) onClose(); }, [anchorEl, onClose]);`.
+   Remember the post-commit effect timing (state is set after render).
+5. **floating-ui in jsdom:** `ResizeObserver` polyfill is GLOBAL in
+   `vitest.setup.ts` (PR1 Task 1b), not per-file. Prefer **Escape** as the
+   primary close assertion; for outside-press use `fireEvent.pointerDown`
+   (floating-ui `useDismiss` listens on **pointerdown**, NOT mousedown). jsdom
+   renders+positions floating-ui fine (all-zero rects → `translate(0,0)`), so
+   popover tests are real, not hollow.
+6. **Verbatim transcription hotspots.** Two branches must move
+   character-for-character: (a) the measure branch with the
+   `(widget.config as KPIConfig|BarConfig|PieConfig|SparklineConfig).measure`
+   cast → `DataTab`; (b) the `area`/`stacked_bar` stacked branch → `StyleTab`,
+   keeping BOTH the label split ("Stack mode" vs "Stack series") AND the default
+   split (`stacked_bar`: `stacked !== false`; `area`: `Boolean(stacked)`) AND
+   the shared `aria-label="Stack series"`.
+7. **Reflow invariance is the core regression guard** — assert the canvas
+   column (`report-canvas-column`) stays the **sole element-child** of the flex
+   row when the popover opens, on **both** pages (PR2 Tasks 12b + 13). The
+   popover is portaled to `document.body`, never a `w-80` flex sibling.
+8. **`No Off-Token` design rule:** every color from theme tokens
+   (`border-border`, `bg-surface`, `text-text-*`, `ring-accent`, …) — reuse
    ConfigRail's exact classes. `frontend/scripts/check-design-tokens.sh`
    CI-blocks raw Tailwind palette colors.
-8. **Frozen surfaces:** do NOT edit `Canvas.tsx`, `CanvasFiltersBar.tsx`,
-   `lib/reports/resolve.ts`, or the filter model. Confirm via `git diff --stat`.
+9. **Frozen surfaces:** do NOT edit `Canvas.tsx`, `CanvasFiltersBar.tsx`,
+   `lib/reports/resolve.ts`, or the filter model. Confirm via `git diff --stat`
+   in both gates.
+10. **Dep + lockfile via the container** (PR1 Task 1a): `npm install` inside the
+    frontend container, then `up --build -d frontend`, or a stale dev image
+    fails the import locally while CI is green.
 
 ---
 
 ## Self-Review
 
-**Spec coverage:**
-- Popover replaces ConfigRail, floats over canvas, anchored to widget via
-  `data-widget-shell` lookup → Tasks 5, 7, 8. ✔
-- floating-ui `useFloating`+`autoUpdate`+`useDismiss`+`useRole`+
-  `FloatingFocusManager` wiring spelled out → "Floating-UI wiring". ✔
-- 3 tabs Data/Filters/Style, default Data → Task 7. ✔
-- Data tab = disabled source + measure(s) + primary/optional-secondary
-  dimension; Filters = verbatim FilterEditor; Style = title + per-type knobs →
-  Tasks 4, 6. ✔
-- ALL ConfigRail controls + their `onUpdate` logic preserved by extraction →
-  Tasks 2-4, 6 (verbatim ports). ✔
-- Canvas does not reflow; ConfigRail removed from flex row; popover portaled →
-  Task 8 + reflow test. ✔
-- Page still gates on `editModeActive && selectedWidget` → Task 8 mount guard. ✔
-- Real test commands + full-suite gate → every task + Task 9. ✔
-- Must-flag list (8 items incl. dep/lockfile, broken testids, flex change, tab
-  state, a11y, reflow test) → present. ✔
-- Single coherent PR with internal ordering → stated; 9 tasks. ✔
+**PR split coverage:**
+- PR1 = extraction with **zero behavior change**; `ConfigRail.tsx` keeps
+  rendering the extracted pieces (Task 8) so both pages + all existing tests
+  stay green; popover built + unit-tested (Task 7) but NOT wired; 3 component
+  tests re-homed (Task 9). ✔
+- PR2 = wire both pages (Tasks 12, 13), `anchorEl` effect + staleness guard,
+  delete ConfigRail (Task 14), migrate page tests (waitFor + Escape + Filters
+  tab), reflow test for BOTH pages, grep gate = zero `ConfigRail` hits anywhere
+  (Task 15). ✔
 
-**Placeholder scan:** no `TODO`/`FIXME`/`...`-as-stub left in the plan; every
-new file has a concrete purpose and at least one test path. The optional
-`useWidgetMutations.ts` is called out as optional, not a dangling reference.
+**Architect's 6 numbered items — where each lands:**
+1. Second consumer `new/page.tsx` migrated identically → Goal, PR2 Task 13,
+   Must-flag #1. ✔
+2. Three orphaned test files re-homed (not dropped) → PR1 Task 9, Must-flag #2. ✔
+3. Second-render `waitFor` timing → "Test timing" section, PR2 Tasks 12a/12b/13,
+   Must-flag #3. ✔
+4. querySelector staleness guard (`!anchorEl.isConnected` → onClose) →
+   "Floating-UI wiring" + PR1 Task 7 + Must-flag #4. ✔
+5. floating-ui in jsdom: global `ResizeObserver` in `vitest.setup.ts` (Task 1b),
+   Escape primary, `pointerDown` (not mouseDown), real-not-hollow → "jsdom test
+   handling" + Must-flag #5. ✔
+6. Verbatim branches named (measure cast → DataTab; stacked label+default split
+   → StyleTab) → "Verbatim branches" section + PR1 Task 6 + Must-flag #6. ✔
 
-**Type consistency:** all types referenced (`Widget`, `CanvasFilters`,
-`WidgetFilters`, `Measure`, `SeriesConfig`, `Dimension`, `KPIConfig`/
-`BarConfig`/`PieConfig`/`SparklineConfig`/`LineConfig`/`AreaConfig`/
-`StackedBarConfig`/`TableConfig`) exist in `lib/reports/types.ts` as read.
-`anchorEl: HTMLElement | null` matches floating-ui's external-reference
-contract. `useReportQuery`/SWR untouched. `tsc --noEmit` is a gate in Tasks
-2-9.
+**CI gates:** both PRs end on a gate task (Task 10 / Task 15) running
+`eslint . --quiet` + `tsc --noEmit` + FULL `vitest run`; PR2 adds the grep gate.
+Commands use `docker compose exec -T frontend …` throughout. ✔
 
-**Known deviation (also in the final report):** ConfigRail renders **no**
-`Line.smooth` and **no** `format` control today; the brief listed both as Style
-knobs. To honor "re-housing, not logic rewrite" + the no-new-knobs non-goal,
-4a ports only existing controls and defers `smooth`/`format` to a fast-follow.
+**Known deviation (unchanged from prior plan):** ConfigRail renders **no**
+`Line.smooth` and **no** `format` control today; the original brief listed both
+as Style knobs. To honor "re-housing, not logic rewrite" + the no-new-knobs
+non-goal, 4a ports only existing controls and defers `smooth`/`format` to a
+fast-follow.
+
+**Type consistency:** all referenced types (`Widget`, `CanvasFilters`,
+`WidgetFilters`, `Measure`, `SeriesConfig`, `Dimension`, `KPIConfig`/`BarConfig`/
+`PieConfig`/`SparklineConfig`/`LineConfig`/`AreaConfig`/`StackedBarConfig`/
+`TableConfig`) exist in `lib/reports/types.ts`. `anchorEl: HTMLElement | null`
+matches floating-ui's external-reference contract. `tsc --noEmit` is a gate in
+every task.


### PR DESCRIPTION
PR 1 of 2 for the Reports v3 phase-4a widget-editor popover. **Zero behavior change.**

This PR extracts every `ConfigRail` sub-block into reusable pieces under `components/reports/config/` (control constants + `Section`, `SingleMeasureEditor`, `MeasuresEditor`, `FilterEditor`, a `useWidgetMutations` hook holding the verbatim mutation closures, and `DataTab`/`StyleTab` composers), and builds + unit-tests a new `WidgetEditorPopover` (floating-ui anchored dialog with a 3-tab Data/Filters/Style frame, dismissal, focus management, and the querySelector staleness guard).

`ConfigRail.tsx` still renders the extracted pieces, so both report pages and all existing ConfigRail tests stay green untouched — that is the proof of zero behavior change. The popover is built and unit-tested but **not yet wired into any page** (PR 2 wires it into both editor pages, adds the reflow-invariance regression test, and deletes `ConfigRail`).

The three orphaned ConfigRail component tests are re-homed onto the extracted components (tooltips → `DataTab`/`MeasuresEditor`; override pill → `FilterEditor`; secondary dimension → `DataTab`) and renamed off the `config-rail` name.

Adds `@floating-ui/react` plus a global `ResizeObserver` polyfill in `vitest.setup.ts` (floating-ui needs it under jsdom).

Gates: `eslint . --quiet`, `tsc --noEmit`, and the full `vitest run` (234 files / 1735 tests) all green. Both report pages and `Canvas`/`CanvasFiltersBar` are unchanged.