### PR TITLE
refactor(reports): polish widget-editor popover (shared anchor hook, a11y, tests)

### DIFF
--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -21,7 +21,7 @@
  * button in the header; the rollout-table PR2 row says "Save layout
  * (PATCH)" — both align with explicit-save.
  */
-import { use, useEffect, useMemo, useState } from "react";
+import { use, useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 
@@ -49,6 +49,7 @@ import Canvas from "@/components/reports/Canvas";
 import HistoryPanel from "@/components/reports/HistoryPanel";
 import CanvasFiltersBar from "@/components/reports/CanvasFiltersBar";
 import WidgetEditorPopover from "@/components/reports/WidgetEditorPopover";
+import { useWidgetAnchor } from "@/lib/reports/use-widget-anchor";
 import WidgetPicker from "@/components/reports/WidgetPicker";
 import WidgetShell from "@/components/reports/WidgetShell";
 import KPIWidget from "@/components/reports/widgets/KPIWidget";
@@ -305,7 +306,6 @@ export default function ReportEditorPage({ params }: PageProps) {
   const [layout, setLayout] = useState<LayoutJson>(DEFAULT_LAYOUT);
   const [canvasFilters, setCanvasFilters] = useState<CanvasFilters>({});
   const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [editMode, setEditMode] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -401,29 +401,24 @@ export default function ReportEditorPage({ params }: PageProps) {
   // resizing back up to desktop (as an owner) restores what they had open.
   const editModeActive = editMode && !isSmallScreen && canEdit;
 
-  // Resolve the selected widget's shell DOM node into ``anchorEl`` so the
-  // popover can float anchored to it. Keyed on the selected id and the
-  // widget list (a re-render of the canvas re-creates the shell node), so
-  // the anchor stays fresh. Runs post-commit, so the popover mounts on the
-  // render AFTER selection — page-level tests must ``waitFor`` it.
-  useEffect(() => {
-    if (!editModeActive || !selectedWidgetId) {
-      setAnchorEl(null);
-      return;
-    }
-    setAnchorEl(
-      document.querySelector(
-        `[data-widget-shell="${selectedWidgetId}"]`,
-      ) as HTMLElement | null,
-    );
-  }, [editModeActive, selectedWidgetId, layout.widgets]);
+  // Resolve the selected widget's shell into the popover anchor. Edit here
+  // is gated on ``editModeActive`` (desktop + owner + edit toggle).
+  const anchorEl = useWidgetAnchor(
+    selectedWidgetId,
+    editModeActive,
+    layout.widgets,
+  );
 
   function updateLayout(next: LayoutJson) {
     setLayout(next);
     setDirty(true);
   }
 
-  function updateWidget(nextWidget: Widget) {
+  // Stable identities so the popover's effects (keyed on ``onClose``) and
+  // ``buildWidgetMutations`` don't re-run on every parent render.
+  const closePopover = useCallback(() => setSelectedWidgetId(null), []);
+
+  const updateWidget = useCallback((nextWidget: Widget) => {
     setLayout((prev) => ({
       ...prev,
       widgets: prev.widgets.map((w) =>
@@ -431,7 +426,7 @@ export default function ReportEditorPage({ params }: PageProps) {
       ),
     }));
     setDirty(true);
-  }
+  }, []);
 
   function addWidget(type: WidgetType) {
     const id = newWidgetId();
@@ -845,14 +840,14 @@ export default function ReportEditorPage({ params }: PageProps) {
       {/* Widget editor — an anchored floating popover portaled to the body,
           NOT a flex sibling of the canvas, so selecting a widget never
           reflows / re-clamps the canvas grid. Gated on a resolved
-          ``anchorEl`` (set post-commit by the effect above). */}
+          ``anchorEl`` (set post-commit by ``useWidgetAnchor``). */}
       {editModeActive && selectedWidget && anchorEl && (
         <WidgetEditorPopover
           widget={selectedWidget}
           canvasFilters={canvasFilters}
           anchorEl={anchorEl}
           onUpdate={updateWidget}
-          onClose={() => setSelectedWidgetId(null)}
+          onClose={closePopover}
         />
       )}
 

--- a/frontend/app/reports/new/page.tsx
+++ b/frontend/app/reports/new/page.tsx
@@ -15,7 +15,7 @@
  * there is nothing saved to act on yet. Those live on the saved-report
  * editor at `/reports/[id]`.
  */
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
@@ -32,6 +32,7 @@ import type {
 import Canvas from "@/components/reports/Canvas";
 import CanvasFiltersBar from "@/components/reports/CanvasFiltersBar";
 import WidgetEditorPopover from "@/components/reports/WidgetEditorPopover";
+import { useWidgetAnchor } from "@/lib/reports/use-widget-anchor";
 import WidgetPicker from "@/components/reports/WidgetPicker";
 import WidgetShell from "@/components/reports/WidgetShell";
 import {
@@ -50,7 +51,6 @@ export default function ReportDraftPage() {
   const [layout, setLayout] = useState<LayoutJson | null>(null);
   const [canvasFilters, setCanvasFilters] = useState<CanvasFilters>({});
   const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -115,27 +115,20 @@ export default function ReportDraftPage() {
     [layout, selectedWidgetId],
   );
 
-  // Resolve the selected widget's shell DOM node into ``anchorEl`` for the
-  // popover anchor. The draft page is ALWAYS in edit mode, so there is no
-  // ``editModeActive`` gate here (unlike the saved-report editor). Runs
-  // post-commit, so the popover mounts on the render after selection.
-  useEffect(() => {
-    if (!selectedWidgetId) {
-      setAnchorEl(null);
-      return;
-    }
-    setAnchorEl(
-      document.querySelector(
-        `[data-widget-shell="${selectedWidgetId}"]`,
-      ) as HTMLElement | null,
-    );
-  }, [selectedWidgetId, layout?.widgets]);
+  // Resolve the selected widget's shell into the popover anchor. The draft
+  // page is ALWAYS in edit mode, so ``enabled`` is hardwired ``true`` (no
+  // ``editModeActive`` gate, unlike the saved-report editor).
+  const anchorEl = useWidgetAnchor(selectedWidgetId, true, layout?.widgets);
 
   function updateLayout(next: LayoutJson) {
     setLayout(next);
   }
 
-  function updateWidget(nextWidget: Widget) {
+  // Stable identities so the popover's effects (keyed on ``onClose``) and
+  // ``buildWidgetMutations`` don't re-run on every parent render.
+  const closePopover = useCallback(() => setSelectedWidgetId(null), []);
+
+  const updateWidget = useCallback((nextWidget: Widget) => {
     setLayout((prev) =>
       prev
         ? {
@@ -146,7 +139,7 @@ export default function ReportDraftPage() {
           }
         : prev,
     );
-  }
+  }, []);
 
   function addWidget(type: WidgetType) {
     const id = newWidgetId();
@@ -339,7 +332,7 @@ export default function ReportDraftPage() {
             canvasFilters={canvasFilters}
             anchorEl={anchorEl}
             onUpdate={updateWidget}
-            onClose={() => setSelectedWidgetId(null)}
+            onClose={closePopover}
           />
         )}
 

--- a/frontend/components/reports/WidgetEditorPopover.tsx
+++ b/frontend/components/reports/WidgetEditorPopover.tsx
@@ -66,8 +66,11 @@ export default function WidgetEditorPopover({
     refs.setReference(anchorEl);
   }, [anchorEl, refs]);
 
-  // querySelector anchor staleness guard: if the resolved node detaches
-  // (widget removed / canvas re-rendered the shell), close (deselect).
+  // querySelector anchor staleness guard: ``useWidgetAnchor`` resolves the
+  // shell node by querySelector, so a node captured in a prior render can be
+  // stale by the time the popover anchors to it (e.g. the widget was removed
+  // between resolution and this commit). If the captured node is no longer
+  // attached to the document, deselect rather than anchor to a dead node.
   useEffect(() => {
     if (anchorEl && !anchorEl.isConnected) onClose();
   }, [anchorEl, onClose]);
@@ -138,10 +141,19 @@ export default function WidgetEditorPopover({
                   tabIndex={active ? 0 : -1}
                   onClick={() => setTab(t.key)}
                   onKeyDown={(e) => {
-                    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+                    let nextIndex: number;
+                    if (e.key === "ArrowLeft") {
+                      nextIndex = (i - 1 + tabs.length) % tabs.length;
+                    } else if (e.key === "ArrowRight") {
+                      nextIndex = (i + 1) % tabs.length;
+                    } else if (e.key === "Home") {
+                      nextIndex = 0;
+                    } else if (e.key === "End") {
+                      nextIndex = tabs.length - 1;
+                    } else {
+                      return;
+                    }
                     e.preventDefault();
-                    const delta = e.key === "ArrowRight" ? 1 : -1;
-                    const nextIndex = (i + delta + tabs.length) % tabs.length;
                     const next = tabs[nextIndex];
                     setTab(next.key);
                     document

--- a/frontend/components/reports/config/useWidgetMutations.ts
+++ b/frontend/components/reports/config/useWidgetMutations.ts
@@ -4,10 +4,9 @@
  * The widget-editor mutation closures, extracted verbatim from the original
  * widget config rail into one shared plain factory so ``DataTab`` /
  * ``StyleTab`` / the popover all call the identical logic. It calls no React
- * hooks (callers invoke it
- * unconditionally at render), so it is named ``build*`` rather than
- * ``use*`` to keep the rules-of-hooks linter off a non-hook. Each setter
- * early-returns on the same type guards it did
+ * hooks (callers invoke it unconditionally at render), so it is named
+ * ``build*`` rather than ``use*`` to keep the rules-of-hooks linter off a
+ * non-hook. Each setter early-returns on the same type guards it enforced
  * inline (these guards are load-bearing — e.g. ``setSingleMeasure``
  * early-returns on ``isMultiSeries`` and ``setSecondaryDimension``
  * early-returns on ``kpi`` / ``isSingleAggLocked``).

--- a/frontend/lib/reports/use-widget-anchor.ts
+++ b/frontend/lib/reports/use-widget-anchor.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Resolve the selected widget's shell DOM node into an ``anchorEl`` so the
+ * widget-editor popover can float anchored to it (rather than consuming
+ * flex width and reflowing the canvas). Shared by the saved-report editor
+ * (``/reports/[id]``) and the draft creator (``/reports/new``).
+ *
+ * The effect runs post-commit, so the anchor resolves on the render AFTER
+ * selection — page-level tests must ``waitFor`` the popover.
+ *
+ * @param selectedWidgetId the currently selected widget id, or ``null``.
+ * @param enabled gate that mirrors each page's edit-mode contract. The
+ *   saved editor passes ``editModeActive`` (desktop + owner + edit toggle);
+ *   the draft creator is ALWAYS in edit mode, so it passes ``true``.
+ * @param reResolveTrigger the widgets list (``layout.widgets`` /
+ *   ``layout?.widgets``). A canvas re-render re-creates the shell node, so
+ *   re-resolving when the list identity changes keeps the anchor fresh.
+ */
+export function useWidgetAnchor(
+  selectedWidgetId: string | null,
+  enabled: boolean,
+  reResolveTrigger: unknown,
+): HTMLElement | null {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !selectedWidgetId) {
+      setAnchorEl(null);
+      return;
+    }
+    setAnchorEl(
+      document.querySelector(
+        `[data-widget-shell="${selectedWidgetId}"]`,
+      ) as HTMLElement | null,
+    );
+    // ``reResolveTrigger`` is the re-resolve dependency (the widgets list).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, selectedWidgetId, reResolveTrigger]);
+
+  return anchorEl;
+}

--- a/frontend/tests/app/reports-editor-page.test.tsx
+++ b/frontend/tests/app/reports-editor-page.test.tsx
@@ -384,10 +384,11 @@ describe("ReportEditorPage", () => {
     await screen.findByTestId("kpi-widget");
     fireEvent.click(screen.getByTestId("report-editor-toggle-edit"));
 
-    // Click the widget shell to select it; the popover mounts on the next
-    // render (after the anchorEl effect resolves the shell node).
-    const shell = screen.getByTestId("kpi-widget");
-    fireEvent.click(shell);
+    // Click the rendered widget to select it; the popover mounts on the next
+    // render (after ``useWidgetAnchor`` resolves the widget's shell node via
+    // querySelector). The Canvas stub renders the widget directly, so this
+    // click stands in for clicking the widget's shell on the real grid.
+    fireEvent.click(screen.getByTestId("kpi-widget"));
 
     await waitFor(() =>
       expect(screen.getByTestId("widget-editor-popover")).toBeInTheDocument(),
@@ -1049,5 +1050,41 @@ describe("ReportEditorPage", () => {
     // geometry/width is unchanged (the reflow regression guard).
     expect(flexRow.children).toHaveLength(1);
     expect(flexRow.children[0]).toBe(canvasCol);
+  });
+
+  it("edits a widget through the popover and the change round-trips into the saved layout", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);
+    saveLayoutMock.mockResolvedValue(REPORT_WITH_WIDGET as never);
+
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
+
+    // Report has a widget → opens in view mode; enter edit mode and select.
+    await screen.findByTestId("kpi-widget");
+    fireEvent.click(screen.getByTestId("report-editor-toggle-edit"));
+    fireEvent.click(screen.getByTestId("kpi-widget"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-editor-popover")).toBeInTheDocument(),
+    );
+
+    // The title control lives in the Style tab — switch to it, then rename
+    // the widget through the popover's title input.
+    fireEvent.click(screen.getByRole("tab", { name: /style/i }));
+    const titleInput = screen.getByLabelText("Widget title");
+    expect(titleInput).toHaveValue("Total");
+    fireEvent.change(titleInput, { target: { value: "Net total" } });
+    // The popover reflects the new value immediately (controlled input fed
+    // by the page's updateWidget state).
+    expect(screen.getByLabelText("Widget title")).toHaveValue("Net total");
+
+    // Persist and assert the edit reached the saved layout — i.e. the
+    // popover's onUpdate path actually mutated widget state on the page.
+    fireEvent.click(screen.getByTestId("report-editor-save"));
+    await waitFor(() => expect(saveLayoutMock).toHaveBeenCalledTimes(1));
+    const [, savedLayout] = saveLayoutMock.mock.calls[0];
+    expect(savedLayout.widgets).toHaveLength(1);
+    expect(savedLayout.widgets[0].id).toBe("w_kpi");
+    expect(savedLayout.widgets[0].title).toBe("Net total");
   });
 });


### PR DESCRIPTION
Post-merge follow-up to #446. No behavior change.

- **Shared anchor hook** — dedup the near-identical `anchorEl` querySelector effect from `reports/[id]` and `reports/new` into `lib/reports/use-widget-anchor.ts` (`useWidgetAnchor(selectedWidgetId, enabled, reResolveTrigger)`). The `enabled` gate preserves the per-page contract: `[id]` passes `editModeActive`, `new` (always edit mode, nullable layout) passes `true`.
- **Stabilize handlers** — wrap each page's `onClose` and `updateWidget` in `useCallback` so the popover's staleness-guard effect (dep `[anchorEl, onClose]`) and `buildWidgetMutations` stop re-running every render.
- **Home/End tablist keys** — add the standard WAI-ARIA first/last-tab keys alongside the existing Arrow handling.
- **Docs/comments** — complete a truncated/awkward JSDoc in `useWidgetMutations`; reword the staleness-guard comment (it catches a stale querySelector node, not a canvas re-render) and the override-pill test's shell-vs-widget comment.
- **Test** — add a page-level round-trip test: select a widget, edit its title through the popover, assert the change reaches the saved layout (the page's `updateWidget`/`onUpdate` path).

eslint, tsc, and the full vitest suite (236 files / 1777 tests) all green.