### PR TITLE
feat(reports): shared-date filter bar + per-widget filter chips

### DIFF
--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -24,12 +24,10 @@
 import { use, useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import useSWR from "swr";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
-import { apiFetch } from "@/lib/api";
-import type { Account, Category } from "@/lib/types";
+import { useFilterChipState } from "@/lib/reports/use-filter-chip-state";
 import {
   deleteReport,
   duplicateReport,
@@ -52,7 +50,6 @@ import Canvas from "@/components/reports/Canvas";
 import HistoryPanel from "@/components/reports/HistoryPanel";
 import CanvasFiltersBar from "@/components/reports/CanvasFiltersBar";
 import WidgetEditorPopover from "@/components/reports/WidgetEditorPopover";
-import type { TabKey } from "@/components/reports/WidgetEditorPopover";
 import { useWidgetAnchor } from "@/lib/reports/use-widget-anchor";
 import WidgetPicker from "@/components/reports/WidgetPicker";
 import WidgetShell from "@/components/reports/WidgetShell";
@@ -306,30 +303,21 @@ export default function ReportEditorPage({ params }: PageProps) {
   const { user, loading: authLoading, featureReportsV2 } = useAuth();
   const isSmallScreen = useIsSmallScreen();
 
-  // Accounts + categories for the filter-chip name lookups. Reuse the
-  // EXACT SWR keys ``AccountFilter`` / ``CategoryPicker`` use so the
-  // cache is shared (no extra network round-trip) and ids resolve to
-  // names in the chip header. Default to [] (count-fallback) while warm.
-  const { data: accounts } = useSWR<Account[]>(
-    "/api/v1/accounts?for=reports-filter",
-    () => apiFetch<Account[]>("/api/v1/accounts"),
-    { revalidateOnFocus: false },
-  );
-  const { data: categories } = useSWR<Category[]>(
-    "/api/v1/categories?for=reports-filter",
-    () => apiFetch<Category[]>("/api/v1/categories"),
-    { revalidateOnFocus: false },
-  );
-
   const [report, setReport] = useState<ReportSummary | null>(null);
   const [layout, setLayout] = useState<LayoutJson>(DEFAULT_LAYOUT);
   const [canvasFilters, setCanvasFilters] = useState<CanvasFilters>({});
   const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
-  // Deep-link request: a filter-chip click sets this to "filters" so the
-  // popover opens on its Filters tab. Cleared the instant the popover
-  // consumes it (consume-and-clear handshake), so every chip click is a
-  // fresh null → "filters" transition.
-  const [requestedTab, setRequestedTab] = useState<TabKey | null>(null);
+  // Shared filter-chip wiring: accounts/categories name lookups (shared
+  // SWR cache), the popover Filters-tab deep-link request, and the
+  // select-with-Filters chip handler. ``setSelectedWidgetId`` is a stable
+  // useState setter so the hook's callbacks keep a stable identity.
+  const {
+    accounts,
+    categories,
+    requestedTab,
+    selectWidgetFilters,
+    clearRequestedTab,
+  } = useFilterChipState(setSelectedWidgetId);
   const [editMode, setEditMode] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -445,14 +433,8 @@ export default function ReportEditorPage({ params }: PageProps) {
     // Belt-and-suspenders: the consume callback is the real clear, but
     // also drop any pending request on close so a stale chip request
     // can't leak into the next selection.
-    setRequestedTab(null);
-  }, []);
-
-  // Chip click: select the widget AND request the Filters tab.
-  const selectWidgetFilters = useCallback((widgetId: string) => {
-    setSelectedWidgetId(widgetId);
-    setRequestedTab("filters");
-  }, []);
+    clearRequestedTab();
+  }, [clearRequestedTab]);
 
   const updateWidget = useCallback((nextWidget: Widget) => {
     setLayout((prev) => ({
@@ -524,6 +506,10 @@ export default function ReportEditorPage({ params }: PageProps) {
   // reflects the most recent successful load/save.
   function handleCancelEdit() {
     if (report) hydrateFromReport(report);
+    // Mirror handleSave: clear any open selection + pending tab request so
+    // dropping to view mode never leaves a selection ring with no popover.
+    setSelectedWidgetId(null);
+    clearRequestedTab();
     setEditMode(false);
     setSaveError(null);
   }
@@ -866,15 +852,14 @@ export default function ReportEditorPage({ params }: PageProps) {
                   onRemove={() => removeWidget(w.id)}
                   widget={w}
                   canvasFilters={canvasFilters}
-                  accounts={accounts ?? []}
-                  categories={categories ?? []}
-                  // View-mode orphan-selection guard: the popover is gated
-                  // on ``editModeActive``, so in view mode a chip click
-                  // would draw a selection ring with no editor behind it.
-                  // Chips still render (informational) but are inert.
-                  onSelectFilters={
-                    editModeActive ? () => selectWidgetFilters(w.id) : () => {}
-                  }
+                  accounts={accounts}
+                  categories={categories}
+                  // WidgetShell gates chip interactivity on its ``editMode``
+                  // prop (``editModeActive`` here): in view mode the chips
+                  // render as inert informational spans, so this handler is
+                  // only ever invoked in edit mode — no orphan-selection
+                  // guard needed.
+                  onSelectFilters={() => selectWidgetFilters(w.id)}
                 >
                   {renderWidgetByType(w, canvasFilters, editModeActive)}
                 </WidgetShell>
@@ -894,7 +879,7 @@ export default function ReportEditorPage({ params }: PageProps) {
           canvasFilters={canvasFilters}
           anchorEl={anchorEl}
           requestedTab={requestedTab ?? undefined}
-          onTabConsumed={() => setRequestedTab(null)}
+          onTabConsumed={clearRequestedTab}
           onUpdate={updateWidget}
           onClose={closePopover}
         />

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -24,9 +24,12 @@
 import { use, useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import useSWR from "swr";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+import type { Account, Category } from "@/lib/types";
 import {
   deleteReport,
   duplicateReport,
@@ -49,6 +52,7 @@ import Canvas from "@/components/reports/Canvas";
 import HistoryPanel from "@/components/reports/HistoryPanel";
 import CanvasFiltersBar from "@/components/reports/CanvasFiltersBar";
 import WidgetEditorPopover from "@/components/reports/WidgetEditorPopover";
+import type { TabKey } from "@/components/reports/WidgetEditorPopover";
 import { useWidgetAnchor } from "@/lib/reports/use-widget-anchor";
 import WidgetPicker from "@/components/reports/WidgetPicker";
 import WidgetShell from "@/components/reports/WidgetShell";
@@ -302,10 +306,30 @@ export default function ReportEditorPage({ params }: PageProps) {
   const { user, loading: authLoading, featureReportsV2 } = useAuth();
   const isSmallScreen = useIsSmallScreen();
 
+  // Accounts + categories for the filter-chip name lookups. Reuse the
+  // EXACT SWR keys ``AccountFilter`` / ``CategoryPicker`` use so the
+  // cache is shared (no extra network round-trip) and ids resolve to
+  // names in the chip header. Default to [] (count-fallback) while warm.
+  const { data: accounts } = useSWR<Account[]>(
+    "/api/v1/accounts?for=reports-filter",
+    () => apiFetch<Account[]>("/api/v1/accounts"),
+    { revalidateOnFocus: false },
+  );
+  const { data: categories } = useSWR<Category[]>(
+    "/api/v1/categories?for=reports-filter",
+    () => apiFetch<Category[]>("/api/v1/categories"),
+    { revalidateOnFocus: false },
+  );
+
   const [report, setReport] = useState<ReportSummary | null>(null);
   const [layout, setLayout] = useState<LayoutJson>(DEFAULT_LAYOUT);
   const [canvasFilters, setCanvasFilters] = useState<CanvasFilters>({});
   const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
+  // Deep-link request: a filter-chip click sets this to "filters" so the
+  // popover opens on its Filters tab. Cleared the instant the popover
+  // consumes it (consume-and-clear handshake), so every chip click is a
+  // fresh null → "filters" transition.
+  const [requestedTab, setRequestedTab] = useState<TabKey | null>(null);
   const [editMode, setEditMode] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -416,7 +440,19 @@ export default function ReportEditorPage({ params }: PageProps) {
 
   // Stable identities so the popover's effects (keyed on ``onClose``) and
   // ``buildWidgetMutations`` don't re-run on every parent render.
-  const closePopover = useCallback(() => setSelectedWidgetId(null), []);
+  const closePopover = useCallback(() => {
+    setSelectedWidgetId(null);
+    // Belt-and-suspenders: the consume callback is the real clear, but
+    // also drop any pending request on close so a stale chip request
+    // can't leak into the next selection.
+    setRequestedTab(null);
+  }, []);
+
+  // Chip click: select the widget AND request the Filters tab.
+  const selectWidgetFilters = useCallback((widgetId: string) => {
+    setSelectedWidgetId(widgetId);
+    setRequestedTab("filters");
+  }, []);
 
   const updateWidget = useCallback((nextWidget: Widget) => {
     setLayout((prev) => ({
@@ -775,9 +811,9 @@ export default function ReportEditorPage({ params }: PageProps) {
                 This report has no widgets yet
               </p>
               <p className="mx-auto mt-1 max-w-md text-sm text-text-muted">
-                Add a widget to see your data. Canvas filters (date,
-                accounts, categories) apply to every widget, so a report
-                with no widgets shows nothing.
+                Add a widget to see your data. The canvas date applies to
+                every widget; accounts and categories are per-widget, so a
+                report with no widgets shows nothing.
               </p>
               <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
                 {/* "Add widget" is owner-only: a non-owner viewing a shared
@@ -828,6 +864,17 @@ export default function ReportEditorPage({ params }: PageProps) {
                   editMode={editModeActive}
                   onSelect={() => setSelectedWidgetId(w.id)}
                   onRemove={() => removeWidget(w.id)}
+                  widget={w}
+                  canvasFilters={canvasFilters}
+                  accounts={accounts ?? []}
+                  categories={categories ?? []}
+                  // View-mode orphan-selection guard: the popover is gated
+                  // on ``editModeActive``, so in view mode a chip click
+                  // would draw a selection ring with no editor behind it.
+                  // Chips still render (informational) but are inert.
+                  onSelectFilters={
+                    editModeActive ? () => selectWidgetFilters(w.id) : () => {}
+                  }
                 >
                   {renderWidgetByType(w, canvasFilters, editModeActive)}
                 </WidgetShell>
@@ -846,6 +893,8 @@ export default function ReportEditorPage({ params }: PageProps) {
           widget={selectedWidget}
           canvasFilters={canvasFilters}
           anchorEl={anchorEl}
+          requestedTab={requestedTab ?? undefined}
+          onTabConsumed={() => setRequestedTab(null)}
           onUpdate={updateWidget}
           onClose={closePopover}
         />

--- a/frontend/app/reports/new/page.tsx
+++ b/frontend/app/reports/new/page.tsx
@@ -18,9 +18,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
+import useSWR from "swr";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+import type { Account, Category } from "@/lib/types";
 import { createReport, listTemplates } from "@/lib/reports/api";
 import { blankDraftSeed } from "@/lib/reports/draft";
 import type {
@@ -32,6 +35,7 @@ import type {
 import Canvas from "@/components/reports/Canvas";
 import CanvasFiltersBar from "@/components/reports/CanvasFiltersBar";
 import WidgetEditorPopover from "@/components/reports/WidgetEditorPopover";
+import type { TabKey } from "@/components/reports/WidgetEditorPopover";
 import { useWidgetAnchor } from "@/lib/reports/use-widget-anchor";
 import WidgetPicker from "@/components/reports/WidgetPicker";
 import WidgetShell from "@/components/reports/WidgetShell";
@@ -47,10 +51,27 @@ export default function ReportDraftPage() {
   const templateKey = searchParams.get("template");
   const { user, loading: authLoading, featureReportsV2 } = useAuth();
 
+  // Accounts + categories for the filter-chip name lookups. Same SWR
+  // keys as ``AccountFilter`` / ``CategoryPicker`` so the cache is shared
+  // (no extra network round-trip). Default [] → count-fallback while warm.
+  const { data: accounts } = useSWR<Account[]>(
+    "/api/v1/accounts?for=reports-filter",
+    () => apiFetch<Account[]>("/api/v1/accounts"),
+    { revalidateOnFocus: false },
+  );
+  const { data: categories } = useSWR<Category[]>(
+    "/api/v1/categories?for=reports-filter",
+    () => apiFetch<Category[]>("/api/v1/categories"),
+    { revalidateOnFocus: false },
+  );
+
   const [name, setName] = useState("Untitled report");
   const [layout, setLayout] = useState<LayoutJson | null>(null);
   const [canvasFilters, setCanvasFilters] = useState<CanvasFilters>({});
   const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
+  // Deep-link request for the popover's Filters tab (filter-chip click).
+  // Consume-and-clear: cleared the instant the popover honors it.
+  const [requestedTab, setRequestedTab] = useState<TabKey | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -126,7 +147,17 @@ export default function ReportDraftPage() {
 
   // Stable identities so the popover's effects (keyed on ``onClose``) and
   // ``buildWidgetMutations`` don't re-run on every parent render.
-  const closePopover = useCallback(() => setSelectedWidgetId(null), []);
+  const closePopover = useCallback(() => {
+    setSelectedWidgetId(null);
+    setRequestedTab(null); // belt-and-suspenders; consume callback is the real clear
+  }, []);
+
+  // Chip click: select the widget AND request the Filters tab. The draft
+  // page is always edit mode, so this is always the real handler.
+  const selectWidgetFilters = useCallback((widgetId: string) => {
+    setSelectedWidgetId(widgetId);
+    setRequestedTab("filters");
+  }, []);
 
   const updateWidget = useCallback((nextWidget: Widget) => {
     setLayout((prev) =>
@@ -287,8 +318,8 @@ export default function ReportDraftPage() {
                   This draft has no widgets yet
                 </p>
                 <p className="mx-auto mt-1 max-w-md text-sm text-text-muted">
-                  Add a widget to see your data. Canvas filters (date,
-                  accounts, categories) apply to every widget.
+                  Add a widget to see your data. The canvas date applies to
+                  every widget; accounts and categories are per-widget.
                 </p>
                 <div className="mt-4 flex items-center justify-center">
                   <button
@@ -313,6 +344,12 @@ export default function ReportDraftPage() {
                     editMode
                     onSelect={() => setSelectedWidgetId(w.id)}
                     onRemove={() => removeWidget(w.id)}
+                    widget={w}
+                    canvasFilters={canvasFilters}
+                    accounts={accounts ?? []}
+                    categories={categories ?? []}
+                    // Always edit mode here → the chip's real handler.
+                    onSelectFilters={() => selectWidgetFilters(w.id)}
                   >
                     {renderWidgetByType(w, canvasFilters, true)}
                   </WidgetShell>
@@ -331,6 +368,8 @@ export default function ReportDraftPage() {
             widget={selectedWidget}
             canvasFilters={canvasFilters}
             anchorEl={anchorEl}
+            requestedTab={requestedTab ?? undefined}
+            onTabConsumed={() => setRequestedTab(null)}
             onUpdate={updateWidget}
             onClose={closePopover}
           />

--- a/frontend/app/reports/new/page.tsx
+++ b/frontend/app/reports/new/page.tsx
@@ -18,12 +18,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import useSWR from "swr";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
-import { apiFetch } from "@/lib/api";
-import type { Account, Category } from "@/lib/types";
+import { useFilterChipState } from "@/lib/reports/use-filter-chip-state";
 import { createReport, listTemplates } from "@/lib/reports/api";
 import { blankDraftSeed } from "@/lib/reports/draft";
 import type {
@@ -35,7 +33,6 @@ import type {
 import Canvas from "@/components/reports/Canvas";
 import CanvasFiltersBar from "@/components/reports/CanvasFiltersBar";
 import WidgetEditorPopover from "@/components/reports/WidgetEditorPopover";
-import type { TabKey } from "@/components/reports/WidgetEditorPopover";
 import { useWidgetAnchor } from "@/lib/reports/use-widget-anchor";
 import WidgetPicker from "@/components/reports/WidgetPicker";
 import WidgetShell from "@/components/reports/WidgetShell";
@@ -51,27 +48,21 @@ export default function ReportDraftPage() {
   const templateKey = searchParams.get("template");
   const { user, loading: authLoading, featureReportsV2 } = useAuth();
 
-  // Accounts + categories for the filter-chip name lookups. Same SWR
-  // keys as ``AccountFilter`` / ``CategoryPicker`` so the cache is shared
-  // (no extra network round-trip). Default [] → count-fallback while warm.
-  const { data: accounts } = useSWR<Account[]>(
-    "/api/v1/accounts?for=reports-filter",
-    () => apiFetch<Account[]>("/api/v1/accounts"),
-    { revalidateOnFocus: false },
-  );
-  const { data: categories } = useSWR<Category[]>(
-    "/api/v1/categories?for=reports-filter",
-    () => apiFetch<Category[]>("/api/v1/categories"),
-    { revalidateOnFocus: false },
-  );
-
   const [name, setName] = useState("Untitled report");
   const [layout, setLayout] = useState<LayoutJson | null>(null);
   const [canvasFilters, setCanvasFilters] = useState<CanvasFilters>({});
   const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
-  // Deep-link request for the popover's Filters tab (filter-chip click).
-  // Consume-and-clear: cleared the instant the popover honors it.
-  const [requestedTab, setRequestedTab] = useState<TabKey | null>(null);
+  // Shared filter-chip wiring: accounts/categories name lookups (shared
+  // SWR cache), the popover Filters-tab deep-link request, and the
+  // select-with-Filters chip handler. The draft page is ALWAYS edit mode,
+  // so ``selectWidgetFilters`` is always the real handler.
+  const {
+    accounts,
+    categories,
+    requestedTab,
+    selectWidgetFilters,
+    clearRequestedTab,
+  } = useFilterChipState(setSelectedWidgetId);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -149,15 +140,8 @@ export default function ReportDraftPage() {
   // ``buildWidgetMutations`` don't re-run on every parent render.
   const closePopover = useCallback(() => {
     setSelectedWidgetId(null);
-    setRequestedTab(null); // belt-and-suspenders; consume callback is the real clear
-  }, []);
-
-  // Chip click: select the widget AND request the Filters tab. The draft
-  // page is always edit mode, so this is always the real handler.
-  const selectWidgetFilters = useCallback((widgetId: string) => {
-    setSelectedWidgetId(widgetId);
-    setRequestedTab("filters");
-  }, []);
+    clearRequestedTab(); // belt-and-suspenders; consume callback is the real clear
+  }, [clearRequestedTab]);
 
   const updateWidget = useCallback((nextWidget: Widget) => {
     setLayout((prev) =>
@@ -346,8 +330,8 @@ export default function ReportDraftPage() {
                     onRemove={() => removeWidget(w.id)}
                     widget={w}
                     canvasFilters={canvasFilters}
-                    accounts={accounts ?? []}
-                    categories={categories ?? []}
+                    accounts={accounts}
+                    categories={categories}
                     // Always edit mode here → the chip's real handler.
                     onSelectFilters={() => selectWidgetFilters(w.id)}
                   >
@@ -369,7 +353,7 @@ export default function ReportDraftPage() {
             canvasFilters={canvasFilters}
             anchorEl={anchorEl}
             requestedTab={requestedTab ?? undefined}
-            onTabConsumed={() => setRequestedTab(null)}
+            onTabConsumed={clearRequestedTab}
             onUpdate={updateWidget}
             onClose={closePopover}
           />

--- a/frontend/components/reports/CanvasFiltersBar.tsx
+++ b/frontend/components/reports/CanvasFiltersBar.tsx
@@ -2,23 +2,13 @@
 
 /**
  * Canvas-wide filters row — sits above the canvas. Edits flow into
- * the report's ``canvas_filters_json`` blob and cascade to every
- * widget that doesn't override the same field (spec section 4).
+ * the report's ``canvas_filters_json`` blob.
  *
- * PR3 swaps the comma-list inputs for the proper filter primitives:
- *  - Date range  -> ``DatePresetChips`` (preset chips + custom
- *    absolute inputs).
- *  - Accounts    -> ``AccountFilter`` (chip picker, fetches the org's
- *    accounts on mount).
- *  - Categories  -> ``CategoryPicker`` (tree picker with master /
- *    sub cascade, multi-select).
- *
- * Tag-based filters DO NOT appear on the canvas — they're a
- * per-widget knob per spec section 4 ("the canvas filter shape is
- * date range + accounts + categories; tag filters are widget-only").
+ * Phase 4b: the canvas bar is DATE-ONLY. The shared date range
+ * cascades to every widget that doesn't override it. Accounts,
+ * categories, and tags are all per-widget now (edited in the widget
+ * popover's Filters tab), so they no longer appear on the canvas.
  */
-import AccountFilter from "@/components/reports/filters/AccountFilter";
-import CategoryPicker from "@/components/reports/filters/CategoryPicker";
 import DatePresetChips from "@/components/reports/filters/DatePresetChips";
 import type { CanvasFilters } from "@/lib/reports/types";
 
@@ -31,37 +21,16 @@ export default function CanvasFiltersBar({ value, onChange }: Props) {
   return (
     <div
       data-testid="canvas-filters-bar"
-      className="grid grid-cols-1 gap-4 rounded-md border border-border bg-surface px-4 py-3 lg:grid-cols-3"
+      className="rounded-md border border-border bg-surface px-4 py-3"
     >
-      <div>
-        <span className="mb-1 block text-[10px] font-medium uppercase tracking-wider text-text-muted">
-          Date range
-        </span>
-        <DatePresetChips
-          value={value.date_range}
-          ariaPrefix="Canvas"
-          onChange={(next) =>
-            onChange({ ...value, date_range: next || undefined })
-          }
-        />
-      </div>
-      <AccountFilter
-        value={value.account_ids ?? []}
-        ariaPrefix="Canvas account"
-        onChange={(account_ids) =>
-          onChange({
-            ...value,
-            account_ids: account_ids.length > 0 ? account_ids : undefined,
-          })
-        }
-      />
-      <CategoryPicker
-        value={value.category_ids ?? []}
-        onChange={(category_ids) =>
-          onChange({
-            ...value,
-            category_ids: category_ids.length > 0 ? category_ids : undefined,
-          })
+      <span className="mb-1 block text-[10px] font-medium uppercase tracking-wider text-text-muted">
+        Date range
+      </span>
+      <DatePresetChips
+        value={value.date_range}
+        ariaPrefix="Canvas"
+        onChange={(next) =>
+          onChange({ ...value, date_range: next || undefined })
         }
       />
     </div>

--- a/frontend/components/reports/WidgetEditorPopover.tsx
+++ b/frontend/components/reports/WidgetEditorPopover.tsx
@@ -114,8 +114,13 @@ export default function WidgetEditorPopover({
       setTab(requestedTab);
       onTabConsumed?.();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- onTabConsumed
-    // is read in the body, not a dependency; we act only on requestedTab.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional:
+    // honor a request ONLY on a requestedTab transition. ``onTabConsumed``
+    // is a page callback whose identity isn't guaranteed stable across
+    // renders; listing it would re-fire this effect on its identity change
+    // (re-consuming a request that's already been honored). We deliberately
+    // read the latest ``onTabConsumed`` from the closure and key only on
+    // ``requestedTab``.
   }, [requestedTab]);
 
   const dismiss = useDismiss(context, {

--- a/frontend/components/reports/WidgetEditorPopover.tsx
+++ b/frontend/components/reports/WidgetEditorPopover.tsx
@@ -31,24 +31,37 @@ import FilterEditor from "@/components/reports/config/FilterEditor";
 import { buildWidgetMutations } from "@/components/reports/config/useWidgetMutations";
 import type { CanvasFilters, Widget } from "@/lib/reports/types";
 
+export type TabKey = "data" | "filters" | "style";
+
 interface Props {
   widget: Widget;
   canvasFilters: CanvasFilters;
   anchorEl: HTMLElement | null;
+  /**
+   * A deep-link request to open on a specific tab (e.g. a filter chip
+   * requesting "filters"). Honored once and immediately cleared via
+   * ``onTabConsumed`` — see the consume-and-clear handshake below.
+   */
+  requestedTab?: TabKey;
+  /** Called the instant ``requestedTab`` is honored, so the page can
+   *  clear it back to null (making every chip click a fresh request). */
+  onTabConsumed?: () => void;
   onUpdate: (next: Widget) => void;
   onClose: () => void;
 }
-
-type TabKey = "data" | "filters" | "style";
 
 export default function WidgetEditorPopover({
   widget,
   canvasFilters,
   anchorEl,
+  requestedTab,
+  onTabConsumed,
   onUpdate,
   onClose,
 }: Props) {
-  const [tab, setTab] = useState<TabKey>("data");
+  // Lazy init handles the fresh-mount case (a chip click that mounts the
+  // popover straight onto Filters).
+  const [tab, setTab] = useState<TabKey>(() => requestedTab ?? "data");
   const baseId = useId();
 
   const { refs, floatingStyles, context } = useFloating({
@@ -75,11 +88,35 @@ export default function WidgetEditorPopover({
     if (anchorEl && !anchorEl.isConnected) onClose();
   }, [anchorEl, onClose]);
 
-  // Reset to the default tab when the selected widget identity changes,
-  // so opening a different widget never lands on a stale tab.
+  // Consume-and-clear handshake — TWO separate effects (a single
+  // combined effect is racy; see the requested-tab test for the two
+  // races this avoids).
+  //
+  // Reset effect — keyed on the widget IDENTITY only. Resets the tab
+  // when a different widget is selected (honoring a fresh requestedTab
+  // at switch time). Crucially it is NOT keyed on ``requestedTab``, so
+  // when the page clears requestedTab (filters → null) this effect does
+  // NOT re-fire and clobber the active tab back to Data.
   useEffect(() => {
-    setTab("data");
+    setTab(requestedTab ?? "data");
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional:
+    // reset only on widget-identity change; requestedTab is read at
+    // switch time, not a dependency (adding it causes a clobber-to-Data).
   }, [widget.id]);
+
+  // Honor-request effect — keyed on ``requestedTab`` only. When a chip
+  // click sets requestedTab (a genuine null → "filters" transition,
+  // because the page clears it on consume), switch to that tab and
+  // immediately signal consumption so the page resets it to null. This
+  // makes a SECOND chip click on the already-selected widget work.
+  useEffect(() => {
+    if (requestedTab) {
+      setTab(requestedTab);
+      onTabConsumed?.();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onTabConsumed
+    // is read in the body, not a dependency; we act only on requestedTab.
+  }, [requestedTab]);
 
   const dismiss = useDismiss(context, {
     outsidePress: true,

--- a/frontend/components/reports/WidgetFilterChips.tsx
+++ b/frontend/components/reports/WidgetFilterChips.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * Per-widget filter-chip header row. Renders one pill chip per effective
+ * non-default filter the widget queries (computed by
+ * ``describeWidgetFilters`` so the chips can never lie about what the
+ * widget runs). Each chip is a button that selects the widget and opens
+ * the widget popover on the Filters tab via ``onSelectFilters``.
+ *
+ * Presentational only — it mounts inside ``WidgetShell``. Renders
+ * nothing when the widget has no set filters.
+ */
+import { describeWidgetFilters } from "@/lib/reports/describe-filters";
+import type { CanvasFilters, Widget } from "@/lib/reports/types";
+import type { Account, Category } from "@/lib/types";
+
+interface Props {
+  widget: Widget;
+  canvasFilters: CanvasFilters;
+  accounts: Account[];
+  categories: Category[];
+  /** Select the widget + open the popover's Filters tab. */
+  onSelectFilters: () => void;
+}
+
+// Pill chips share the OverridePill visual register (rounded-full,
+// small text). Overridden date chips use the accent register; every
+// other chip uses a neutral surface register.
+const PILL_BASE =
+  "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium transition";
+const OVERRIDDEN_CLASS = `${PILL_BASE} bg-accent/15 text-accent hover:bg-accent/25`;
+const NEUTRAL_CLASS = `${PILL_BASE} bg-surface-raised text-text-secondary hover:bg-surface`;
+
+export default function WidgetFilterChips({
+  widget,
+  canvasFilters,
+  accounts,
+  categories,
+  onSelectFilters,
+}: Props) {
+  const chips = describeWidgetFilters(widget, canvasFilters, {
+    accounts,
+    categories,
+  });
+
+  if (chips.length === 0) return null;
+
+  return (
+    <div
+      data-testid="widget-filter-chips"
+      className="flex flex-wrap gap-1 px-1 pb-1 pt-0.5"
+    >
+      {chips.map((chip) => (
+        <button
+          key={chip.key}
+          type="button"
+          data-testid={`widget-filter-chip-${chip.key}`}
+          aria-label={`Edit ${chip.key} filter`}
+          onClick={(e) => {
+            // Stop propagation so the chip's own select-with-Filters
+            // action wins over WidgetShell's plain onSelect (which would
+            // select the widget WITHOUT requesting the Filters tab).
+            e.stopPropagation();
+            onSelectFilters();
+          }}
+          className={chip.overridden ? OVERRIDDEN_CLASS : NEUTRAL_CLASS}
+        >
+          {chip.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/reports/WidgetFilterChips.tsx
+++ b/frontend/components/reports/WidgetFilterChips.tsx
@@ -4,8 +4,13 @@
  * Per-widget filter-chip header row. Renders one pill chip per effective
  * non-default filter the widget queries (computed by
  * ``describeWidgetFilters`` so the chips can never lie about what the
- * widget runs). Each chip is a button that selects the widget and opens
- * the widget popover on the Filters tab via ``onSelectFilters``.
+ * widget runs).
+ *
+ * In edit mode (``interactive``) each chip is a ``<button>`` that selects
+ * the widget and opens the widget popover on the Filters tab via
+ * ``onSelectFilters``. In view mode it renders an inert ``<span>`` —
+ * informational only, NOT focusable, with no "Edit" affordance — so a
+ * keyboard user can't tab to a no-op control.
  *
  * Presentational only — it mounts inside ``WidgetShell``. Renders
  * nothing when the widget has no set filters.
@@ -19,6 +24,12 @@ interface Props {
   canvasFilters: CanvasFilters;
   accounts: Account[];
   categories: Category[];
+  /**
+   * When true, chips are interactive buttons that select the widget and
+   * open the popover's Filters tab. When false (view mode) they render as
+   * inert, non-focusable spans. ``WidgetShell`` passes ``editMode``.
+   */
+  interactive: boolean;
   /** Select the widget + open the popover's Filters tab. */
   onSelectFilters: () => void;
 }
@@ -36,6 +47,7 @@ export default function WidgetFilterChips({
   canvasFilters,
   accounts,
   categories,
+  interactive,
   onSelectFilters,
 }: Props) {
   const chips = describeWidgetFilters(widget, canvasFilters, {
@@ -50,24 +62,41 @@ export default function WidgetFilterChips({
       data-testid="widget-filter-chips"
       className="flex flex-wrap gap-1 px-1 pb-1 pt-0.5"
     >
-      {chips.map((chip) => (
-        <button
-          key={chip.key}
-          type="button"
-          data-testid={`widget-filter-chip-${chip.key}`}
-          aria-label={`Edit ${chip.key} filter`}
-          onClick={(e) => {
-            // Stop propagation so the chip's own select-with-Filters
-            // action wins over WidgetShell's plain onSelect (which would
-            // select the widget WITHOUT requesting the Filters tab).
-            e.stopPropagation();
-            onSelectFilters();
-          }}
-          className={chip.overridden ? OVERRIDDEN_CLASS : NEUTRAL_CLASS}
-        >
-          {chip.label}
-        </button>
-      ))}
+      {chips.map((chip) => {
+        const className = chip.overridden ? OVERRIDDEN_CLASS : NEUTRAL_CLASS;
+        // View mode: render an inert, non-focusable, informational span.
+        if (!interactive) {
+          return (
+            <span
+              key={chip.key}
+              data-testid={`widget-filter-chip-${chip.key}`}
+              className={className}
+            >
+              {chip.label}
+            </span>
+          );
+        }
+        // Edit mode: an editable chip. The aria-label uses the HUMAN
+        // display label (e.g. "Pending", "Groceries"), never the raw key.
+        return (
+          <button
+            key={chip.key}
+            type="button"
+            data-testid={`widget-filter-chip-${chip.key}`}
+            aria-label={`Edit ${chip.label} filter`}
+            onClick={(e) => {
+              // Stop propagation so the chip's own select-with-Filters
+              // action wins over WidgetShell's plain onSelect (which would
+              // select the widget WITHOUT requesting the Filters tab).
+              e.stopPropagation();
+              onSelectFilters();
+            }}
+            className={className}
+          >
+            {chip.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/components/reports/WidgetShell.tsx
+++ b/frontend/components/reports/WidgetShell.tsx
@@ -13,12 +13,23 @@
 import { ReactNode } from "react";
 import { GripVertical, X } from "lucide-react";
 
+import WidgetFilterChips from "@/components/reports/WidgetFilterChips";
+import type { CanvasFilters, Widget } from "@/lib/reports/types";
+import type { Account, Category } from "@/lib/types";
+
 interface Props {
   widgetId: string;
   selected: boolean;
   editMode: boolean;
   onSelect: () => void;
   onRemove?: () => void;
+  /** Widget + canvas + lookups feed the effective filter-chip header. */
+  widget: Widget;
+  canvasFilters: CanvasFilters;
+  accounts: Account[];
+  categories: Category[];
+  /** Select the widget + open the popover's Filters tab (chip click). */
+  onSelectFilters: () => void;
   children: ReactNode;
 }
 
@@ -28,6 +39,11 @@ export default function WidgetShell({
   editMode,
   onSelect,
   onRemove,
+  widget,
+  canvasFilters,
+  accounts,
+  categories,
+  onSelectFilters,
   children,
 }: Props) {
   return (
@@ -69,7 +85,18 @@ export default function WidgetShell({
           )}
         </div>
       )}
-      <div className="h-full w-full">{children}</div>
+      {/* Effective filter-chip header — visible in both view and edit
+          mode (status-is-data informational). Left-aligned so it never
+          collides with the absolutely-positioned edit overlay top-right.
+          Renders nothing when the widget has no set filters. */}
+      <WidgetFilterChips
+        widget={widget}
+        canvasFilters={canvasFilters}
+        accounts={accounts}
+        categories={categories}
+        onSelectFilters={onSelectFilters}
+      />
+      <div className="min-h-0 w-full flex-1">{children}</div>
     </div>
   );
 }

--- a/frontend/components/reports/WidgetShell.tsx
+++ b/frontend/components/reports/WidgetShell.tsx
@@ -94,6 +94,9 @@ export default function WidgetShell({
         canvasFilters={canvasFilters}
         accounts={accounts}
         categories={categories}
+        // Interactive (editable) chips only in edit mode; in view mode the
+        // chips render as inert, non-focusable informational spans.
+        interactive={editMode}
         onSelectFilters={onSelectFilters}
       />
       <div className="min-h-0 w-full flex-1">{children}</div>

--- a/frontend/components/reports/config/FilterEditor.tsx
+++ b/frontend/components/reports/config/FilterEditor.tsx
@@ -68,9 +68,6 @@ export default function FilterEditor({
       <div className="flex flex-col gap-1">
         <div className="flex items-center text-xs text-text-secondary">
           Accounts
-          {isFieldOverridden("account_ids", filters, canvasFilters) && (
-            <OverridePill />
-          )}
         </div>
         <AccountFilter
           value={filters.account_ids ?? []}
@@ -88,9 +85,6 @@ export default function FilterEditor({
       <div className="flex flex-col gap-1">
         <div className="flex items-center text-xs text-text-secondary">
           Categories
-          {isFieldOverridden("category_ids", filters, canvasFilters) && (
-            <OverridePill />
-          )}
         </div>
         <CategoryPicker
           value={filters.category_ids ?? []}

--- a/frontend/components/reports/config/FilterEditor.tsx
+++ b/frontend/components/reports/config/FilterEditor.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 /**
- * Per-widget filter override editor (date / accounts / categories /
- * txn_type / amount_range / tags) plus the "Overrides canvas" pill.
- * Extracted verbatim from the original widget config rail. The pill fires when a widget
- * field DIFFERS from the canvas value on the same field, via
+ * Per-widget filter editor (date / accounts / categories / txn_type /
+ * amount_range / tags).
+ *
+ * Phase 4b: ``date_range`` is the ONLY canvas-shared field, so it is the
+ * only field that can carry the "Overrides canvas" pill — the pill fires
+ * when the widget date DIFFERS from the canvas date, via
  * ``isFieldOverridden`` from ``lib/reports/resolve`` (not reimplemented).
+ * Accounts, categories, txn_type, amount_range and tags are all
+ * widget-only now (the canvas can't hold them), so they NEVER show the
+ * override pill — they're plain per-widget controls.
  */
 import { useId } from "react";
 

--- a/frontend/components/reports/filters/AccountFilter.tsx
+++ b/frontend/components/reports/filters/AccountFilter.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 /**
- * Account filter — chip picker over the org's accounts. Replaces the
- * PR2 comma-list ``account_ids`` input on both the canvas filters bar
- * and the per-widget config rail.
+ * Account filter — chip picker over the org's accounts. Used in the
+ * per-widget Filters tab (phase 4b made accounts widget-only; the
+ * canvas filter bar is date-only).
  *
  * Fetches the org's accounts on mount via SWR and renders each as a
  * toggleable chip. Selecting / deselecting a chip flips its id in

--- a/frontend/components/reports/filters/DatePresetChips.tsx
+++ b/frontend/components/reports/filters/DatePresetChips.tsx
@@ -15,6 +15,15 @@
 import { useMemo } from "react";
 
 import type { CanvasDateRange } from "@/lib/reports/types";
+import {
+  buildPresetRanges,
+  matchPreset,
+  type PresetKey,
+} from "@/lib/reports/date-presets";
+
+// Re-export so existing importers of ``buildPresetRanges`` from this
+// component keep working; the canonical home is now ``lib/reports/date-presets``.
+export { buildPresetRanges } from "@/lib/reports/date-presets";
 
 interface Props {
   value: CanvasDateRange | undefined;
@@ -25,8 +34,6 @@ interface Props {
   /** Label prefix applied to aria-labels (e.g. "Canvas" vs "Widget"). */
   ariaPrefix?: string;
 }
-
-type PresetKey = "this_month" | "last_month" | "ytd" | "last_12_months" | "custom";
 
 const PRESETS: Array<{ key: PresetKey; label: string }> = [
   { key: "this_month", label: "This month" },
@@ -142,55 +149,4 @@ export default function DatePresetChips({
       )}
     </div>
   );
-}
-
-function isoDate(d: Date): string {
-  // Build YYYY-MM-DD from local-clock components so a UTC-shifting
-  // ``toISOString`` doesn't shove the date back by a day in negative-
-  // offset timezones.
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-function startOfMonth(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth(), 1);
-}
-
-function endOfMonth(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth() + 1, 0);
-}
-
-export function buildPresetRanges(
-  now: Date,
-): Record<Exclude<PresetKey, "custom">, CanvasDateRange> {
-  const startThisMonth = startOfMonth(now);
-  const endThisMonth = endOfMonth(now);
-
-  const startLastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-  const endLastMonth = new Date(now.getFullYear(), now.getMonth(), 0);
-
-  const startOfYear = new Date(now.getFullYear(), 0, 1);
-
-  const startLast12 = new Date(now.getFullYear() - 1, now.getMonth(), 1);
-
-  return {
-    this_month: { start: isoDate(startThisMonth), end: isoDate(endThisMonth) },
-    last_month: { start: isoDate(startLastMonth), end: isoDate(endLastMonth) },
-    ytd: { start: isoDate(startOfYear), end: isoDate(now) },
-    last_12_months: { start: isoDate(startLast12), end: isoDate(now) },
-  };
-}
-
-function matchPreset(
-  value: CanvasDateRange | undefined,
-  ranges: Record<Exclude<PresetKey, "custom">, CanvasDateRange>,
-): PresetKey | null {
-  if (!value || (!value.start && !value.end)) return null;
-  for (const k of Object.keys(ranges) as Array<keyof typeof ranges>) {
-    const r = ranges[k];
-    if (r.start === value.start && r.end === value.end) return k;
-  }
-  return "custom";
 }

--- a/frontend/lib/reports/date-presets.ts
+++ b/frontend/lib/reports/date-presets.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure date-preset range builders for the reports filter system.
+ *
+ * Lives in ``lib`` (not in the ``DatePresetChips`` component) so both the
+ * component AND ``describe-filters.ts`` can import it without a lib →
+ * component layering inversion. The component owns the UI; this module
+ * owns the pure preset arithmetic.
+ *
+ * Presets resolve relative to the ``now`` passed in, producing an
+ * absolute ISO ``{ start, end }`` window. The architect-locked AST
+ * doesn't model relative ranges; freezing the absolute window at
+ * authoring time keeps the same report layout reproducible across
+ * sessions until the user picks a new preset.
+ */
+import type { CanvasDateRange } from "@/lib/reports/types";
+
+export type PresetKey =
+  | "this_month"
+  | "last_month"
+  | "ytd"
+  | "last_12_months"
+  | "custom";
+
+function isoDate(d: Date): string {
+  // Build YYYY-MM-DD from local-clock components so a UTC-shifting
+  // ``toISOString`` doesn't shove the date back by a day in negative-
+  // offset timezones.
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1);
+}
+
+function endOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth() + 1, 0);
+}
+
+export function buildPresetRanges(
+  now: Date,
+): Record<Exclude<PresetKey, "custom">, CanvasDateRange> {
+  const startThisMonth = startOfMonth(now);
+  const endThisMonth = endOfMonth(now);
+
+  const startLastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  const endLastMonth = new Date(now.getFullYear(), now.getMonth(), 0);
+
+  const startOfYear = new Date(now.getFullYear(), 0, 1);
+
+  const startLast12 = new Date(now.getFullYear() - 1, now.getMonth(), 1);
+
+  return {
+    this_month: { start: isoDate(startThisMonth), end: isoDate(endThisMonth) },
+    last_month: { start: isoDate(startLastMonth), end: isoDate(endLastMonth) },
+    ytd: { start: isoDate(startOfYear), end: isoDate(now) },
+    last_12_months: { start: isoDate(startLast12), end: isoDate(now) },
+  };
+}
+
+export function matchPreset(
+  value: CanvasDateRange | undefined,
+  ranges: Record<Exclude<PresetKey, "custom">, CanvasDateRange>,
+): PresetKey | null {
+  if (!value || (!value.start && !value.end)) return null;
+  for (const k of Object.keys(ranges) as Array<keyof typeof ranges>) {
+    const r = ranges[k];
+    if (r.start === value.start && r.end === value.end) return k;
+  }
+  return "custom";
+}

--- a/frontend/lib/reports/describe-filters.ts
+++ b/frontend/lib/reports/describe-filters.ts
@@ -1,0 +1,199 @@
+/**
+ * ``describeWidgetFilters`` — turns a widget's effective filter state
+ * into an ordered list of human-readable chip descriptors for the
+ * per-widget filter-chip header.
+ *
+ * The chips must mirror exactly what ``resolveFilters`` produces so they
+ * never lie about what the widget queries. To stay in lock-step, this
+ * helper imports ``pickDateRange`` and ``isFieldOverridden`` from
+ * ``resolve.ts`` (the single source of truth for the date inherit /
+ * override decision) rather than reimplementing that logic.
+ *
+ * Account/category ids are resolved to names via already-fetched
+ * ``accounts`` / ``categories`` lookups (the same SWR caches the filter
+ * pickers warm). When no name resolves (deleted/inactive id), the chip
+ * falls back to a plain count label so it never blocks on load.
+ */
+import { buildPresetRanges } from "@/components/reports/filters/DatePresetChips";
+import { isFieldOverridden, pickDateRange } from "@/lib/reports/resolve";
+import type {
+  CanvasDateRange,
+  CanvasFilters,
+  Widget,
+  WidgetFilters,
+} from "@/lib/reports/types";
+import type { Account, Category } from "@/lib/types";
+
+export interface FilterChip {
+  key: "date" | "txn_type" | "amount" | "tags" | "accounts" | "categories";
+  /** Human, truncated label, e.g. "Groceries +2". */
+  label: string;
+  /** Date only: true when the widget overrides the shared canvas date. */
+  overridden?: boolean;
+}
+
+interface Lookups {
+  accounts: Account[];
+  categories: Category[];
+}
+
+export function describeWidgetFilters(
+  widget: Widget,
+  canvasFilters: CanvasFilters | undefined,
+  lookups: Lookups,
+  now?: Date,
+): FilterChip[] {
+  const chips: FilterChip[] = [];
+
+  const widgetFilters: WidgetFilters =
+    "filters" in widget.config && widget.config.filters
+      ? widget.config.filters
+      : {};
+
+  // ── date ──────────────────────────────────────────────────────
+  const effectiveDate = pickDateRange(
+    widgetFilters.date_range,
+    canvasFilters?.date_range,
+  );
+  if (effectiveDate && (effectiveDate.start || effectiveDate.end)) {
+    chips.push({
+      key: "date",
+      label: dateLabel(effectiveDate, now ?? new Date()),
+      overridden: isFieldOverridden("date_range", widgetFilters, canvasFilters),
+    });
+  }
+
+  // ── txn_type ──────────────────────────────────────────────────
+  if (widgetFilters.txn_type) {
+    chips.push({ key: "txn_type", label: capitalize(widgetFilters.txn_type) });
+  }
+
+  // ── amount ────────────────────────────────────────────────────
+  const amount = widgetFilters.amount_range;
+  if (amount && (amount.min !== undefined || amount.max !== undefined)) {
+    chips.push({ key: "amount", label: amountLabel(amount.min, amount.max) });
+  }
+
+  // ── tags ──────────────────────────────────────────────────────
+  if (widgetFilters.tag_names && widgetFilters.tag_names.length > 0) {
+    const base = truncatedList(widgetFilters.tag_names);
+    const suffix = widgetFilters.tag_match === "any" ? " (any)" : "";
+    chips.push({ key: "tags", label: `${base}${suffix}` });
+  }
+
+  // ── accounts ──────────────────────────────────────────────────
+  if (widgetFilters.account_ids && widgetFilters.account_ids.length > 0) {
+    chips.push({
+      key: "accounts",
+      label: nameLabel(
+        widgetFilters.account_ids,
+        lookups.accounts,
+        "account",
+        "accounts",
+      ),
+    });
+  }
+
+  // ── categories ────────────────────────────────────────────────
+  if (widgetFilters.category_ids && widgetFilters.category_ids.length > 0) {
+    chips.push({
+      key: "categories",
+      label: nameLabel(
+        widgetFilters.category_ids,
+        lookups.categories,
+        "category",
+        "categories",
+      ),
+    });
+  }
+
+  return chips;
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// Currency symbol is a bare ``$`` prefix (not per-account currency),
+// consistent with the deferred chart currency-symbol work (roadmap §1b).
+function amountLabel(min?: number, max?: number): string {
+  if (min !== undefined && max !== undefined) return `$${min}–$${max}`;
+  if (min !== undefined) return `≥ $${min}`;
+  return `≤ $${max}`;
+}
+
+// "Groceries +2" — first name plus a count of the rest. A bare list of
+// strings (tags) truncates the same way.
+function truncatedList(names: string[]): string {
+  if (names.length === 0) return "";
+  const first = names[0];
+  const rest = names.length - 1;
+  return rest > 0 ? `${first} +${rest}` : first;
+}
+
+// Resolve ids → names against a lookup keyed by ``id``. Unresolved ids
+// are dropped; if none resolve, fall back to a count label
+// (``"2 accounts"``) so the chip is never empty.
+function nameLabel<T extends { id: number; name: string }>(
+  ids: number[],
+  lookup: T[],
+  singular: string,
+  plural: string,
+): string {
+  const byId = new Map(lookup.map((x) => [x.id, x.name]));
+  const names = ids
+    .map((id) => byId.get(id))
+    .filter((n): n is string => n !== undefined);
+  if (names.length === 0) {
+    return `${ids.length} ${ids.length === 1 ? singular : plural}`;
+  }
+  return truncatedList(names);
+}
+
+const PRESET_LABELS: Record<
+  keyof ReturnType<typeof buildPresetRanges>,
+  string
+> = {
+  this_month: "This month",
+  last_month: "Last month",
+  ytd: "YTD",
+  last_12_months: "Last 12 months",
+};
+
+function dateLabel(range: CanvasDateRange, now: Date): string {
+  const presets = buildPresetRanges(now);
+  for (const key of Object.keys(presets) as Array<keyof typeof presets>) {
+    const r = presets[key];
+    if (r.start === range.start && r.end === range.end) {
+      return PRESET_LABELS[key];
+    }
+  }
+  if (range.start && range.end) {
+    return `${shortDate(range.start)} – ${shortDate(range.end)}`;
+  }
+  if (range.start) return `From ${shortDate(range.start)}`;
+  return `Until ${shortDate(range.end as string)}`;
+}
+
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+// "MMM D" from an ISO YYYY-MM-DD string. Parsed off the literal parts to
+// avoid a UTC-shift on ``new Date("YYYY-MM-DD")`` in negative offsets.
+function shortDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map((p) => Number(p));
+  if (!y || !m || !d) return iso;
+  return `${MONTHS[m - 1]} ${d}`;
+}

--- a/frontend/lib/reports/describe-filters.ts
+++ b/frontend/lib/reports/describe-filters.ts
@@ -14,7 +14,7 @@
  * pickers warm). When no name resolves (deleted/inactive id), the chip
  * falls back to a plain count label so it never blocks on load.
  */
-import { buildPresetRanges } from "@/components/reports/filters/DatePresetChips";
+import { buildPresetRanges } from "@/lib/reports/date-presets";
 import { isFieldOverridden, pickDateRange } from "@/lib/reports/resolve";
 import type {
   CanvasDateRange,
@@ -131,8 +131,10 @@ function truncatedList(names: string[]): string {
   return rest > 0 ? `${first} +${rest}` : first;
 }
 
-// Resolve ids → names against a lookup keyed by ``id``. Unresolved ids
-// are dropped; if none resolve, fall back to a count label
+// Resolve ids → names against a lookup keyed by ``id``. Shows the first
+// resolved name plus a ``+N`` count of EVERY other id — resolved or not —
+// so the chip never underreports how many ids the widget actually
+// filters on. When NO id resolves, fall back to a plain count label
 // (``"2 accounts"``) so the chip is never empty.
 function nameLabel<T extends { id: number; name: string }>(
   ids: number[],
@@ -141,13 +143,14 @@ function nameLabel<T extends { id: number; name: string }>(
   plural: string,
 ): string {
   const byId = new Map(lookup.map((x) => [x.id, x.name]));
-  const names = ids
-    .map((id) => byId.get(id))
-    .filter((n): n is string => n !== undefined);
-  if (names.length === 0) {
+  const firstName = ids.map((id) => byId.get(id)).find((n) => n !== undefined);
+  if (firstName === undefined) {
     return `${ids.length} ${ids.length === 1 ? singular : plural}`;
   }
-  return truncatedList(names);
+  // ``+N`` counts every id beyond the one shown, including unresolved
+  // ids, so the count matches the real number of filtered ids.
+  const rest = ids.length - 1;
+  return rest > 0 ? `${firstName} +${rest}` : firstName;
 }
 
 const PRESET_LABELS: Record<

--- a/frontend/lib/reports/resolve.ts
+++ b/frontend/lib/reports/resolve.ts
@@ -1,10 +1,11 @@
 /**
  * Filter-resolution utilities.
  *
- * The architect-locked hybrid scope (spec §4): canvas-wide cascades,
- * per-widget overrides win on a per-field basis. ``resolveFilters``
- * walks each widget-filter field and decides whether to use the
- * widget value (if present) or fall back to the canvas value.
+ * Phase 4b scope: ``date_range`` is the ONLY canvas-shared field.
+ * The shared canvas date cascades to every widget that doesn't
+ * override it; accounts, categories, and all other filters are
+ * widget-only. ``resolveFilters`` reads the widget value directly for
+ * those and only inherits the date from the canvas.
  *
  * Output is a list of AST filter primitives the backend understands
  * (date BETWEEN, account_id IN, category_id IN, etc.). The compiler
@@ -40,15 +41,11 @@ export function isFieldOverridden(
   const widgetVal = widgetFilters[field];
   if (!hasMeaningfulValue(field, widgetVal)) return false;
 
-  // Tag fields aren't on canvas at all (canvas only has date_range,
-  // account_ids, category_ids), so a widget value there isn't an
-  // override of canvas. Same for txn_type / amount_range.
-  if (
-    field === "tag_names" ||
-    field === "tag_match" ||
-    field === "txn_type" ||
-    field === "amount_range"
-  ) {
+  // Phase 4b: ``date_range`` is the ONLY field the canvas still shares.
+  // Every other field (accounts, categories, tags, txn_type, amount)
+  // is widget-only — the canvas can't hold it, so a widget value is
+  // never an "override" of canvas. Short-circuit them all to false.
+  if (field !== "date_range") {
     return false;
   }
 
@@ -56,7 +53,7 @@ export function isFieldOverridden(
   if (!hasMeaningfulValue(field, canvasVal)) return false;
 
   // Both sides have a value. Pill fires only if they differ.
-  return !valuesEqual(field, widgetVal, canvasVal, widgetFilters);
+  return !valuesEqual(widgetVal, canvasVal);
 }
 
 function hasMeaningfulValue(
@@ -76,48 +73,14 @@ function hasMeaningfulValue(
   return true;
 }
 
-function valuesEqual(
-  field: keyof WidgetFilters,
-  widgetVal: unknown,
-  canvasVal: unknown,
-  widgetFilters: WidgetFilters,
-): boolean {
-  if (field === "date_range") {
-    const a = widgetVal as { start?: string; end?: string };
-    const b = canvasVal as { start?: string; end?: string };
-    return (a.start ?? null) === (b.start ?? null)
-      && (a.end ?? null) === (b.end ?? null);
-  }
-  if (field === "account_ids" || field === "category_ids") {
-    return sameSet(widgetVal as number[], canvasVal as number[]);
-  }
-  if (field === "amount_range") {
-    const a = widgetVal as { min?: number; max?: number };
-    const b = canvasVal as { min?: number; max?: number };
-    return (a.min ?? null) === (b.min ?? null)
-      && (a.max ?? null) === (b.max ?? null);
-  }
-  if (field === "tag_names") {
-    if (!sameSet(widgetVal as string[], canvasVal as string[])) return false;
-    // tag_match flips "all" vs "any" semantics, so an identical tag
-    // list with a different match mode is still an override. Canvas
-    // doesn't model tag_match, so any widget-side tag_match value
-    // other than the implicit default counts as a difference.
-    const widgetMatch = widgetFilters.tag_match ?? "all";
-    return widgetMatch === "all";
-  }
-  // txn_type / tag_match handled above as widget-only; fall back to
-  // strict equality for safety.
-  return widgetVal === canvasVal;
-}
-
-function sameSet<T extends number | string>(a: T[], b: T[]): boolean {
-  if (a.length !== b.length) return false;
-  const bSet = new Set<T>(b);
-  for (const x of a) {
-    if (!bSet.has(x)) return false;
-  }
-  return true;
+// Phase 4b: ``date_range`` is the only field reaching this helper —
+// ``isFieldOverridden`` short-circuits every other field to false
+// before getting here. So this only needs the date comparison.
+function valuesEqual(widgetVal: unknown, canvasVal: unknown): boolean {
+  const a = widgetVal as { start?: string; end?: string };
+  const b = canvasVal as { start?: string; end?: string };
+  return (a.start ?? null) === (b.start ?? null)
+    && (a.end ?? null) === (b.end ?? null);
 }
 
 /**
@@ -145,12 +108,14 @@ export function resolveFilters(
     out.push({ field: "date", op: "lte", value: dr.end });
   }
 
-  const accountIds = pickList(widget?.account_ids, canvas?.account_ids);
+  // Phase 4b: accounts/categories are widget-only — read the widget
+  // value directly, no canvas fallback.
+  const accountIds = widget?.account_ids;
   if (accountIds && accountIds.length > 0) {
     out.push({ field: "account_id", op: "in", value: accountIds });
   }
 
-  const categoryIds = pickList(widget?.category_ids, canvas?.category_ids);
+  const categoryIds = widget?.category_ids;
   if (categoryIds && categoryIds.length > 0) {
     out.push({ field: "category_id", op: "in", value: categoryIds });
   }
@@ -189,18 +154,17 @@ export function resolveFilters(
   return out;
 }
 
-function pickDateRange(
+/**
+ * The single source of truth for the date inherit/override decision:
+ * the widget date wins when it has a start or end, otherwise the
+ * shared canvas date cascades. Exported so the chip-describe helper
+ * (``describe-filters.ts``) reuses this exact logic rather than
+ * reimplementing it.
+ */
+export function pickDateRange(
   widget: CanvasFilters["date_range"] | undefined,
   canvas: CanvasFilters["date_range"] | undefined,
 ): CanvasFilters["date_range"] | undefined {
   if (widget && (widget.start || widget.end)) return widget;
-  return canvas;
-}
-
-function pickList<T>(
-  widget: T[] | undefined,
-  canvas: T[] | undefined,
-): T[] | undefined {
-  if (widget && widget.length > 0) return widget;
   return canvas;
 }

--- a/frontend/lib/reports/types.ts
+++ b/frontend/lib/reports/types.ts
@@ -110,9 +110,13 @@ export interface CanvasDateRange {
 }
 
 export interface CanvasFilters {
+  // Phase 4b: the canvas filter bar shrank to a shared DATE control
+  // only. Accounts and categories are now edited per-widget (in the
+  // widget popover's Filters tab), so they no longer live here.
+  // Saved ``canvas_filters_json`` blobs that still carry the old
+  // ``account_ids`` / ``category_ids`` keys are tolerated by the
+  // ``as CanvasFilters`` hydrate cast and simply never read.
   date_range?: CanvasDateRange;
-  account_ids?: number[];
-  category_ids?: number[];
 }
 
 // ─── widget layout / config ─────────────────────────────────────

--- a/frontend/lib/reports/use-filter-chip-state.ts
+++ b/frontend/lib/reports/use-filter-chip-state.ts
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * Shared filter-chip wiring for the two reports editors
+ * (``/reports/[id]`` and ``/reports/new``). Both pages need the same
+ * boilerplate to drive the per-widget filter chips:
+ *
+ *  - the accounts + categories SWR fetches (same ``?for=reports-filter``
+ *    keys ``AccountFilter`` / ``CategoryPicker`` use, so the cache is
+ *    shared and ids resolve to names in the chip header without an extra
+ *    round-trip),
+ *  - the ``requestedTab`` deep-link state (a chip click requests the
+ *    popover's Filters tab; consume-and-clear resets it to null),
+ *  - ``selectWidgetFilters`` (select the widget AND request Filters),
+ *  - ``clearRequestedTab`` (used by the page's ``closePopover``).
+ *
+ * The page still owns ``selectedWidgetId`` (its selection model differs:
+ * the ``[id]`` page is editMode-gated, the draft is always-edit), so it
+ * passes ``setSelectedWidgetId`` in and the hook composes the chip-click
+ * handler around it. Behavior is identical to the prior inlined code on
+ * both pages.
+ */
+import { useCallback, useState } from "react";
+import useSWR from "swr";
+
+import { apiFetch } from "@/lib/api";
+import type { TabKey } from "@/components/reports/WidgetEditorPopover";
+import type { Account, Category } from "@/lib/types";
+
+interface FilterChipState {
+  /** Accounts for chip name lookups (``[]`` while warming → count fallback). */
+  accounts: Account[];
+  /** Categories for chip name lookups (``[]`` while warming → count fallback). */
+  categories: Category[];
+  /** Deep-link request for the popover's Filters tab, or null. */
+  requestedTab: TabKey | null;
+  /** Select the widget AND request the popover's Filters tab. */
+  selectWidgetFilters: (widgetId: string) => void;
+  /** Clear any pending tab request (consume-and-clear / on popover close). */
+  clearRequestedTab: () => void;
+}
+
+export function useFilterChipState(
+  setSelectedWidgetId: (id: string) => void,
+): FilterChipState {
+  // Reuse the EXACT SWR keys ``AccountFilter`` / ``CategoryPicker`` use so
+  // the cache is shared (no extra network round-trip). Default to []
+  // (count-fallback) while warm.
+  const { data: accounts } = useSWR<Account[]>(
+    "/api/v1/accounts?for=reports-filter",
+    () => apiFetch<Account[]>("/api/v1/accounts"),
+    { revalidateOnFocus: false },
+  );
+  const { data: categories } = useSWR<Category[]>(
+    "/api/v1/categories?for=reports-filter",
+    () => apiFetch<Category[]>("/api/v1/categories"),
+    { revalidateOnFocus: false },
+  );
+
+  // Deep-link request: a filter-chip click sets this to "filters" so the
+  // popover opens on its Filters tab. Cleared the instant the popover
+  // consumes it (consume-and-clear handshake).
+  const [requestedTab, setRequestedTab] = useState<TabKey | null>(null);
+
+  // Chip click: select the widget AND request the Filters tab. Stable
+  // identity so the popover's effects don't re-run on every parent render.
+  const selectWidgetFilters = useCallback(
+    (widgetId: string) => {
+      setSelectedWidgetId(widgetId);
+      setRequestedTab("filters");
+    },
+    [setSelectedWidgetId],
+  );
+
+  const clearRequestedTab = useCallback(() => setRequestedTab(null), []);
+
+  return {
+    accounts: accounts ?? [],
+    categories: categories ?? [],
+    requestedTab,
+    selectWidgetFilters,
+    clearRequestedTab,
+  };
+}

--- a/frontend/tests/app/reports-draft-popover.test.tsx
+++ b/frontend/tests/app/reports-draft-popover.test.tsx
@@ -157,6 +157,23 @@ describe("ReportDraftPage popover (/reports/new)", () => {
     );
   });
 
+  it("clicking a widget filter chip opens the popover on the Filters tab", async () => {
+    mockUser(true);
+
+    render(<ReportDraftPage />);
+
+    // The seeded starter widget carries a txn_type filter → a chip.
+    await screen.findByText("Spend by category");
+    fireEvent.click(screen.getByTestId("widget-filter-chip-txn_type"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-editor-popover")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("tab", { name: /filters/i }),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
   it("opening the widget editor popover does not reflow the canvas (draft editor)", async () => {
     mockUser(true);
 

--- a/frontend/tests/app/reports-editor-page.test.tsx
+++ b/frontend/tests/app/reports-editor-page.test.tsx
@@ -191,7 +191,7 @@ describe("ReportEditorPage", () => {
       screen.getByText(/Add a widget to see your data/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/apply to every widget/i),
+      screen.getByText(/canvas date applies to every widget/i),
     ).toBeInTheDocument();
 
     // Add widget opens the picker dialog.
@@ -1050,6 +1050,48 @@ describe("ReportEditorPage", () => {
     // geometry/width is unchanged (the reflow regression guard).
     expect(flexRow.children).toHaveLength(1);
     expect(flexRow.children[0]).toBe(canvasCol);
+  });
+
+  it("clicking a widget filter chip selects the widget and opens the popover on Filters", async () => {
+    mockUser(true);
+    // Widget carries a txn_type filter → renders a filter chip.
+    getReportMock.mockResolvedValue({
+      ...REPORT_WITH_WIDGET,
+      layout_json: {
+        version: 1 as const,
+        widgets: [
+          {
+            id: "w_kpi",
+            type: "kpi" as const,
+            title: "Total",
+            grid: { x: 0, y: 0, w: 3, h: 2 },
+            config: {
+              dataset: "transactions" as const,
+              measure: { agg: "sum" as const, field: "amount" as const },
+              format: "currency" as const,
+              filters: { txn_type: "expense" as const },
+            },
+          },
+        ],
+      },
+    } as never);
+
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
+
+    // View mode opens for a report with widgets; enter edit mode so the
+    // chip's real handler is wired (view mode passes a no-op).
+    await screen.findByTestId("kpi-widget");
+    fireEvent.click(screen.getByTestId("report-editor-toggle-edit"));
+
+    // Chip renders in the shell header. Click it → widget selected +
+    // popover deep-links to the Filters tab.
+    fireEvent.click(screen.getByTestId("widget-filter-chip-txn_type"));
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-editor-popover")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("tab", { name: /filters/i }),
+    ).toHaveAttribute("aria-selected", "true");
   });
 
   it("edits a widget through the popover and the change round-trips into the saved layout", async () => {

--- a/frontend/tests/app/reports-editor-page.test.tsx
+++ b/frontend/tests/app/reports-editor-page.test.tsx
@@ -1094,6 +1094,62 @@ describe("ReportEditorPage", () => {
     ).toHaveAttribute("aria-selected", "true");
   });
 
+  it("a SECOND chip click on the already-selected widget returns the popover to Filters", async () => {
+    // Page-level analog of the popover unit test's consume-and-clear: a
+    // second chip click on the SAME widget (after the user navigated away
+    // to Data) must re-deep-link to the Filters tab. This exercises the
+    // requestedTab handshake end-to-end through the page wiring.
+    mockUser(true);
+    getReportMock.mockResolvedValue({
+      ...REPORT_WITH_WIDGET,
+      layout_json: {
+        version: 1 as const,
+        widgets: [
+          {
+            id: "w_kpi",
+            type: "kpi" as const,
+            title: "Total",
+            grid: { x: 0, y: 0, w: 3, h: 2 },
+            config: {
+              dataset: "transactions" as const,
+              measure: { agg: "sum" as const, field: "amount" as const },
+              format: "currency" as const,
+              filters: { txn_type: "expense" as const },
+            },
+          },
+        ],
+      },
+    } as never);
+
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("kpi-widget");
+    fireEvent.click(screen.getByTestId("report-editor-toggle-edit"));
+
+    // First chip click → popover opens deep-linked to Filters.
+    fireEvent.click(screen.getByTestId("widget-filter-chip-txn_type"));
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-editor-popover")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("tab", { name: /filters/i }),
+    ).toHaveAttribute("aria-selected", "true");
+
+    // User manually switches to the Data tab.
+    fireEvent.click(screen.getByRole("tab", { name: /data/i }));
+    expect(
+      screen.getByRole("tab", { name: /data/i }),
+    ).toHaveAttribute("aria-selected", "true");
+
+    // Second chip click on the SAME (already-selected) widget → back to Filters.
+    fireEvent.click(screen.getByTestId("widget-filter-chip-txn_type"));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("tab", { name: /filters/i }),
+      ).toHaveAttribute("aria-selected", "true"),
+    );
+  });
+
   it("edits a widget through the popover and the change round-trips into the saved layout", async () => {
     mockUser(true);
     getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);

--- a/frontend/tests/components/reports/canvas-filters-bar.test.tsx
+++ b/frontend/tests/components/reports/canvas-filters-bar.test.tsx
@@ -1,0 +1,18 @@
+/**
+ * Phase 4b: the canvas filter bar is now date-only. Accounts and
+ * categories moved to per-widget editing, so the account/category
+ * pickers must no longer render here — only the shared date control.
+ */
+import { render, screen } from "@testing-library/react";
+
+import CanvasFiltersBar from "@/components/reports/CanvasFiltersBar";
+
+describe("CanvasFiltersBar", () => {
+  it("renders only the date control (no account/category pickers)", () => {
+    render(<CanvasFiltersBar value={{}} onChange={() => {}} />);
+    expect(screen.getByTestId("canvas-filters-bar")).toBeInTheDocument();
+    expect(screen.getByTestId("date-preset-chips")).toBeInTheDocument();
+    expect(screen.queryByTestId("account-filter")).toBeNull();
+    expect(screen.queryByTestId("category-picker")).toBeNull();
+  });
+});

--- a/frontend/tests/components/reports/config/filter-editor-override-pill.test.tsx
+++ b/frontend/tests/components/reports/config/filter-editor-override-pill.test.tsx
@@ -1,10 +1,10 @@
 /**
- * Regression: the "Overrides canvas" pill fires when the widget-level
- * filter actually DIFFERS from the canvas-level value (and never when
- * they match). Re-homed from override-pill-pickers onto the extracted
- * ``FilterEditor``, which owns the override pill and the picker filters.
- * The pickers feed the same ``WidgetFilters`` shape — these tests pin the
- * equality semantics survive on the extracted component.
+ * Phase 4b: ``date_range`` is the ONLY canvas-shared field, so it's the
+ * only field whose widget value can "override" the canvas and show the
+ * "Overrides canvas" pill. Accounts and categories are widget-only now
+ * (the canvas no longer carries them), so ``isFieldOverridden`` always
+ * returns false for them and their override pills never render — pinned
+ * below. The surviving override case is date_range.
  */
 import { renderWithSWR, screen } from "../../../utils/render-with-swr";
 
@@ -87,59 +87,51 @@ function renderEditor(
   );
 }
 
-describe("Override pill — picker-based filters", () => {
+describe("Override pill — phase 4b (date-only canvas)", () => {
   beforeEach(() => {
     vi.mocked(apiFetch).mockReset();
     mockApi();
   });
 
-  it("does NOT show the pill when the widget category selection matches the canvas selection", async () => {
-    renderEditor({ category_ids: [1, 2] }, { category_ids: [2, 1] });
-
-    // Wait a tick for the SWR fetches to resolve so the picker has
-    // populated the tree (pill renders synchronously off the prop
-    // values).
+  it("NEVER shows the pill for category — categories are widget-only (match)", async () => {
+    renderEditor({ category_ids: [1, 2] }, {});
     await screen.findByTestId("category-picker");
-    // Pill is keyed by data-testid="override-pill"; assert none on
-    // category_ids equality.
-    const pills = screen.queryAllByTestId("override-pill");
-    expect(pills.length).toBe(0);
-  });
-
-  it("DOES show the pill when the widget category selection differs from the canvas", async () => {
-    renderEditor({ category_ids: [1] }, { category_ids: [2] });
-    await screen.findByTestId("category-picker");
-    const pills = screen.queryAllByTestId("override-pill");
-    expect(pills.length).toBeGreaterThanOrEqual(1);
-  });
-
-  it("does NOT show the pill when the widget account selection matches the canvas selection", async () => {
-    renderEditor({ account_ids: [1] }, { account_ids: [1] });
-    await screen.findByTestId("account-filter");
-    const pills = screen.queryAllByTestId("override-pill");
-    expect(pills.length).toBe(0);
-  });
-
-  it("DOES show the pill when the widget account selection differs from the canvas", async () => {
-    renderEditor({ account_ids: [2] }, { account_ids: [1] });
-    await screen.findByTestId("account-filter");
-    const pills = screen.queryAllByTestId("override-pill");
-    expect(pills.length).toBeGreaterThanOrEqual(1);
-  });
-
-  it("keeps the pill off when widget account_ids is empty (inherit)", async () => {
-    const onChange = vi.fn();
-    const { rerender } = renderEditor({ account_ids: [1] }, { account_ids: [1] }, onChange);
-
-    await screen.findByTestId("account-filter");
-    // Empty widget account_ids means inherit — pill stays off.
-    rerender(
-      <FilterEditor
-        filters={{ account_ids: [] }}
-        canvasFilters={{ account_ids: [1] }}
-        onChange={onChange}
-      />,
-    );
     expect(screen.queryAllByTestId("override-pill").length).toBe(0);
+  });
+
+  it("NEVER shows the pill for category — categories are widget-only (set)", async () => {
+    renderEditor({ category_ids: [1] }, {});
+    await screen.findByTestId("category-picker");
+    expect(screen.queryAllByTestId("override-pill").length).toBe(0);
+  });
+
+  it("NEVER shows the pill for account — accounts are widget-only (match)", async () => {
+    renderEditor({ account_ids: [1] }, {});
+    await screen.findByTestId("account-filter");
+    expect(screen.queryAllByTestId("override-pill").length).toBe(0);
+  });
+
+  it("NEVER shows the pill for account — accounts are widget-only (set)", async () => {
+    renderEditor({ account_ids: [1] }, {});
+    await screen.findByTestId("account-filter");
+    expect(screen.queryAllByTestId("override-pill").length).toBe(0);
+  });
+
+  it("does NOT show the pill when the widget date matches the canvas date", async () => {
+    renderEditor(
+      { date_range: { start: "2026-01-01", end: "2026-01-31" } },
+      { date_range: { start: "2026-01-01", end: "2026-01-31" } },
+    );
+    await screen.findByTestId("account-filter");
+    expect(screen.queryAllByTestId("override-pill").length).toBe(0);
+  });
+
+  it("DOES show the pill when the widget date differs from the canvas date", async () => {
+    renderEditor(
+      { date_range: { start: "2026-02-01", end: "2026-02-28" } },
+      { date_range: { start: "2026-01-01", end: "2026-01-31" } },
+    );
+    await screen.findByTestId("account-filter");
+    expect(screen.queryAllByTestId("override-pill").length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/frontend/tests/components/reports/widget-editor-popover-requested-tab.test.tsx
+++ b/frontend/tests/components/reports/widget-editor-popover-requested-tab.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * WidgetEditorPopover — the ``requestedTab`` deep-link (consume-and-clear
+ * handshake). A filter chip sets ``requestedTab="filters"`` on the page;
+ * the popover's honor-request effect selects that tab and calls
+ * ``onTabConsumed`` so the page clears the request back to null. Two
+ * separate effects keep this race-free:
+ *  - reset effect keyed on [widget.id] ONLY → resets to Data on a new
+ *    widget identity, never clobbers when requestedTab clears.
+ *  - honor-request effect keyed on [requestedTab] ONLY → honors a chip
+ *    click, including a SECOND click on the already-selected widget.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import WidgetEditorPopover from "@/components/reports/WidgetEditorPopover";
+import type { TabKey } from "@/components/reports/WidgetEditorPopover";
+import { apiFetch } from "@/lib/api";
+import type { BarWidget, KPIWidget } from "@/lib/reports/types";
+
+vi.mock("@/lib/api", () => ({ apiFetch: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(apiFetch).mockReset();
+  vi.mocked(apiFetch).mockImplementation(
+    () => Promise.resolve([]) as Promise<unknown>,
+  );
+});
+
+let anchorEl: HTMLElement;
+beforeEach(() => {
+  anchorEl = document.createElement("div");
+  document.body.appendChild(anchorEl);
+});
+afterEach(() => {
+  anchorEl.remove();
+});
+
+function bar(id = "w_bar"): BarWidget {
+  return {
+    id,
+    type: "bar",
+    title: "Bar",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+    },
+  };
+}
+
+function kpi(id = "w_kpi"): KPIWidget {
+  return {
+    id,
+    type: "kpi",
+    title: "KPI",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config: { dataset: "transactions", measure: { agg: "sum", field: "amount" } },
+  };
+}
+
+function selected(tab: string): boolean {
+  return (
+    screen.getByRole("tab", { name: tab }).getAttribute("aria-selected") ===
+    "true"
+  );
+}
+
+describe("WidgetEditorPopover — requestedTab deep-link", () => {
+  it("opens on the Filters tab when requestedTab='filters'", () => {
+    render(
+      <WidgetEditorPopover
+        widget={bar()}
+        canvasFilters={{}}
+        anchorEl={anchorEl}
+        requestedTab="filters"
+        onTabConsumed={() => {}}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(selected("Filters")).toBe(true);
+  });
+
+  it("defaults to Data when no requestedTab is passed", () => {
+    render(
+      <WidgetEditorPopover
+        widget={bar()}
+        canvasFilters={{}}
+        anchorEl={anchorEl}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(selected("Data")).toBe(true);
+  });
+
+  it("lands on Filters when a fresh widget id is passed with requestedTab", () => {
+    const { rerender } = render(
+      <WidgetEditorPopover
+        widget={bar("w_a")}
+        canvasFilters={{}}
+        anchorEl={anchorEl}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(selected("Data")).toBe(true);
+    rerender(
+      <WidgetEditorPopover
+        widget={bar("w_b")}
+        canvasFilters={{}}
+        anchorEl={anchorEl}
+        requestedTab="filters"
+        onTabConsumed={() => {}}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(selected("Filters")).toBe(true);
+  });
+
+  it("re-opens Filters on a SECOND chip click on the same widget", () => {
+    // Model the page's consume-and-clear: onTabConsumed clears the prop.
+    let requestedTab: TabKey | null = "filters";
+    const onTabConsumed = vi.fn(() => {
+      requestedTab = null;
+    });
+    const renderPopover = () => (
+      <WidgetEditorPopover
+        widget={bar("w_same")}
+        canvasFilters={{}}
+        anchorEl={anchorEl}
+        requestedTab={requestedTab ?? undefined}
+        onTabConsumed={onTabConsumed}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />
+    );
+    const { rerender } = render(renderPopover());
+    // First chip click consumed → Filters, then prop cleared to null.
+    expect(selected("Filters")).toBe(true);
+    rerender(renderPopover());
+    expect(onTabConsumed).toHaveBeenCalled();
+
+    // User manually goes to Data.
+    fireEvent.click(screen.getByRole("tab", { name: "Data" }));
+    expect(selected("Data")).toBe(true);
+
+    // Second chip click on the SAME widget: page sets requestedTab again.
+    requestedTab = "filters";
+    rerender(renderPopover());
+    expect(selected("Filters")).toBe(true);
+  });
+
+  it("does NOT clobber the tab back to Data when requestedTab clears (filters → null)", () => {
+    const { rerender } = render(
+      <WidgetEditorPopover
+        widget={bar("w_stable")}
+        canvasFilters={{}}
+        anchorEl={anchorEl}
+        requestedTab="filters"
+        onTabConsumed={() => {}}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(selected("Filters")).toBe(true);
+    // The consume: requestedTab goes filters → null with a STABLE widget id.
+    rerender(
+      <WidgetEditorPopover
+        widget={bar("w_stable")}
+        canvasFilters={{}}
+        anchorEl={anchorEl}
+        requestedTab={undefined}
+        onTabConsumed={() => {}}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    // Must STILL be on Filters — the reset effect is keyed on widget.id
+    // only, so a requestedTab clear never re-fires it.
+    expect(selected("Filters")).toBe(true);
+  });
+
+  it("resets a fresh widget to Data even after a prior Filters request", () => {
+    const { rerender } = render(
+      <WidgetEditorPopover
+        widget={bar("w_one")}
+        canvasFilters={{}}
+        anchorEl={anchorEl}
+        requestedTab="filters"
+        onTabConsumed={() => {}}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(selected("Filters")).toBe(true);
+    // Plain widget switch (no requestedTab) → Data default preserved.
+    rerender(
+      <WidgetEditorPopover
+        widget={kpi("w_two")}
+        canvasFilters={{}}
+        anchorEl={anchorEl}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(selected("Data")).toBe(true);
+  });
+});

--- a/frontend/tests/components/reports/widget-filter-chips.test.tsx
+++ b/frontend/tests/components/reports/widget-filter-chips.test.tsx
@@ -1,12 +1,18 @@
 /**
- * WidgetFilterChips — the per-widget filter-chip header row. Renders a
- * pill button per effective non-default filter; clicking one selects the
- * widget and opens the popover's Filters tab via ``onSelectFilters``.
+ * WidgetFilterChips — the per-widget filter-chip header row.
+ *
+ * In edit mode (``interactive``) each chip is a button that selects the
+ * widget and opens the popover's Filters tab via ``onSelectFilters``. In
+ * view mode the chips render as inert, non-focusable informational spans.
  */
 import { fireEvent, render, screen } from "@testing-library/react";
 
 import WidgetFilterChips from "@/components/reports/WidgetFilterChips";
+import { buildPresetRanges } from "@/lib/reports/date-presets";
 import type { BarWidget, WidgetFilters } from "@/lib/reports/types";
+import type { Account, Category } from "@/lib/types";
+
+const NOW = new Date(2026, 5, 15); // 2026-06-15 (stable)
 
 function barWith(filters: WidgetFilters): BarWidget {
   return {
@@ -23,8 +29,49 @@ function barWith(filters: WidgetFilters): BarWidget {
   };
 }
 
-describe("WidgetFilterChips", () => {
-  it("renders a chip per set filter and fires onSelectFilters on click", () => {
+const ACCTS: Account[] = [
+  {
+    id: 1,
+    name: "Checking",
+    account_type_id: 1,
+    account_type_name: "Bank",
+    account_type_slug: "bank",
+    balance: 0,
+    currency: "USD",
+    is_active: true,
+    close_day: null,
+    is_default: true,
+  },
+  {
+    id: 2,
+    name: "Savings",
+    account_type_id: 1,
+    account_type_name: "Bank",
+    account_type_slug: "bank",
+    balance: 0,
+    currency: "USD",
+    is_active: true,
+    close_day: null,
+    is_default: false,
+  },
+];
+
+const CATS: Category[] = [
+  {
+    id: 10,
+    name: "Groceries",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "groceries",
+    is_system: false,
+    transaction_count: 0,
+  },
+];
+
+describe("WidgetFilterChips (interactive / edit mode)", () => {
+  it("renders a chip button per set filter and fires onSelectFilters on click", () => {
     const onSelectFilters = vi.fn();
     render(
       <WidgetFilterChips
@@ -32,11 +79,31 @@ describe("WidgetFilterChips", () => {
         canvasFilters={{}}
         accounts={[]}
         categories={[]}
+        interactive
         onSelectFilters={onSelectFilters}
       />,
     );
-    fireEvent.click(screen.getByTestId("widget-filter-chip-txn_type"));
+    const chip = screen.getByTestId("widget-filter-chip-txn_type");
+    expect(chip.tagName).toBe("BUTTON");
+    fireEvent.click(chip);
     expect(onSelectFilters).toHaveBeenCalledOnce();
+  });
+
+  it("uses the HUMAN display label in the aria-label, not the raw key", () => {
+    render(
+      <WidgetFilterChips
+        widget={barWith({ txn_type: "expense" })}
+        canvasFilters={{}}
+        accounts={[]}
+        categories={[]}
+        interactive
+        onSelectFilters={() => {}}
+      />,
+    );
+    // Edit verb + human label ("Expense"), never "Edit txn_type filter".
+    expect(
+      screen.getByRole("button", { name: "Edit Expense filter" }),
+    ).toBeInTheDocument();
   });
 
   it("renders nothing when the widget has no set filters", () => {
@@ -46,9 +113,119 @@ describe("WidgetFilterChips", () => {
         canvasFilters={{}}
         accounts={[]}
         categories={[]}
+        interactive
         onSelectFilters={() => {}}
       />,
     );
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a date chip and applies the overridden accent class when the widget date differs from canvas", () => {
+    const presets = buildPresetRanges(NOW);
+    render(
+      <WidgetFilterChips
+        widget={barWith({ date_range: { start: "2026-03-01", end: "2026-03-31" } })}
+        canvasFilters={{ date_range: presets.this_month }}
+        accounts={[]}
+        categories={[]}
+        interactive
+        onSelectFilters={() => {}}
+      />,
+    );
+    const chip = screen.getByTestId("widget-filter-chip-date");
+    // Overridden date chips use the accent register.
+    expect(chip.className).toContain("text-accent");
+    expect(chip.className).not.toContain("text-text-secondary");
+  });
+
+  it("renders an inherited (non-overridden) date chip in the neutral register", () => {
+    const presets = buildPresetRanges(NOW);
+    render(
+      <WidgetFilterChips
+        widget={barWith({})}
+        canvasFilters={{ date_range: presets.this_month }}
+        accounts={[]}
+        categories={[]}
+        interactive
+        onSelectFilters={() => {}}
+      />,
+    );
+    const chip = screen.getByTestId("widget-filter-chip-date");
+    expect(chip.className).toContain("text-text-secondary");
+    expect(chip.className).not.toContain("text-accent");
+  });
+
+  it("shows the resolved name plus a +N that counts unresolved ids too (partial resolution)", () => {
+    // id 1 resolves to "Checking"; id 99 does not — but the widget filters
+    // on 2 accounts, so the count must be "+1", not bare "Checking".
+    render(
+      <WidgetFilterChips
+        widget={barWith({ account_ids: [1, 99] })}
+        canvasFilters={{}}
+        accounts={ACCTS}
+        categories={[]}
+        interactive
+        onSelectFilters={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("widget-filter-chip-accounts")).toHaveTextContent(
+      "Checking +1",
+    );
+  });
+
+  it("uses the singular count noun for a single unresolved id", () => {
+    render(
+      <WidgetFilterChips
+        widget={barWith({ account_ids: [99] })}
+        canvasFilters={{}}
+        accounts={ACCTS}
+        categories={[]}
+        interactive
+        onSelectFilters={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("widget-filter-chip-accounts")).toHaveTextContent(
+      "1 account",
+    );
+  });
+
+  it("uses the plural count noun for multiple unresolved ids", () => {
+    render(
+      <WidgetFilterChips
+        widget={barWith({ category_ids: [98, 99] })}
+        canvasFilters={{}}
+        accounts={[]}
+        categories={CATS}
+        interactive
+        onSelectFilters={() => {}}
+      />,
+    );
+    expect(
+      screen.getByTestId("widget-filter-chip-categories"),
+    ).toHaveTextContent("2 categories");
+  });
+});
+
+describe("WidgetFilterChips (non-interactive / view mode)", () => {
+  it("renders chips as inert, non-focusable spans (no button, no Edit affordance)", () => {
+    const onSelectFilters = vi.fn();
+    render(
+      <WidgetFilterChips
+        widget={barWith({ txn_type: "expense" })}
+        canvasFilters={{}}
+        accounts={[]}
+        categories={[]}
+        interactive={false}
+        onSelectFilters={onSelectFilters}
+      />,
+    );
+    const chip = screen.getByTestId("widget-filter-chip-txn_type");
+    // A span, not a button → not focusable, no false "Edit" affordance.
+    expect(chip.tagName).toBe("SPAN");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Edit .* filter/)).not.toBeInTheDocument();
+    // Clicking it does nothing (no onClick handler wired).
+    fireEvent.click(chip);
+    expect(onSelectFilters).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/components/reports/widget-filter-chips.test.tsx
+++ b/frontend/tests/components/reports/widget-filter-chips.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * WidgetFilterChips — the per-widget filter-chip header row. Renders a
+ * pill button per effective non-default filter; clicking one selects the
+ * widget and opens the popover's Filters tab via ``onSelectFilters``.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import WidgetFilterChips from "@/components/reports/WidgetFilterChips";
+import type { BarWidget, WidgetFilters } from "@/lib/reports/types";
+
+function barWith(filters: WidgetFilters): BarWidget {
+  return {
+    id: "w_bar",
+    type: "bar",
+    title: "Bar",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+      filters,
+    },
+  };
+}
+
+describe("WidgetFilterChips", () => {
+  it("renders a chip per set filter and fires onSelectFilters on click", () => {
+    const onSelectFilters = vi.fn();
+    render(
+      <WidgetFilterChips
+        widget={barWith({ txn_type: "expense" })}
+        canvasFilters={{}}
+        accounts={[]}
+        categories={[]}
+        onSelectFilters={onSelectFilters}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("widget-filter-chip-txn_type"));
+    expect(onSelectFilters).toHaveBeenCalledOnce();
+  });
+
+  it("renders nothing when the widget has no set filters", () => {
+    const { container } = render(
+      <WidgetFilterChips
+        widget={barWith({})}
+        canvasFilters={{}}
+        accounts={[]}
+        categories={[]}
+        onSelectFilters={() => {}}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/tests/components/reports/widget-shell.test.tsx
+++ b/frontend/tests/components/reports/widget-shell.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * WidgetShell — mounts the per-widget filter-chip header above the
+ * widget body in BOTH view and edit mode, and wires chip clicks to
+ * ``onSelectFilters`` (which the page uses to select the widget and
+ * deep-link the popover to the Filters tab).
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import WidgetShell from "@/components/reports/WidgetShell";
+import type { BarWidget, WidgetFilters } from "@/lib/reports/types";
+
+function barWith(filters: WidgetFilters): BarWidget {
+  return {
+    id: "w1",
+    type: "bar",
+    title: "Bar",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+      filters,
+    },
+  };
+}
+
+function renderShell(editMode: boolean, onSelectFilters = () => {}) {
+  return render(
+    <WidgetShell
+      widgetId="w1"
+      selected={false}
+      editMode={editMode}
+      onSelect={() => {}}
+      onSelectFilters={onSelectFilters}
+      widget={barWith({ txn_type: "expense" })}
+      canvasFilters={{}}
+      accounts={[]}
+      categories={[]}
+    >
+      <div>body</div>
+    </WidgetShell>,
+  );
+}
+
+describe("WidgetShell filter chips", () => {
+  it("renders filter chips in view mode and fires onSelectFilters", () => {
+    const onSelectFilters = vi.fn();
+    renderShell(false, onSelectFilters);
+    fireEvent.click(screen.getByTestId("widget-filter-chip-txn_type"));
+    expect(onSelectFilters).toHaveBeenCalledOnce();
+  });
+
+  it("renders filter chips in edit mode too", () => {
+    renderShell(true);
+    expect(screen.getByTestId("widget-filter-chip-txn_type")).toBeInTheDocument();
+  });
+
+  it("does not fire the shell onSelect when a chip is clicked", () => {
+    const onSelect = vi.fn();
+    render(
+      <WidgetShell
+        widgetId="w1"
+        selected={false}
+        editMode={false}
+        onSelect={onSelect}
+        onSelectFilters={() => {}}
+        widget={barWith({ txn_type: "expense" })}
+        canvasFilters={{}}
+        accounts={[]}
+        categories={[]}
+      >
+        <div>body</div>
+      </WidgetShell>,
+    );
+    fireEvent.click(screen.getByTestId("widget-filter-chip-txn_type"));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/components/reports/widget-shell.test.tsx
+++ b/frontend/tests/components/reports/widget-shell.test.tsx
@@ -1,8 +1,11 @@
 /**
  * WidgetShell — mounts the per-widget filter-chip header above the
- * widget body in BOTH view and edit mode, and wires chip clicks to
- * ``onSelectFilters`` (which the page uses to select the widget and
- * deep-link the popover to the Filters tab).
+ * widget body in BOTH view and edit mode. The chips are INTERACTIVE only
+ * in edit mode: ``WidgetShell`` passes ``interactive={editMode}`` to
+ * ``WidgetFilterChips``. In edit mode a chip is a button wired to
+ * ``onSelectFilters`` (select the widget + deep-link the popover's
+ * Filters tab); in view mode the chips render as inert informational
+ * spans (no false "edit" affordance for keyboard users).
  */
 import { fireEvent, render, screen } from "@testing-library/react";
 
@@ -43,25 +46,33 @@ function renderShell(editMode: boolean, onSelectFilters = () => {}) {
 }
 
 describe("WidgetShell filter chips", () => {
-  it("renders filter chips in view mode and fires onSelectFilters", () => {
+  it("renders chips as inert spans in view mode (no onSelectFilters)", () => {
     const onSelectFilters = vi.fn();
     renderShell(false, onSelectFilters);
-    fireEvent.click(screen.getByTestId("widget-filter-chip-txn_type"));
+    const chip = screen.getByTestId("widget-filter-chip-txn_type");
+    expect(chip.tagName).toBe("SPAN");
+    fireEvent.click(chip);
+    expect(onSelectFilters).not.toHaveBeenCalled();
+  });
+
+  it("renders interactive chip buttons in edit mode and fires onSelectFilters", () => {
+    const onSelectFilters = vi.fn();
+    renderShell(true, onSelectFilters);
+    const chip = screen.getByTestId("widget-filter-chip-txn_type");
+    expect(chip.tagName).toBe("BUTTON");
+    fireEvent.click(chip);
     expect(onSelectFilters).toHaveBeenCalledOnce();
   });
 
-  it("renders filter chips in edit mode too", () => {
-    renderShell(true);
-    expect(screen.getByTestId("widget-filter-chip-txn_type")).toBeInTheDocument();
-  });
-
-  it("does not fire the shell onSelect when a chip is clicked", () => {
+  it("does not fire the shell onSelect when an edit-mode chip button is clicked", () => {
+    // The chip button stops propagation so its select-with-Filters action
+    // wins over the shell's plain onSelect.
     const onSelect = vi.fn();
     render(
       <WidgetShell
         widgetId="w1"
         selected={false}
-        editMode={false}
+        editMode
         onSelect={onSelect}
         onSelectFilters={() => {}}
         widget={barWith({ txn_type: "expense" })}

--- a/frontend/tests/lib/reports/describe-filters.test.ts
+++ b/frontend/tests/lib/reports/describe-filters.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { describeWidgetFilters } from "@/lib/reports/describe-filters";
-import { buildPresetRanges } from "@/components/reports/filters/DatePresetChips";
+import { buildPresetRanges } from "@/lib/reports/date-presets";
 import type { BarWidget, WidgetFilters } from "@/lib/reports/types";
 import type { Account, Category } from "@/lib/types";
 
@@ -142,6 +142,53 @@ describe("describeWidgetFilters", () => {
       NOW,
     );
     expect(chips.find((c) => c.key === "accounts")?.label).toBe("2 accounts");
+  });
+
+  it("uses the singular count noun when a single account id is unresolved", () => {
+    const chips = describeWidgetFilters(
+      bar({ account_ids: [99] }),
+      {},
+      { accounts: ACCTS, categories: [] },
+      NOW,
+    );
+    expect(chips.find((c) => c.key === "accounts")?.label).toBe("1 account");
+  });
+
+  it("counts unresolved ids in +N when SOME names resolve (no underreport)", () => {
+    // ids [1, 99]: only id 1 ("Checking") resolves. The widget still
+    // filters on 2 accounts, so the chip must read "Checking +1" — NOT a
+    // bare "Checking" that hides the second (unresolved) id.
+    const chips = describeWidgetFilters(
+      bar({ account_ids: [1, 99] }),
+      {},
+      { accounts: ACCTS, categories: [] },
+      NOW,
+    );
+    expect(chips.find((c) => c.key === "accounts")?.label).toBe("Checking +1");
+  });
+
+  it("counts MULTIPLE unresolved ids in +N alongside a resolved name", () => {
+    // ids [1, 98, 99]: only id 1 resolves; "+2" must cover both unresolved.
+    const chips = describeWidgetFilters(
+      bar({ account_ids: [1, 98, 99] }),
+      {},
+      { accounts: ACCTS, categories: [] },
+      NOW,
+    );
+    expect(chips.find((c) => c.key === "accounts")?.label).toBe("Checking +2");
+  });
+
+  it("counts a leading-unresolved id in +N (resolved name need not be first)", () => {
+    // ids [99, 1]: id 99 is unresolved, id 1 ("Checking") resolves second.
+    // The shown name is the first RESOLVED one, and +N still counts all
+    // other ids → "Checking +1".
+    const chips = describeWidgetFilters(
+      bar({ account_ids: [99, 1] }),
+      {},
+      { accounts: ACCTS, categories: [] },
+      NOW,
+    );
+    expect(chips.find((c) => c.key === "accounts")?.label).toBe("Checking +1");
   });
 
   it("resolves category ids to names", () => {

--- a/frontend/tests/lib/reports/describe-filters.test.ts
+++ b/frontend/tests/lib/reports/describe-filters.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+
+import { describeWidgetFilters } from "@/lib/reports/describe-filters";
+import { buildPresetRanges } from "@/components/reports/filters/DatePresetChips";
+import type { BarWidget, WidgetFilters } from "@/lib/reports/types";
+import type { Account, Category } from "@/lib/types";
+
+const NOW = new Date(2026, 5, 15); // 2026-06-15 (stable)
+
+function bar(filters: WidgetFilters): BarWidget {
+  return {
+    id: "w_bar",
+    type: "bar",
+    title: "Bar",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+      filters,
+    },
+  };
+}
+
+const ACCTS: Account[] = [
+  {
+    id: 1,
+    name: "Checking",
+    account_type_id: 1,
+    account_type_name: "Bank",
+    account_type_slug: "bank",
+    balance: 0,
+    currency: "USD",
+    is_active: true,
+    close_day: null,
+    is_default: true,
+  },
+  {
+    id: 2,
+    name: "Savings",
+    account_type_id: 1,
+    account_type_name: "Bank",
+    account_type_slug: "bank",
+    balance: 0,
+    currency: "USD",
+    is_active: true,
+    close_day: null,
+    is_default: false,
+  },
+  {
+    id: 3,
+    name: "Credit",
+    account_type_id: 2,
+    account_type_name: "Card",
+    account_type_slug: "card",
+    balance: 0,
+    currency: "USD",
+    is_active: true,
+    close_day: null,
+    is_default: false,
+  },
+];
+
+const CATS: Category[] = [
+  {
+    id: 10,
+    name: "Groceries",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "groceries",
+    is_system: false,
+    transaction_count: 0,
+  },
+  {
+    id: 20,
+    name: "Transport",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "transport",
+    is_system: false,
+    transaction_count: 0,
+  },
+];
+
+const NO_LOOKUPS = { accounts: [], categories: [] };
+
+describe("describeWidgetFilters", () => {
+  it("returns [] for a widget with no set filters", () => {
+    expect(describeWidgetFilters(bar({}), {}, NO_LOOKUPS, NOW)).toEqual([]);
+  });
+
+  it("emits a date chip inherited from canvas (not overridden), preset-named", () => {
+    const presets = buildPresetRanges(NOW);
+    const chips = describeWidgetFilters(
+      bar({}),
+      { date_range: presets.this_month },
+      NO_LOOKUPS,
+      NOW,
+    );
+    const date = chips.find((c) => c.key === "date");
+    expect(date).toBeDefined();
+    expect(date?.overridden).toBeFalsy();
+    expect(date?.label).toBe("This month");
+  });
+
+  it("marks the date chip overridden when the widget date differs from canvas", () => {
+    const presets = buildPresetRanges(NOW);
+    const chips = describeWidgetFilters(
+      bar({ date_range: { start: "2026-03-01", end: "2026-03-31" } }),
+      { date_range: presets.this_month },
+      NO_LOOKUPS,
+      NOW,
+    );
+    const date = chips.find((c) => c.key === "date");
+    expect(date?.overridden).toBe(true);
+  });
+
+  it("does NOT emit a date chip when neither widget nor canvas has a date", () => {
+    const chips = describeWidgetFilters(bar({}), {}, NO_LOOKUPS, NOW);
+    expect(chips.find((c) => c.key === "date")).toBeUndefined();
+  });
+
+  it("resolves account ids to names with +N truncation", () => {
+    const chips = describeWidgetFilters(
+      bar({ account_ids: [1, 2, 3] }),
+      {},
+      { accounts: ACCTS, categories: [] },
+      NOW,
+    );
+    expect(chips.find((c) => c.key === "accounts")?.label).toBe("Checking +2");
+  });
+
+  it("falls back to a count label when no account name resolves", () => {
+    const chips = describeWidgetFilters(
+      bar({ account_ids: [99, 98] }),
+      {},
+      { accounts: ACCTS, categories: [] },
+      NOW,
+    );
+    expect(chips.find((c) => c.key === "accounts")?.label).toBe("2 accounts");
+  });
+
+  it("resolves category ids to names", () => {
+    const chips = describeWidgetFilters(
+      bar({ category_ids: [10, 20] }),
+      {},
+      { accounts: [], categories: CATS },
+      NOW,
+    );
+    expect(chips.find((c) => c.key === "categories")?.label).toBe("Groceries +1");
+  });
+
+  it("emits a txn_type chip capitalized only when set", () => {
+    expect(
+      describeWidgetFilters(bar({ txn_type: "expense" }), {}, NO_LOOKUPS, NOW)
+        .find((c) => c.key === "txn_type")?.label,
+    ).toBe("Expense");
+    expect(
+      describeWidgetFilters(bar({}), {}, NO_LOOKUPS, NOW).find(
+        (c) => c.key === "txn_type",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("emits amount chips for range / one-sided bounds", () => {
+    expect(
+      describeWidgetFilters(
+        bar({ amount_range: { min: 100, max: 500 } }),
+        {},
+        NO_LOOKUPS,
+        NOW,
+      ).find((c) => c.key === "amount")?.label,
+    ).toBe("$100–$500");
+    expect(
+      describeWidgetFilters(
+        bar({ amount_range: { min: 100 } }),
+        {},
+        NO_LOOKUPS,
+        NOW,
+      ).find((c) => c.key === "amount")?.label,
+    ).toBe("≥ $100");
+    expect(
+      describeWidgetFilters(
+        bar({ amount_range: { max: 500 } }),
+        {},
+        NO_LOOKUPS,
+        NOW,
+      ).find((c) => c.key === "amount")?.label,
+    ).toBe("≤ $500");
+  });
+
+  it("emits a tags chip and adds the (any) suffix only for tag_match=any", () => {
+    const anyChips = describeWidgetFilters(
+      bar({ tag_names: ["a", "b"], tag_match: "any" }),
+      {},
+      NO_LOOKUPS,
+      NOW,
+    );
+    expect(anyChips.find((c) => c.key === "tags")?.label).toContain("(any)");
+
+    const allChips = describeWidgetFilters(
+      bar({ tag_names: ["a", "b"], tag_match: "all" }),
+      {},
+      NO_LOOKUPS,
+      NOW,
+    );
+    expect(allChips.find((c) => c.key === "tags")?.label).not.toContain("(any)");
+  });
+
+  it("orders chips date, txn_type, amount, tags, accounts, categories", () => {
+    const presets = buildPresetRanges(NOW);
+    const chips = describeWidgetFilters(
+      bar({
+        date_range: presets.this_month,
+        txn_type: "income",
+        amount_range: { min: 10 },
+        tag_names: ["x"],
+        account_ids: [1],
+        category_ids: [10],
+      }),
+      {},
+      { accounts: ACCTS, categories: CATS },
+      NOW,
+    );
+    expect(chips.map((c) => c.key)).toEqual([
+      "date",
+      "txn_type",
+      "amount",
+      "tags",
+      "accounts",
+      "categories",
+    ]);
+  });
+});

--- a/frontend/tests/lib/reports/resolve.test.ts
+++ b/frontend/tests/lib/reports/resolve.test.ts
@@ -237,6 +237,47 @@ describe("resolveFilters — widget-only accounts/categories", () => {
     expect(out).toContainEqual({ field: "account_id", op: "in", value: [7] });
     expect(out).toContainEqual({ field: "category_id", op: "in", value: [9] });
   });
+
+  it("does NOT propagate canvas-level account_ids/category_ids (phase-4b model guard)", () => {
+    // Defensive against a regression that reintroduces a canvas fallback.
+    // CanvasFilters no longer types these, but a legacy/casted JSON blob
+    // could still carry them — they must be ignored entirely. Only the
+    // widget contributes account/category filters.
+    const canvasWithStaleIds = {
+      date_range: { start: "2026-01-01", end: "2026-01-31" },
+      // Cast through unknown: these keys are NOT on CanvasFilters by design.
+      account_ids: [101, 102],
+      category_ids: [201],
+    } as unknown as CanvasFilters;
+
+    const out = resolveFilters(canvasWithStaleIds, {});
+    // The date still resolves from the canvas...
+    expect(out).toContainEqual({
+      field: "date",
+      op: "between",
+      value: ["2026-01-01", "2026-01-31"],
+    });
+    // ...but NO account/category filter is emitted from canvas-level ids.
+    expect(out.some((f) => f.field === "account_id")).toBe(false);
+    expect(out.some((f) => f.field === "category_id")).toBe(false);
+  });
+
+  it("emits ONLY the widget account ids even when canvas also carries (stale) ids", () => {
+    const canvasWithStaleIds = {
+      account_ids: [101],
+      category_ids: [201],
+    } as unknown as CanvasFilters;
+
+    const out = resolveFilters(canvasWithStaleIds, { account_ids: [7] });
+    expect(out).toContainEqual({ field: "account_id", op: "in", value: [7] });
+    // The canvas id 101 must never appear.
+    expect(out).not.toContainEqual({
+      field: "account_id",
+      op: "in",
+      value: [101],
+    });
+    expect(out.some((f) => f.field === "category_id")).toBe(false);
+  });
 });
 
 describe("pickDateRange (exported single source of truth)", () => {
@@ -247,5 +288,19 @@ describe("pickDateRange (exported single source of truth)", () => {
     expect(pickDateRange(undefined, { start: "2026-01-01" })).toEqual({
       start: "2026-01-01",
     });
+  });
+
+  it("falls back to canvas when the widget range is empty (no start/end)", () => {
+    expect(pickDateRange({}, { start: "2026-01-01" })).toEqual({
+      start: "2026-01-01",
+    });
+  });
+
+  it("returns undefined when neither widget nor canvas has a date", () => {
+    expect(pickDateRange(undefined, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when the widget range is empty and there is no canvas", () => {
+    expect(pickDateRange({}, undefined)).toBeUndefined();
   });
 });

--- a/frontend/tests/lib/reports/resolve.test.ts
+++ b/frontend/tests/lib/reports/resolve.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it } from "vitest";
 
-import { isFieldOverridden, resolveFilters } from "@/lib/reports/resolve";
+import {
+  isFieldOverridden,
+  pickDateRange,
+  resolveFilters,
+} from "@/lib/reports/resolve";
 import type { CanvasFilters, WidgetFilters } from "@/lib/reports/types";
 
 /**
- * Locked rule (spec §4): the "Overrides canvas" pill fires ONLY
- * when BOTH widget and canvas have a meaningful value AND the
- * values differ. Identical values must NOT show the pill.
+ * Phase 4b model: ``date_range`` is the ONLY canvas-shared field, so
+ * it's the only field that can be an "override". Accounts and
+ * categories are now widget-only — ``CanvasFilters`` no longer carries
+ * them — so ``isFieldOverridden`` must always return false for them.
  *
- * These tests pin the five canonical cases across each field type:
+ * The date_range cases pin the five canonical override cases:
  *   1. identical -> no pill
  *   2. different by one element -> pill
  *   3. partial overlap -> pill
@@ -64,73 +69,29 @@ describe("isFieldOverridden", () => {
     });
   });
 
-  describe("account_ids", () => {
-    it("returns false when both lists contain the same ids regardless of order", () => {
-      const canvas: CanvasFilters = { account_ids: [3, 1, 2] };
-      const widget: WidgetFilters = { account_ids: [1, 2, 3] };
-      expect(isFieldOverridden("account_ids", widget, canvas)).toBe(false);
+  describe("account_ids (widget-only, never a canvas override)", () => {
+    // Accounts no longer live on the canvas, so a widget account list
+    // is never an "override" — the pill must never fire for it.
+    it("returns false even when a widget account list is set", () => {
+      const widget: WidgetFilters = { account_ids: [1, 2] };
+      expect(isFieldOverridden("account_ids", widget, {})).toBe(false);
     });
 
-    it("returns true when the widget list has an extra id", () => {
-      const canvas: CanvasFilters = { account_ids: [1, 2] };
-      const widget: WidgetFilters = { account_ids: [1, 2, 3] };
-      expect(isFieldOverridden("account_ids", widget, canvas)).toBe(true);
-    });
-
-    it("returns true when the lists partially overlap", () => {
-      const canvas: CanvasFilters = { account_ids: [1, 2, 3] };
-      const widget: WidgetFilters = { account_ids: [2, 3, 4] };
-      expect(isFieldOverridden("account_ids", widget, canvas)).toBe(true);
-    });
-
-    it("returns false when canvas has account_ids but the widget doesn't", () => {
-      const canvas: CanvasFilters = { account_ids: [1, 2, 3] };
-      const widget: WidgetFilters = {};
-      expect(isFieldOverridden("account_ids", widget, canvas)).toBe(false);
-    });
-
-    it("returns false when only the widget has account_ids (no canvas value)", () => {
-      const canvas: CanvasFilters = {};
-      const widget: WidgetFilters = { account_ids: [5] };
-      expect(isFieldOverridden("account_ids", widget, canvas)).toBe(false);
-    });
-
-    it("treats an empty widget account_ids array as inherit (no pill)", () => {
-      const canvas: CanvasFilters = { account_ids: [1, 2, 3] };
+    it("returns false for an empty widget account list", () => {
       const widget: WidgetFilters = { account_ids: [] };
-      expect(isFieldOverridden("account_ids", widget, canvas)).toBe(false);
+      expect(isFieldOverridden("account_ids", widget, {})).toBe(false);
     });
   });
 
-  describe("category_ids", () => {
-    it("returns false when both lists contain the same ids regardless of order", () => {
-      const canvas: CanvasFilters = { category_ids: [10, 20, 30] };
-      const widget: WidgetFilters = { category_ids: [30, 20, 10] };
-      expect(isFieldOverridden("category_ids", widget, canvas)).toBe(false);
+  describe("category_ids (widget-only, never a canvas override)", () => {
+    it("returns false even when a widget category list is set", () => {
+      const widget: WidgetFilters = { category_ids: [10, 20] };
+      expect(isFieldOverridden("category_ids", widget, {})).toBe(false);
     });
 
-    it("returns true when one id differs", () => {
-      const canvas: CanvasFilters = { category_ids: [10, 20] };
-      const widget: WidgetFilters = { category_ids: [10, 21] };
-      expect(isFieldOverridden("category_ids", widget, canvas)).toBe(true);
-    });
-
-    it("returns true on partial overlap", () => {
-      const canvas: CanvasFilters = { category_ids: [10, 20, 30] };
-      const widget: WidgetFilters = { category_ids: [20, 30, 40] };
-      expect(isFieldOverridden("category_ids", widget, canvas)).toBe(true);
-    });
-
-    it("returns false when canvas has category_ids but the widget doesn't", () => {
-      const canvas: CanvasFilters = { category_ids: [10, 20] };
-      const widget: WidgetFilters = {};
-      expect(isFieldOverridden("category_ids", widget, canvas)).toBe(false);
-    });
-
-    it("returns false when only the widget has category_ids", () => {
-      const canvas: CanvasFilters = {};
-      const widget: WidgetFilters = { category_ids: [10] };
-      expect(isFieldOverridden("category_ids", widget, canvas)).toBe(false);
+    it("returns false for an empty widget category list", () => {
+      const widget: WidgetFilters = { category_ids: [] };
+      expect(isFieldOverridden("category_ids", widget, {})).toBe(false);
     });
   });
 
@@ -263,6 +224,28 @@ describe("resolveFilters — tag emission", () => {
       op: "in",
       value: ["essentials"],
       tag_match: "all",
+    });
+  });
+});
+
+describe("resolveFilters — widget-only accounts/categories", () => {
+  it("emits account_id/category_id filters from the WIDGET (canvas no longer contributes)", () => {
+    const out = resolveFilters(
+      { date_range: { start: "2026-01-01", end: "2026-01-31" } },
+      { account_ids: [7], category_ids: [9] },
+    );
+    expect(out).toContainEqual({ field: "account_id", op: "in", value: [7] });
+    expect(out).toContainEqual({ field: "category_id", op: "in", value: [9] });
+  });
+});
+
+describe("pickDateRange (exported single source of truth)", () => {
+  it("prefers the widget date, falls back to canvas", () => {
+    expect(
+      pickDateRange({ start: "2026-02-01" }, { start: "2026-01-01" }),
+    ).toEqual({ start: "2026-02-01" });
+    expect(pickDateRange(undefined, { start: "2026-01-01" })).toEqual({
+      start: "2026-01-01",
     });
   });
 });

--- a/specs/2026-06-12-reports-v3-phase4b-filter-chips-plan.md
+++ b/specs/2026-06-12-reports-v3-phase4b-filter-chips-plan.md
@@ -1,0 +1,428 @@
+# Reports v3 Phase 4b — shared-date filter model + per-widget filter chips
+
+**Status:** plan (not implemented)
+**Date:** 2026-06-12
+**Companion:** visual companion (user-approved). The design below is **locked** — do not relitigate.
+
+---
+
+## Goal
+
+Make every report widget self-describing about what it queries:
+
+1. **Shrink the canvas filter bar to a shared DATE control only.** No accounts/categories at the canvas level. Widgets inherit the shared date and may override it per-widget.
+2. **Make accounts and categories fully per-widget** — edited only in the widget popover's Filters tab. The canvas no longer carries `account_ids` / `category_ids`.
+3. **Give each widget a slim filter-chip header** (pill chips) showing its **effective non-default filters**, visible in BOTH view and edit mode. Clicking a chip **selects the widget and opens the popover on the Filters tab**.
+
+The chips must mirror exactly what `resolveFilters(canvasFilters, widgetFilters)` produces, so they never lie about what the widget queries.
+
+## Architecture
+
+- **Filter model change (`lib/reports/types.ts`):** `CanvasFilters` keeps `date_range` and **drops** `account_ids` / `category_ids`. `WidgetFilters` is unchanged (keeps `date_range`, `account_ids`, `category_ids`, `txn_type`, `amount_range`, `tag_names`, `tag_match`).
+- **Resolution (`lib/reports/resolve.ts`):** `resolveFilters` stops cascading accounts/categories from canvas (widget-only now). `isFieldOverridden` keeps working for `date_range` (the only field still shared); the `account_ids`/`category_ids` branches become dead (canvas no longer has those keys) and are removed/no-op cleanly.
+- **New describe helper (`lib/reports/describe-filters.ts`):** `describeWidgetFilters(widget, canvasFilters, { accounts, categories })` returns an ordered list of **chip descriptors** computed consistently with `resolveFilters`. Pure, unit-tested. Takes already-fetched `accounts: Account[]` and `categories: Category[]` so it can map ids → names; falls back to count labels when a name is unresolved.
+- **Chip header (`WidgetShell.tsx`):** new slim header row above `children`, rendered in both view and edit mode. It calls `describeWidgetFilters` and renders pill chips. Each chip is a button: `onClick` → `onSelectFilters()` (a new callback that selects the widget AND requests the Filters tab). Account/category names come from SWR-fetched `accounts`/`categories` (same endpoints `AccountFilter`/`CategoryPicker` already use), fetched once at the page level and threaded down (NOT per-widget, to avoid N fetches).
+- **Popover deep-link (`WidgetEditorPopover.tsx`):** new `requestedTab?: TabKey` prop. When the selected widget changes, the popover honors a requested tab if present, else resets to `"data"` (preserving the #447 reset behavior).
+- **Page wiring (both pages):** add `requestedTab` state set alongside `selectedWidgetId` when a chip fires; threaded into `WidgetEditorPopover`; cleared after the popover consumes it.
+- **Backend:** no change. The query endpoint already ignores canvas `account_ids`/`category_ids`; the frontend simply stops sending them. Note only.
+
+### Name data source decision: **NAMES, not counts** (with count fallback)
+
+`Account` and `Category` both carry a `name` field, and `AccountFilter` (`GET /api/v1/accounts`, SWR key `/api/v1/accounts?for=reports-filter`) and `CategoryPicker` (`GET /api/v1/categories`, SWR key `/api/v1/categories?for=reports-filter`) already fetch the full lists. The chip header reuses those exact same SWR keys (so the cache is shared — no extra network cost) to resolve ids → names. Chips show truncated name lists, e.g. `Groceries +2`. When a list is fetched but an id is unresolved (deleted/inactive account), that id is dropped from the label and the count reflects only resolved names; if NONE resolve (data still loading or all unresolved), the chip falls back to a count label (`2 accounts`). This keeps chips human-readable without ever blocking on load.
+
+## Tech Stack
+
+- Next.js 16 App Router, React 19, TypeScript, Tailwind, SWR.
+- Vitest + Testing Library (`renderWithSWR` harness at `tests/utils/render-with-swr`).
+- CI gates run inside the frontend container.
+
+## Non-goals
+
+- No backend changes (the AST/query service already tolerates absent canvas account/category).
+- No data migration of saved reports. Pre-launch, no backcompat: saved reports whose `canvas_filters_json` still carries `account_ids`/`category_ids` simply have those keys ignored on read (they're no longer in `CanvasFilters`, and `resolveFilters` no longer reads them). Do NOT write a migration script.
+- No change to the 8 widget components' internals beyond what `WidgetShell` already wraps (the header lives in the shell, not each widget).
+- No keyboard-selection rework for widgets (a known pre-existing gap; out of scope).
+- No new chip UI for `status` filters — `WidgetFilters` has no status field today; "status" in the locked decision maps to `txn_type`. (If a future status field lands, the describe helper extends cleanly.)
+
+## File Structure
+
+**New files**
+- `frontend/lib/reports/describe-filters.ts` — `describeWidgetFilters()` + `FilterChip` descriptor type + the date/amount label formatters.
+- `frontend/tests/lib/reports/describe-filters.test.ts` — unit tests for the helper.
+- `frontend/components/reports/WidgetFilterChips.tsx` — presentational chip-row component (rendered by `WidgetShell`); keeps `WidgetShell` lean and independently testable.
+- `frontend/tests/components/reports/widget-filter-chips.test.tsx` — render/click tests for the chip row.
+
+**Edited files**
+- `frontend/lib/reports/types.ts` — drop `account_ids`/`category_ids` from `CanvasFilters`.
+- `frontend/lib/reports/resolve.ts` — widget-only accounts/categories; prune dead canvas branches.
+- `frontend/components/reports/CanvasFiltersBar.tsx` — date-only.
+- `frontend/components/reports/WidgetShell.tsx` — add chip header + `onSelectFilters` + `accounts`/`categories` props.
+- `frontend/components/reports/WidgetEditorPopover.tsx` — `requestedTab` prop.
+- `frontend/app/reports/[id]/page.tsx` — `requestedTab` state, fetch accounts/categories, thread props.
+- `frontend/app/reports/new/page.tsx` — same wiring.
+- `frontend/tests/lib/reports/resolve.test.ts` — rework canvas account/category cases.
+- `frontend/tests/components/reports/config/filter-editor-override-pill.test.tsx` — rework: only `date_range` can be a canvas-vs-widget override now; the account/category override-pill cases must change (account/category are widget-only → never an "override").
+
+---
+
+## PR strategy: **ONE PR**
+
+This is smaller than Phase 4a. No new dependency, no large new component (the chip row is a thin presentational component reusing existing SWR keys and the existing pill visual register from `OverridePill`). The change is one coherent model shift — splitting it would leave an intermediate state where the canvas still has account/category inputs but resolve ignores them, or where chips reference a model that hasn't shrunk yet. Ship as a single PR. Title:
+
+```
+feat(reports): shared-date canvas filter + per-widget filter chips
+```
+
+All CI gates below are **pre-PR** steps.
+
+---
+
+## TDD Tasks (bite-sized)
+
+> Test command: `docker compose exec -T frontend npx vitest run <path>`
+> Type-check: `docker compose exec -T frontend npx tsc --noEmit`
+> Lint (CI gate): `docker compose exec -T frontend npx eslint . --quiet`
+
+Work in dependency order: model → resolve → describe helper → chip row → shell → popover → pages → rework existing tests → final gates.
+
+---
+
+### Task 1 — Shrink `CanvasFilters` to date-only (type)
+
+**Files:** `frontend/lib/reports/types.ts`
+
+**Failing test:** add to `frontend/tests/lib/reports/resolve.test.ts` a compile-level assertion that canvas account/category no longer cascade (see Task 3); for this task the "failing" signal is `tsc`. Add a tiny type test instead — append to a new `describe-filters.test.ts` stub later. For Task 1 specifically, drive failure via `tsc`:
+
+1. **Run-to-fail (baseline):** `docker compose exec -T frontend npx tsc --noEmit` — currently GREEN (nothing changed yet). This task is a refactor whose failure surfaces in dependents (resolve, CanvasFiltersBar, FilterEditor). To make the failure explicit first, do Task 2's test edit before this — OR accept that Task 1+2+3 land together as the "model" unit. **Chosen approach:** treat Tasks 1–3 as one red→green unit (edit the resolve test red first, see Task 3).
+
+**Implement:**
+```ts
+export interface CanvasFilters {
+  date_range?: CanvasDateRange;
+}
+```
+Remove `account_ids` / `category_ids`.
+
+**Run-to-pass:** deferred to Task 3 (tsc + resolve test green together).
+
+**Commit:** fold into Task 3 commit (`refactor(reports): canvas filters are date-only`).
+
+---
+
+### Task 2 — Rework `resolve.test.ts` canvas account/category cases (RED first)
+
+**Files:** `frontend/tests/lib/reports/resolve.test.ts`
+
+**Failing test:** rewrite the `account_ids` and `category_ids` describe blocks. Under the new model, `isFieldOverridden("account_ids", ...)` and `("category_ids", ...)` must **always return false** (these are widget-only — canvas can't hold them, so a widget value is never an "override"). Replace the five canonical cases per field with assertions that account/category are never overrides, e.g.:
+
+```ts
+describe("account_ids (widget-only, never a canvas override)", () => {
+  it("returns false even when a widget account list is set", () => {
+    expect(isFieldOverridden("account_ids", { account_ids: [1, 2] }, {})).toBe(false);
+  });
+});
+```
+Keep all `date_range` cases as-is (date is the only still-shared field). Keep the tag-emission `resolveFilters` block as-is. Add a new `resolveFilters` case: **widget account/category still emit AST filters** (they're widget-only, but still real filters):
+
+```ts
+it("emits account_id/category_id filters from the WIDGET (canvas no longer contributes)", () => {
+  const out = resolveFilters({ date_range: { start: "2026-01-01", end: "2026-01-31" } },
+                             { account_ids: [7], category_ids: [9] });
+  expect(out).toContainEqual({ field: "account_id", op: "in", value: [7] });
+  expect(out).toContainEqual({ field: "category_id", op: "in", value: [9] });
+});
+```
+
+**Run-to-fail:** `docker compose exec -T frontend npx vitest run tests/lib/reports/resolve.test.ts` — RED (canvas account/category cases reference old behavior; also `tsc` will object once types shrink).
+
+---
+
+### Task 3 — Make accounts/categories widget-only in `resolve.ts` (GREEN)
+
+**Files:** `frontend/lib/reports/resolve.ts` (+ Task 1's `types.ts` edit)
+
+**Implement:**
+- In `resolveFilters`, replace `pickList(widget?.account_ids, canvas?.account_ids)` with `widget?.account_ids` directly (drop the canvas fallback). Same for `category_ids`. Remove the now-unused `pickList` helper if nothing else uses it (it's only used for account/category — confirm with grep; `pickDateRange` is separate and stays).
+- In `isFieldOverridden`, the `account_ids`/`category_ids` path now reads `canvasFilters?.[field]` which is always `undefined` → already returns false via the `hasMeaningfulValue(canvasVal)` guard. Tidy: keep the early-return structure; the `valuesEqual` `account_ids`/`category_ids` branch becomes dead — leave it harmless or remove. Document with a one-line comment that only `date_range` is canvas-shared now.
+
+**Run-to-pass:**
+- `docker compose exec -T frontend npx vitest run tests/lib/reports/resolve.test.ts` — GREEN
+- `docker compose exec -T frontend npx tsc --noEmit` — GREEN (after CanvasFiltersBar/FilterEditor edits in Tasks 4–5; if tsc is red here only because of those two files, proceed to 4–5 then re-run). **Note:** `FilterEditor` calls `isFieldOverridden("account_ids"/"category_ids", ...)` — that still compiles (the field key is valid on `WidgetFilters`), it just always returns false now, so those pills stop rendering. That's intended; the FilterEditor's account/category override pills disappear.
+
+**Commit:** `refactor(reports): canvas filters are date-only; accounts/categories are widget-only`
+
+---
+
+### Task 4 — Canvas bar shrinks to date-only
+
+**Files:** `frontend/components/reports/CanvasFiltersBar.tsx`
+
+**Failing test:** check for an existing CanvasFiltersBar test first (`grep -rl CanvasFiltersBar tests/`). If one exists, update it to assert the account/category pickers are GONE and the date control remains. If none exists, add `frontend/tests/components/reports/canvas-filters-bar.test.tsx`:
+```ts
+it("renders only the date control (no account/category pickers)", () => {
+  render(<CanvasFiltersBar value={{}} onChange={() => {}} />);
+  expect(screen.getByTestId("date-preset-chips")).toBeInTheDocument();
+  expect(screen.queryByTestId("account-filter")).toBeNull();
+  expect(screen.queryByTestId("category-picker")).toBeNull();
+});
+```
+
+**Run-to-fail:** `docker compose exec -T frontend npx vitest run tests/components/reports/canvas-filters-bar.test.tsx` — RED.
+
+**Implement:** remove the `AccountFilter` and `CategoryPicker` columns and their imports; collapse the grid to a single date column (drop `lg:grid-cols-3`). Keep `data-testid="canvas-filters-bar"` and the date label. Update the component doc comment (it still claims accounts/categories cascade).
+
+**Run-to-pass:** vitest GREEN; `tsc --noEmit` GREEN.
+
+**Commit:** `feat(reports): canvas filter bar is date-only`
+
+---
+
+### Task 5 — `describeWidgetFilters` helper (pure, unit-tested)
+
+**Files:** `frontend/lib/reports/describe-filters.ts` (new), `frontend/tests/lib/reports/describe-filters.test.ts` (new)
+
+**Design the descriptor:**
+```ts
+export interface FilterChip {
+  key: "date" | "txn_type" | "amount" | "tags" | "accounts" | "categories";
+  label: string;          // human, truncated, e.g. "Groceries +2"
+  overridden?: boolean;   // date only: true when widget overrides the shared canvas date
+}
+export function describeWidgetFilters(
+  widget: Widget,
+  canvasFilters: CanvasFilters | undefined,
+  lookups: { accounts: Account[]; categories: Category[] },
+): FilterChip[];
+```
+
+**Rules (mirror `resolveFilters`):**
+- Read `widget.config.filters` (guard `"filters" in widget.config`).
+- **date:** use the same `pickDateRange(widget, canvas)` logic. Emit a chip ONLY when an effective date range is set (start or end). Label = preset name if it matches a `buildPresetRanges(now)` entry (reuse the exported `buildPresetRanges` + a match), else `"MMM D – MMM D"` (or `"From MMM D"` / `"Until MMM D"` for one-sided). Set `overridden: true` when the widget's own `date_range` differs from the canvas date (reuse `isFieldOverridden("date_range", widgetFilters, canvasFilters)`).
+- **accounts:** only when `widgetFilters.account_ids?.length`. Label = resolved names joined, truncated to first 1–2 with `+N` (e.g. `Checking +2`); fall back to `"N accounts"` when zero names resolve.
+- **categories:** same pattern against `categories` lookup → `"Groceries +2"` / `"N categories"`.
+- **txn_type:** only when set → `"Income"` / `"Expense"` / `"Transfer"` (capitalize).
+- **amount:** only when `amount_range` has min or max → `"$100–$500"` / `"≥ $100"` / `"≤ $500"` (plain number formatting; currency symbol optional — keep minimal, match the roadmap deferral on chart currency symbols by NOT inventing per-account currency here; use a bare number or `$` prefix — pick `$` for readability and note it).
+- **tags:** only when `tag_names?.length` → names truncated `Groceries +2`, plus match mode suffix when `any` (e.g. `"tags: a, b (any)"` — keep short). Default `all` shows no suffix.
+- Order: date, txn_type, amount, tags, accounts, categories (stable). A widget with no set filters returns `[]`.
+
+**Failing test:** cover each rule:
+- empty filters → `[]`.
+- date inherited from canvas (no widget date) → ONE date chip, `overridden` falsy, label = preset name when canvas date == a preset.
+- widget date overrides canvas → date chip with `overridden: true`.
+- accounts resolve to names with `+N` truncation; unresolved id → count fallback.
+- txn_type / amount / tags chips appear only when set.
+- tag `any` adds the match suffix; `all` does not.
+
+```ts
+const w = makeBarWidget({ filters: { account_ids: [1, 2, 3] } });
+const chips = describeWidgetFilters(w, {}, { accounts: ACCTS, categories: [] });
+expect(chips.find(c => c.key === "accounts")?.label).toBe("Checking +2");
+```
+Use a fixed `now` injection for date-label determinism (accept an optional `now?: Date` arg mirroring `DatePresetChips`).
+
+**Run-to-fail:** `docker compose exec -T frontend npx vitest run tests/lib/reports/describe-filters.test.ts` — RED.
+
+**Implement** the helper.
+
+**Run-to-pass:** vitest GREEN; `tsc --noEmit` GREEN.
+
+**Commit:** `feat(reports): describeWidgetFilters chip descriptor helper`
+
+---
+
+### Task 6 — `WidgetFilterChips` presentational row
+
+**Files:** `frontend/components/reports/WidgetFilterChips.tsx` (new), `frontend/tests/components/reports/widget-filter-chips.test.tsx` (new)
+
+**Props:**
+```ts
+interface Props {
+  widget: Widget;
+  canvasFilters: CanvasFilters;
+  accounts: Account[];
+  categories: Category[];
+  onSelectFilters: () => void;   // select widget + open Filters tab
+}
+```
+Renders nothing (or a minimal empty state — choose nothing, return `null`) when `describeWidgetFilters` is empty. Otherwise a `flex flex-wrap gap-1` row of pill `<button>`s reusing the `OverridePill` visual register (rounded-full, `bg-accent/15`/`text-accent` for overridden date; `badgeNeutral` from `lib/styles.ts` for the rest). Each button:
+- `type="button"`, `data-testid={`widget-filter-chip-${chip.key}`}`,
+- `aria-label={`Edit ${chip.key} filter`}`,
+- `onClick={(e) => { e.stopPropagation(); onSelectFilters(); }}` (stop propagation so it doesn't double-fire `WidgetShell`'s `onSelect`),
+- shows `chip.label`.
+
+**Failing test:**
+```ts
+it("renders a chip per set filter and fires onSelectFilters on click", async () => {
+  const onSelectFilters = vi.fn();
+  render(<WidgetFilterChips widget={barWith({ txn_type: "expense" })}
+           canvasFilters={{}} accounts={[]} categories={[]}
+           onSelectFilters={onSelectFilters} />);
+  await userEvent.click(screen.getByTestId("widget-filter-chip-txn_type"));
+  expect(onSelectFilters).toHaveBeenCalledOnce();
+});
+it("renders nothing when the widget has no set filters", () => {
+  const { container } = render(<WidgetFilterChips widget={barWith({})} canvasFilters={{}} accounts={[]} categories={[]} onSelectFilters={() => {}} />);
+  expect(container).toBeEmptyDOMElement();
+});
+```
+
+**Run-to-fail:** `docker compose exec -T frontend npx vitest run tests/components/reports/widget-filter-chips.test.tsx` — RED.
+
+**Implement.** **Run-to-pass:** GREEN; `tsc --noEmit` GREEN.
+
+**Commit:** `feat(reports): widget filter-chip row`
+
+---
+
+### Task 7 — Mount chips in `WidgetShell`
+
+**Files:** `frontend/components/reports/WidgetShell.tsx`
+
+**Failing test:** check for an existing WidgetShell test (`grep -rl WidgetShell tests/`); add/extend `frontend/tests/components/reports/widget-shell.test.tsx`:
+```ts
+it("renders filter chips in both view and edit mode and wires onSelectFilters", async () => {
+  const onSelectFilters = vi.fn();
+  render(<WidgetShell widgetId="w1" selected={false} editMode={false}
+           onSelect={() => {}} onSelectFilters={onSelectFilters}
+           widget={barWith({ txn_type: "expense" })}
+           canvasFilters={{}} accounts={[]} categories={[]}>
+           <div>body</div></WidgetShell>);
+  await userEvent.click(screen.getByTestId("widget-filter-chip-txn_type"));
+  expect(onSelectFilters).toHaveBeenCalledOnce();
+});
+```
+
+**Run-to-fail:** RED (props don't exist).
+
+**Implement:** add props `widget: Widget`, `canvasFilters: CanvasFilters`, `accounts: Account[]`, `categories: Category[]`, `onSelectFilters: () => void`. Render `<WidgetFilterChips ... />` as a slim header row ABOVE `children` (inside the shell div, before `<div className="h-full w-full">{children}</div>`). Keep it visible regardless of `editMode`. The existing edit-mode drag/remove overlay stays absolutely positioned top-right; ensure the chip row doesn't collide (chips left-aligned, small top padding). Keep `data-widget-shell` anchor and aria contract.
+
+**Run-to-pass:** GREEN; `tsc --noEmit` GREEN.
+
+**Commit:** `feat(reports): widget shell renders effective filter chips`
+
+---
+
+### Task 8 — `requestedTab` deep-link on the popover
+
+**Files:** `frontend/components/reports/WidgetEditorPopover.tsx`
+
+**Failing test:** `frontend/tests/components/reports/widget-editor-popover-requested-tab.test.tsx` (new) — render with `requestedTab="filters"` and assert the Filters tab is selected (`aria-selected="true"` on the Filters tab / the `FilterEditor` is visible). Also assert that WITHOUT `requestedTab`, the Data tab is selected (preserve #447 default). And that changing `widget.id` with a fresh `requestedTab="filters"` lands on Filters.
+
+```ts
+it("opens on the Filters tab when requestedTab='filters'", () => {
+  renderWithSWR(<WidgetEditorPopover widget={bar} canvasFilters={{}}
+    anchorEl={document.body} requestedTab="filters"
+    onUpdate={() => {}} onClose={() => {}} />);
+  expect(screen.getByRole("tab", { name: "Filters" })).toHaveAttribute("aria-selected", "true");
+});
+```
+
+**Run-to-fail:** RED.
+
+**Implement:**
+- Add `requestedTab?: TabKey` to `Props`.
+- Initialize `tab` from `requestedTab ?? "data"` (lazy `useState(() => requestedTab ?? "data")`).
+- Rework the reset effect (currently `useEffect(() => setTab("data"), [widget.id])`): on `widget.id` change, set `setTab(requestedTab ?? "data")` so a new selection carrying a requested tab honors it. Key the effect on `[widget.id, requestedTab]`. Guard against fighting user clicks: only re-apply when `widget.id` OR `requestedTab` actually changes (the effect dep array handles this; the page clears `requestedTab` after first open — see Task 9 — so a later manual tab click isn't clobbered).
+
+**Run-to-pass:** GREEN; `tsc --noEmit` GREEN.
+
+**Commit:** `feat(reports): popover honors a requested tab for chip deep-link`
+
+---
+
+### Task 9 — Wire `[id]` page: fetch lookups, thread chips + requestedTab
+
+**Files:** `frontend/app/reports/[id]/page.tsx`
+
+**Failing test:** extend the page's existing test (find via `grep -rl "reports/\[id\]\|ReportEditorPage" tests/`) or add a focused integration test: clicking a widget's filter chip selects the widget and the popover opens on Filters. If full page render is heavy in tests, a lighter unit test on the chip→state path is acceptable; prefer reusing the existing page test harness.
+
+**Run-to-fail:** RED.
+
+**Implement:**
+- Fetch accounts + categories once with SWR using the SAME keys the filters use (`/api/v1/accounts?for=reports-filter`, `/api/v1/categories?for=reports-filter`) so the cache is shared with `AccountFilter`/`CategoryPicker`. Default to `[]`.
+- Add `const [requestedTab, setRequestedTab] = useState<TabKey | null>(null);` (import `TabKey` or redefine the union locally; export `TabKey` from the popover for reuse).
+- Add a handler `selectWidgetFilters(id)`: `setSelectedWidgetId(id); setRequestedTab("filters");`.
+- In the `WidgetShell` render callback, pass `widget={w}`, `canvasFilters`, `accounts`, `categories`, and `onSelectFilters={() => selectWidgetFilters(w.id)}`. Also pass the same to the mobile-stack branch (chips should show there too, but mobile is read-only — `onSelectFilters` can be a no-op or still open nothing; keep chips visible, click does nothing on mobile since there's no popover. Pass `onSelectFilters={() => {}}` in the stack).
+- Pass `requestedTab={requestedTab ?? undefined}` to `WidgetEditorPopover`, and clear it after open: when the popover mounts/opens, call `setRequestedTab(null)` (e.g. clear in `closePopover` AND once the popover has consumed it — simplest: clear on the next tick after select, or clear inside `selectWidgetFilters` is wrong because the popover reads it on mount; instead clear when `closePopover` runs and also reset when `selectedWidgetId` changes via plain click). **Mechanism:** keep `requestedTab` set until the popover closes; the popover's lazy init + `[widget.id, requestedTab]` effect consume it on open. On `closePopover`, `setRequestedTab(null)`. A plain `onSelect` (non-chip click) sets `selectedWidgetId` but NOT `requestedTab`, and because `requestedTab` was cleared on previous close, the popover defaults to Data.
+- Update the empty-state helper copy that says "Canvas filters (date, accounts, categories)" → "Canvas date applies to every widget; accounts and categories are per-widget."
+
+**Run-to-pass:** GREEN; `tsc --noEmit` GREEN.
+
+**Commit:** `feat(reports): [id] editor wires filter chips + filters deep-link`
+
+---
+
+### Task 10 — Wire `new` (draft) page: same changes
+
+**Files:** `frontend/app/reports/new/page.tsx`
+
+**Failing test:** mirror Task 9's test against the draft page (it's always edit mode, so the popover gate is just `selectedWidget && anchorEl`).
+
+**Run-to-fail:** RED.
+
+**Implement:** same as Task 9 — fetch accounts/categories (shared SWR keys), add `requestedTab` state + `selectWidgetFilters`, thread `widget`/`canvasFilters`/`accounts`/`categories`/`onSelectFilters` into `WidgetShell`, pass `requestedTab` to the popover, clear on close, fix the empty-state copy. The draft page uses `widgetKit.renderWidgetByType`; the chip header is in `WidgetShell` (rendered inline on this page), so no `widgetKit` change needed — just the `WidgetShell` props.
+
+**Run-to-pass:** GREEN; `tsc --noEmit` GREEN.
+
+**Commit:** `feat(reports): draft editor wires filter chips + filters deep-link`
+
+---
+
+### Task 11 — Rework the FilterEditor override-pill test
+
+**Files:** `frontend/tests/components/reports/config/filter-editor-override-pill.test.tsx`
+
+**Failing test / rework:** the account and category "override pill" cases can no longer fire — account/category are widget-only, so `isFieldOverridden` always returns false for them and no `override-pill` renders. Rewrite those four cases:
+- account match/differ → pill NEVER shows (both assert `0` pills).
+- category match/differ → pill NEVER shows.
+- Keep (or add) the `date_range` override case as the surviving canvas-vs-widget override the pill still represents (add a date case if none exists, asserting the pill shows when widget date differs from canvas date and not when equal).
+Also drop the canvas `account_ids`/`category_ids` props from these fixtures (those keys no longer exist on `CanvasFilters` → tsc error otherwise).
+
+**Run-to-fail:** `docker compose exec -T frontend npx vitest run tests/components/reports/config/filter-editor-override-pill.test.tsx` — RED (old expectations + removed canvas keys).
+
+**Implement** the rewrite.
+
+**Run-to-pass:** GREEN; `tsc --noEmit` GREEN.
+
+**Commit:** `test(reports): rework override-pill cases for date-only canvas`
+
+---
+
+### Task 12 — Repo-wide sweep for removed canvas keys + final gates
+
+**Files:** any remaining references.
+
+1. **Grep sweep:** `docker compose exec -T frontend grep -rn "account_ids\|category_ids" app components lib tests` — confirm every `canvas`-side reference is gone (widget-side `WidgetFilters.account_ids`/`category_ids` stays). Check templates/draft seed (`lib/reports/draft.ts`, `lib/reports/api.ts`, any template fixtures, `ReportTemplate.canvas_filters_json` shapes) for canvas `account_ids`/`category_ids` literals and remove them. Check `series.ts`, `csv.ts`, `use-widget-anchor.ts` for any canvas-filter coupling (unlikely).
+2. **Full vitest suite** (NOT just touched files — per the full-suite verification rule; a cross-file rename can regress elsewhere):
+   `docker compose exec -T frontend npx vitest run`
+3. **Type-check:** `docker compose exec -T frontend npx tsc --noEmit`
+4. **Lint (CI gate):** `docker compose exec -T frontend npx eslint . --quiet`
+
+All three must be clean before opening the PR.
+
+**Commit (if sweep changes anything):** `chore(reports): drop residual canvas account/category references`
+
+---
+
+## Must-flag list (call out in the PR description / review)
+
+1. **No data migration** of saved reports. Old `canvas_filters_json` with `account_ids`/`category_ids` is silently ignored on read (keys no longer in `CanvasFilters`; `resolveFilters` no longer reads them). This is a **behavior change** for any saved report that relied on canvas-level account/category scoping — those filters effectively vanish until the user re-adds them per-widget. Pre-launch, no users, acceptable; flag explicitly.
+2. **Backend sends nothing new** — confirm the query endpoint still accepts a `canvas_filters_json` lacking those keys (it does; note it). `saveLayout`/`createReport` now persist a date-only canvas blob.
+3. **Chip name resolution depends on shared SWR cache.** If a widget references a deleted/inactive account or category id, that id is dropped from the label (count fallback). Inactive accounts are already filtered out of `AccountFilter`'s selectable list, so a previously-selected-then-deactivated account could become a count-only chip — acceptable, note it.
+4. **`stopPropagation` on chip click** is required so the chip's `onSelectFilters` doesn't also trigger `WidgetShell`'s `onSelect` (which would set `selectedWidgetId` without the Filters tab). Verify the chip wins.
+5. **`requestedTab` lifecycle:** set on chip click, consumed by the popover on open, cleared on close. A subsequent plain widget click must default to the Data tab (regression risk against the #447 reset). Covered by Task 8 + Task 9 tests.
+6. **Mobile stack** shows chips but they're inert (read-only, no popover). Confirm no console error / no broken click.
+7. **Currency symbol on the amount chip** is a bare `$` prefix (not per-account currency) — consistent with the deferred chart currency-symbol work (roadmap §1b). Note the simplification.
+8. **Amount/date label formatting** has no shared formatter today (`grep` confirmed none in `lib/reports`); the new formatters live in `describe-filters.ts`. Don't duplicate `buildPresetRanges` — import it from `DatePresetChips`.
+
+---
+
+## Self-Review
+
+- **Does `describeWidgetFilters` mirror `resolveFilters`?** Both read `widget.config.filters`, both use `pickDateRange` for the effective date, both gate accounts/categories on widget-only presence, both treat empty arrays as unset. The describe helper must NOT show a chip for a filter `resolveFilters` wouldn't emit (e.g. empty `tag_names`). Tested in Task 5.
+- **Is the canvas→widget model shift total?** `CanvasFilters` shrinks (Task 1), `resolveFilters` drops the fallback (Task 3), `CanvasFiltersBar` drops the pickers (Task 4), and the repo sweep (Task 12) catches stragglers in templates/draft/api. `FilterEditor` still renders the account/category PICKERS (widget-only editing) — that's correct and unchanged; only its override PILLS for those fields go dark.
+- **Deep-link correctness:** chip → `onSelectFilters` → `selectedWidgetId` + `requestedTab="filters"` → popover opens on Filters. Plain widget click → `onSelect` → Data tab. The #447 reset-on-widget-change is preserved by initializing/resetting `tab` from `requestedTab ?? "data"`.
+- **Both pages:** Tasks 9 + 10 apply identical wiring. The draft page is always-edit; the `[id]` page gates the popover on `editModeActive` — chips still render on `[id]` in VIEW mode (locked decision), but clicking a chip in view mode can't open the popover (no `editModeActive`). **Decision:** in view mode, `onSelectFilters` still sets `selectedWidgetId`, but the popover is gated on `editModeActive`, so nothing opens. Either (a) leave it inert in view mode (chips are informational there), or (b) have the chip click flip into edit mode first. **Choose (a)** — keep view mode read-only; chips are status-is-data informational. Note this in the PR.
+- **No new dependency, one cohesive PR** — justified above.
+- **CI gates are pre-PR:** full `vitest run`, `tsc --noEmit`, `eslint . --quiet` (Task 12).
+- **Pre-launch hygiene:** no compat shims, no migration script (per locked feedback rules).

--- a/specs/2026-06-12-reports-v3-phase4b-filter-chips-plan.md
+++ b/specs/2026-06-12-reports-v3-phase4b-filter-chips-plan.md
@@ -3,6 +3,7 @@
 **Status:** plan (not implemented)
 **Date:** 2026-06-12
 **Companion:** visual companion (user-approved). The design below is **locked** — do not relitigate.
+**Revision:** absorbs senior-architect race-condition fixes to the chip→popover deep-link (the `requestedTab` consume-and-clear handshake, mobile-stack chip decision, `pickDateRange` export, view-mode orphan-selection guard, draft-page empty-state copy).
 
 ---
 
@@ -19,14 +20,23 @@ The chips must mirror exactly what `resolveFilters(canvasFilters, widgetFilters)
 ## Architecture
 
 - **Filter model change (`lib/reports/types.ts`):** `CanvasFilters` keeps `date_range` and **drops** `account_ids` / `category_ids`. `WidgetFilters` is unchanged (keeps `date_range`, `account_ids`, `category_ids`, `txn_type`, `amount_range`, `tag_names`, `tag_match`).
-- **Resolution (`lib/reports/resolve.ts`):** `resolveFilters` stops cascading accounts/categories from canvas (widget-only now). `isFieldOverridden` keeps working for `date_range` (the only field still shared); the `account_ids`/`category_ids` branches become dead (canvas no longer has those keys) and are removed/no-op cleanly.
-- **New describe helper (`lib/reports/describe-filters.ts`):** `describeWidgetFilters(widget, canvasFilters, { accounts, categories })` returns an ordered list of **chip descriptors** computed consistently with `resolveFilters`. Pure, unit-tested. Takes already-fetched `accounts: Account[]` and `categories: Category[]` so it can map ids → names; falls back to count labels when a name is unresolved.
+- **Resolution (`lib/reports/resolve.ts`):** `resolveFilters` stops cascading accounts/categories from canvas (widget-only now). `isFieldOverridden` keeps working for `date_range` (the only field still shared); the `account_ids`/`category_ids` branches become dead (canvas no longer has those keys) and are removed/no-op cleanly. **`pickDateRange` is now exported** (it was module-private at ~line 192) so the describe helper can reuse the single date inherit/override implementation rather than reimplementing it.
+- **New describe helper (`lib/reports/describe-filters.ts`):** `describeWidgetFilters(widget, canvasFilters, { accounts, categories })` returns an ordered list of **chip descriptors** computed consistently with `resolveFilters`. Pure, unit-tested. Takes already-fetched `accounts: Account[]` and `categories: Category[]` so it can map ids → names; falls back to count labels when a name is unresolved. **Imports `pickDateRange` and `isFieldOverridden` from `resolve.ts`** — single source of truth for the date inherit/override decision.
 - **Chip header (`WidgetShell.tsx`):** new slim header row above `children`, rendered in both view and edit mode. It calls `describeWidgetFilters` and renders pill chips. Each chip is a button: `onClick` → `onSelectFilters()` (a new callback that selects the widget AND requests the Filters tab). Account/category names come from SWR-fetched `accounts`/`categories` (same endpoints `AccountFilter`/`CategoryPicker` already use), fetched once at the page level and threaded down (NOT per-widget, to avoid N fetches).
-- **Popover deep-link (`WidgetEditorPopover.tsx`):** new `requestedTab?: TabKey` prop. When the selected widget changes, the popover honors a requested tab if present, else resets to `"data"` (preserving the #447 reset behavior).
-- **Page wiring (both pages):** add `requestedTab` state set alongside `selectedWidgetId` when a chip fires; threaded into `WidgetEditorPopover`; cleared after the popover consumes it.
+- **Popover deep-link (`WidgetEditorPopover.tsx`) — consume-and-clear handshake:** new `requestedTab?: TabKey` AND `onTabConsumed?: () => void` props, with **two separate effects** (NOT one combined effect — see Task 8 for why the single-effect approach is broken):
+  - a **reset effect** keyed on `[widget.id]` only, which resets the tab on widget-identity change;
+  - a **honor-request effect** keyed on `[requestedTab]` which, when `requestedTab` is truthy, sets the tab to it and immediately calls `onTabConsumed()` so the page clears the request in the same cycle.
+  The page holds `requestedTab` and clears it the instant the popover consumes it. Because of consume-and-clear, **every** chip click is a genuine `null → "filters"` transition — so clicking a chip on the already-selected widget a second time still re-opens Filters.
+- **Page wiring (both pages):** add `requestedTab` state set alongside `selectedWidgetId` when a chip fires; threaded into `WidgetEditorPopover` together with `onTabConsumed={() => setRequestedTab(null)}`. `closePopover` ALSO clears `requestedTab` (harmless belt-and-suspenders; the real clear is the consume callback).
 - **Backend:** no change. The query endpoint already ignores canvas `account_ids`/`category_ids`; the frontend simply stops sending them. Note only.
 
-### Name data source decision: **NAMES, not counts** (with count fallback)
+### Architect-verified facts (encode, do not relitigate)
+
+- **`Canvas.tsx` is NOT touched.** The new `WidgetShell` props (`widget`, `canvasFilters`, `accounts`, `categories`, `onSelectFilters`) are all supplied by the page-level `renderWidget` closure passed into `Canvas`. `Canvas` only forwards `renderWidget` and never reads filter state, so nothing in `Canvas.tsx` changes.
+- **The `CanvasFilters` type shrink surfaces no hidden reads.** Saved `canvas_filters_json` that still carries `account_ids`/`category_ids` is tolerated via the existing `as CanvasFilters` cast at hydrate time — the extra keys are simply not in the type and are never read. **No migration.**
+- **`pickList` can be deleted.** Grep confirms it is used only by the two removed account/category cascade branches in `resolveFilters`. Once those switch to reading the widget value directly, `pickList` has no callers and is removed. (`pickDateRange` is a separate helper and STAYS — now exported.)
+
+### Name data source decision: **NAMES, not counts** (with count fallback) — **LOCKED, keep**
 
 `Account` and `Category` both carry a `name` field, and `AccountFilter` (`GET /api/v1/accounts`, SWR key `/api/v1/accounts?for=reports-filter`) and `CategoryPicker` (`GET /api/v1/categories`, SWR key `/api/v1/categories?for=reports-filter`) already fetch the full lists. The chip header reuses those exact same SWR keys (so the cache is shared — no extra network cost) to resolve ids → names. Chips show truncated name lists, e.g. `Groceries +2`. When a list is fetched but an id is unresolved (deleted/inactive account), that id is dropped from the label and the count reflects only resolved names; if NONE resolve (data still loading or all unresolved), the chip falls back to a count label (`2 accounts`). This keeps chips human-readable without ever blocking on load.
 
@@ -39,10 +49,11 @@ The chips must mirror exactly what `resolveFilters(canvasFilters, widgetFilters)
 ## Non-goals
 
 - No backend changes (the AST/query service already tolerates absent canvas account/category).
-- No data migration of saved reports. Pre-launch, no backcompat: saved reports whose `canvas_filters_json` still carries `account_ids`/`category_ids` simply have those keys ignored on read (they're no longer in `CanvasFilters`, and `resolveFilters` no longer reads them). Do NOT write a migration script.
+- No data migration of saved reports. Pre-launch, no backcompat: saved reports whose `canvas_filters_json` still carries `account_ids`/`category_ids` simply have those keys ignored on read (they're no longer in `CanvasFilters`, and `resolveFilters` no longer reads them; the `as CanvasFilters` hydrate cast tolerates the extra keys). Do NOT write a migration script.
 - No change to the 8 widget components' internals beyond what `WidgetShell` already wraps (the header lives in the shell, not each widget).
 - No keyboard-selection rework for widgets (a known pre-existing gap; out of scope).
 - No new chip UI for `status` filters — `WidgetFilters` has no status field today; "status" in the locked decision maps to `txn_type`. (If a future status field lands, the describe helper extends cleanly.)
+- **No chips on the mobile read-only stack.** The mobile branch renders `renderWidgetByType` directly, NOT wrapped in `WidgetShell` — so chips never appear there, and that is the intended outcome (mobile is read-only, there is no popover to deep-link into). We do NOT add `WidgetShell` to the stack. See Tasks 9/10.
 
 ## File Structure
 
@@ -54,12 +65,12 @@ The chips must mirror exactly what `resolveFilters(canvasFilters, widgetFilters)
 
 **Edited files**
 - `frontend/lib/reports/types.ts` — drop `account_ids`/`category_ids` from `CanvasFilters`.
-- `frontend/lib/reports/resolve.ts` — widget-only accounts/categories; prune dead canvas branches.
+- `frontend/lib/reports/resolve.ts` — widget-only accounts/categories; prune dead canvas branches; delete `pickList`; **export `pickDateRange`**.
 - `frontend/components/reports/CanvasFiltersBar.tsx` — date-only.
-- `frontend/components/reports/WidgetShell.tsx` — add chip header + `onSelectFilters` + `accounts`/`categories` props.
-- `frontend/components/reports/WidgetEditorPopover.tsx` — `requestedTab` prop.
-- `frontend/app/reports/[id]/page.tsx` — `requestedTab` state, fetch accounts/categories, thread props.
-- `frontend/app/reports/new/page.tsx` — same wiring.
+- `frontend/components/reports/WidgetShell.tsx` — add chip header + `onSelectFilters` + `widget`/`canvasFilters`/`accounts`/`categories` props.
+- `frontend/components/reports/WidgetEditorPopover.tsx` — `requestedTab` + `onTabConsumed` props; two-effect consume-and-clear.
+- `frontend/app/reports/[id]/page.tsx` — `requestedTab` state, fetch accounts/categories, thread props, view-mode no-op handler, empty-state copy.
+- `frontend/app/reports/new/page.tsx` — same wiring (always edit mode), draft empty-state copy.
 - `frontend/tests/lib/reports/resolve.test.ts` — rework canvas account/category cases.
 - `frontend/tests/components/reports/config/filter-editor-override-pill.test.tsx` — rework: only `date_range` can be a canvas-vs-widget override now; the account/category override-pill cases must change (account/category are widget-only → never an "override").
 
@@ -132,17 +143,26 @@ it("emits account_id/category_id filters from the WIDGET (canvas no longer contr
   expect(out).toContainEqual({ field: "category_id", op: "in", value: [9] });
 });
 ```
+Also add a focused export/parity case for `pickDateRange` (now public — Task 3): import it and assert the widget date wins when set, canvas otherwise:
+```ts
+it("pickDateRange prefers the widget date, falls back to canvas", () => {
+  expect(pickDateRange({ start: "2026-02-01" }, { start: "2026-01-01" })).toEqual({ start: "2026-02-01" });
+  expect(pickDateRange(undefined, { start: "2026-01-01" })).toEqual({ start: "2026-01-01" });
+});
+```
 
-**Run-to-fail:** `docker compose exec -T frontend npx vitest run tests/lib/reports/resolve.test.ts` — RED (canvas account/category cases reference old behavior; also `tsc` will object once types shrink).
+**Run-to-fail:** `docker compose exec -T frontend npx vitest run tests/lib/reports/resolve.test.ts` — RED (canvas account/category cases reference old behavior; `pickDateRange` import is not yet exported; `tsc` will object once types shrink).
 
 ---
 
-### Task 3 — Make accounts/categories widget-only in `resolve.ts` (GREEN)
+### Task 3 — Make accounts/categories widget-only in `resolve.ts`; export `pickDateRange` (GREEN)
 
 **Files:** `frontend/lib/reports/resolve.ts` (+ Task 1's `types.ts` edit)
 
 **Implement:**
-- In `resolveFilters`, replace `pickList(widget?.account_ids, canvas?.account_ids)` with `widget?.account_ids` directly (drop the canvas fallback). Same for `category_ids`. Remove the now-unused `pickList` helper if nothing else uses it (it's only used for account/category — confirm with grep; `pickDateRange` is separate and stays).
+- In `resolveFilters`, replace `pickList(widget?.account_ids, canvas?.account_ids)` with `widget?.account_ids` directly (drop the canvas fallback). Same for `category_ids`.
+- **Delete the `pickList` helper.** Grep confirms it is used ONLY by the two account/category cascade branches just removed; nothing else references it. (`pickDateRange` is a separate helper and stays.)
+- **Export `pickDateRange`** (currently module-private at ~line 192). Change `function pickDateRange(...)` → `export function pickDateRange(...)`. This is the single source of truth for the date inherit/override decision that Task 5's `describeWidgetFilters` will import (instead of reimplementing the logic).
 - In `isFieldOverridden`, the `account_ids`/`category_ids` path now reads `canvasFilters?.[field]` which is always `undefined` → already returns false via the `hasMeaningfulValue(canvasVal)` guard. Tidy: keep the early-return structure; the `valuesEqual` `account_ids`/`category_ids` branch becomes dead — leave it harmless or remove. Document with a one-line comment that only `date_range` is canvas-shared now.
 
 **Run-to-pass:**
@@ -192,16 +212,19 @@ export function describeWidgetFilters(
   widget: Widget,
   canvasFilters: CanvasFilters | undefined,
   lookups: { accounts: Account[]; categories: Category[] },
+  now?: Date,
 ): FilterChip[];
 ```
 
+**Single source of truth (N2):** import `pickDateRange` and `isFieldOverridden` from `resolve.ts` — do NOT reimplement the date inherit/override logic. The effective date is `pickDateRange(widgetFilters.date_range, canvasFilters?.date_range)`; the `overridden` flag is `isFieldOverridden("date_range", widgetFilters, canvasFilters)`.
+
 **Rules (mirror `resolveFilters`):**
 - Read `widget.config.filters` (guard `"filters" in widget.config`).
-- **date:** use the same `pickDateRange(widget, canvas)` logic. Emit a chip ONLY when an effective date range is set (start or end). Label = preset name if it matches a `buildPresetRanges(now)` entry (reuse the exported `buildPresetRanges` + a match), else `"MMM D – MMM D"` (or `"From MMM D"` / `"Until MMM D"` for one-sided). Set `overridden: true` when the widget's own `date_range` differs from the canvas date (reuse `isFieldOverridden("date_range", widgetFilters, canvasFilters)`).
+- **date:** use `pickDateRange(widget, canvas)` (imported). Emit a chip ONLY when an effective date range is set (start or end). Label = preset name if it matches a `buildPresetRanges(now)` entry (reuse the exported `buildPresetRanges` + a match), else `"MMM D – MMM D"` (or `"From MMM D"` / `"Until MMM D"` for one-sided). Set `overridden: true` via `isFieldOverridden("date_range", widgetFilters, canvasFilters)`.
 - **accounts:** only when `widgetFilters.account_ids?.length`. Label = resolved names joined, truncated to first 1–2 with `+N` (e.g. `Checking +2`); fall back to `"N accounts"` when zero names resolve.
 - **categories:** same pattern against `categories` lookup → `"Groceries +2"` / `"N categories"`.
 - **txn_type:** only when set → `"Income"` / `"Expense"` / `"Transfer"` (capitalize).
-- **amount:** only when `amount_range` has min or max → `"$100–$500"` / `"≥ $100"` / `"≤ $500"` (plain number formatting; currency symbol optional — keep minimal, match the roadmap deferral on chart currency symbols by NOT inventing per-account currency here; use a bare number or `$` prefix — pick `$` for readability and note it).
+- **amount:** only when `amount_range` has min or max → `"$100–$500"` / `"≥ $100"` / `"≤ $500"` (plain number formatting; currency symbol optional — keep minimal, match the roadmap deferral on chart currency symbols by NOT inventing per-account currency here; use a bare `$` prefix and note it).
 - **tags:** only when `tag_names?.length` → names truncated `Groceries +2`, plus match mode suffix when `any` (e.g. `"tags: a, b (any)"` — keep short). Default `all` shows no suffix.
 - Order: date, txn_type, amount, tags, accounts, categories (stable). A widget with no set filters returns `[]`.
 
@@ -218,7 +241,7 @@ const w = makeBarWidget({ filters: { account_ids: [1, 2, 3] } });
 const chips = describeWidgetFilters(w, {}, { accounts: ACCTS, categories: [] });
 expect(chips.find(c => c.key === "accounts")?.label).toBe("Checking +2");
 ```
-Use a fixed `now` injection for date-label determinism (accept an optional `now?: Date` arg mirroring `DatePresetChips`).
+Use the optional `now?: Date` arg for date-label determinism (mirrors `DatePresetChips`).
 
 **Run-to-fail:** `docker compose exec -T frontend npx vitest run tests/lib/reports/describe-filters.test.ts` — RED.
 
@@ -244,7 +267,7 @@ interface Props {
   onSelectFilters: () => void;   // select widget + open Filters tab
 }
 ```
-Renders nothing (or a minimal empty state — choose nothing, return `null`) when `describeWidgetFilters` is empty. Otherwise a `flex flex-wrap gap-1` row of pill `<button>`s reusing the `OverridePill` visual register (rounded-full, `bg-accent/15`/`text-accent` for overridden date; `badgeNeutral` from `lib/styles.ts` for the rest). Each button:
+Renders nothing (return `null`) when `describeWidgetFilters` is empty. Otherwise a `flex flex-wrap gap-1` row of pill `<button>`s reusing the `OverridePill` visual register (rounded-full, `bg-accent/15`/`text-accent` for overridden date; `badgeNeutral` from `lib/styles.ts` for the rest). Each button:
 - `type="button"`, `data-testid={`widget-filter-chip-${chip.key}`}`,
 - `aria-label={`Edit ${chip.key} filter`}`,
 - `onClick={(e) => { e.stopPropagation(); onSelectFilters(); }}` (stop propagation so it doesn't double-fire `WidgetShell`'s `onSelect`),
@@ -302,31 +325,59 @@ it("renders filter chips in both view and edit mode and wires onSelectFilters", 
 
 ---
 
-### Task 8 — `requestedTab` deep-link on the popover
+### Task 8 — `requestedTab` deep-link on the popover (consume-and-clear handshake)
 
 **Files:** `frontend/components/reports/WidgetEditorPopover.tsx`
 
-**Failing test:** `frontend/tests/components/reports/widget-editor-popover-requested-tab.test.tsx` (new) — render with `requestedTab="filters"` and assert the Filters tab is selected (`aria-selected="true"` on the Filters tab / the `FilterEditor` is visible). Also assert that WITHOUT `requestedTab`, the Data tab is selected (preserve #447 default). And that changing `widget.id` with a fresh `requestedTab="filters"` lands on Filters.
+**Why the old single-effect approach is broken (do not restore it):**
+The previous design ("clear `requestedTab` on close", reset effect keyed on `[widget.id, requestedTab]`) has two race conditions:
+- **(a) Dead second click.** Clicking a chip on the ALREADY-selected widget produces no state transition the second time — `requestedTab` is still `"filters"`, so the effect's deps don't change and the chip goes dead.
+- **(b) Clobber-to-Data.** Keying the reset effect on `[widget.id, requestedTab]` means when `requestedTab` later clears (`"filters" → null`), the effect re-fires and resets the tab back to `"data"`, yanking the user off Filters.
 
+The fix is a **consume-and-clear handshake with TWO separate effects**, plus a page that clears `requestedTab` the instant the popover consumes it (so every chip click is a genuine `null → "filters"` transition).
+
+**Failing test:** `frontend/tests/components/reports/widget-editor-popover-requested-tab.test.tsx` (new):
 ```ts
 it("opens on the Filters tab when requestedTab='filters'", () => {
   renderWithSWR(<WidgetEditorPopover widget={bar} canvasFilters={{}}
-    anchorEl={document.body} requestedTab="filters"
+    anchorEl={document.body} requestedTab="filters" onTabConsumed={() => {}}
     onUpdate={() => {}} onClose={() => {}} />);
   expect(screen.getByRole("tab", { name: "Filters" })).toHaveAttribute("aria-selected", "true");
 });
 ```
+Plus the four behavioral cases:
+1. **default:** WITHOUT `requestedTab`, the Data tab is selected (preserve #447 default).
+2. **fresh widget + requested tab:** changing `widget.id` while passing `requestedTab="filters"` lands on Filters.
+3. **(NEW) same-widget second click re-opens Filters:** render with `requestedTab="filters"` (Filters selected) + an `onTabConsumed` that clears the prop; user manually clicks the Data tab (now on Data); re-set `requestedTab="filters"` (simulating a second chip click on the same widget) → tab returns to Filters. This proves the dead-second-click race (a) is fixed.
+4. **(NEW) clobber guard:** with a stable `widget.id`, transition `requestedTab` `"filters" → null` (the consume) and assert the tab does NOT reset to Data — it stays on whatever it is. This proves race (b) is fixed (the reset effect is NOT keyed on `requestedTab`).
 
 **Run-to-fail:** RED.
 
 **Implement:**
-- Add `requestedTab?: TabKey` to `Props`.
-- Initialize `tab` from `requestedTab ?? "data"` (lazy `useState(() => requestedTab ?? "data")`).
-- Rework the reset effect (currently `useEffect(() => setTab("data"), [widget.id])`): on `widget.id` change, set `setTab(requestedTab ?? "data")` so a new selection carrying a requested tab honors it. Key the effect on `[widget.id, requestedTab]`. Guard against fighting user clicks: only re-apply when `widget.id` OR `requestedTab` actually changes (the effect dep array handles this; the page clears `requestedTab` after first open — see Task 9 — so a later manual tab click isn't clobbered).
+- Add `requestedTab?: TabKey` AND `onTabConsumed?: () => void` to `Props`. **Export `TabKey`** so the pages can type their `requestedTab` state.
+- Keep the lazy init for the fresh-mount case: `const [tab, setTab] = useState<TabKey>(() => requestedTab ?? "data");`
+- **Reset effect (widget-identity only):**
+  ```ts
+  useEffect(() => { setTab(requestedTab ?? "data"); }, [widget.id]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: reset
+  // only on widget-identity change; requestedTab is read at switch time, not a dep.
+  ```
+  Do NOT add `requestedTab` to this effect's dep array (that is exactly what causes the clobber-to-Data race).
+- **Honor-request effect (requestedTab only):**
+  ```ts
+  useEffect(() => {
+    if (requestedTab) {
+      setTab(requestedTab);
+      onTabConsumed?.();
+    }
+  }, [requestedTab]); // onTabConsumed read in body, not a dep
+  ```
+  Acts ONLY when `requestedTab` is truthy, and calls `onTabConsumed` in the same body so the page clears it immediately → the next chip click is again a `null → "filters"` transition.
+- Remove the old single `useEffect(() => setTab("data"), [widget.id])` and any "clear on close / clear on next tick" deliberation. The page's `closePopover` clearing `requestedTab` is kept only as a harmless belt-and-suspenders.
 
-**Run-to-pass:** GREEN; `tsc --noEmit` GREEN.
+**Run-to-pass:** GREEN (all 6 cases); `tsc --noEmit` GREEN.
 
-**Commit:** `feat(reports): popover honors a requested tab for chip deep-link`
+**Commit:** `feat(reports): popover honors a requested tab via consume-and-clear`
 
 ---
 
@@ -340,11 +391,16 @@ it("opens on the Filters tab when requestedTab='filters'", () => {
 
 **Implement:**
 - Fetch accounts + categories once with SWR using the SAME keys the filters use (`/api/v1/accounts?for=reports-filter`, `/api/v1/categories?for=reports-filter`) so the cache is shared with `AccountFilter`/`CategoryPicker`. Default to `[]`.
-- Add `const [requestedTab, setRequestedTab] = useState<TabKey | null>(null);` (import `TabKey` or redefine the union locally; export `TabKey` from the popover for reuse).
+- Add `const [requestedTab, setRequestedTab] = useState<TabKey | null>(null);` (import `TabKey` from the popover — Task 8 exports it).
 - Add a handler `selectWidgetFilters(id)`: `setSelectedWidgetId(id); setRequestedTab("filters");`.
-- In the `WidgetShell` render callback, pass `widget={w}`, `canvasFilters`, `accounts`, `categories`, and `onSelectFilters={() => selectWidgetFilters(w.id)}`. Also pass the same to the mobile-stack branch (chips should show there too, but mobile is read-only — `onSelectFilters` can be a no-op or still open nothing; keep chips visible, click does nothing on mobile since there's no popover. Pass `onSelectFilters={() => {}}` in the stack).
-- Pass `requestedTab={requestedTab ?? undefined}` to `WidgetEditorPopover`, and clear it after open: when the popover mounts/opens, call `setRequestedTab(null)` (e.g. clear in `closePopover` AND once the popover has consumed it — simplest: clear on the next tick after select, or clear inside `selectWidgetFilters` is wrong because the popover reads it on mount; instead clear when `closePopover` runs and also reset when `selectedWidgetId` changes via plain click). **Mechanism:** keep `requestedTab` set until the popover closes; the popover's lazy init + `[widget.id, requestedTab]` effect consume it on open. On `closePopover`, `setRequestedTab(null)`. A plain `onSelect` (non-chip click) sets `selectedWidgetId` but NOT `requestedTab`, and because `requestedTab` was cleared on previous close, the popover defaults to Data.
-- Update the empty-state helper copy that says "Canvas filters (date, accounts, categories)" → "Canvas date applies to every widget; accounts and categories are per-widget."
+- In the **desktop `Canvas` `renderWidget` closure / `WidgetShell` render**, pass `widget={w}`, `canvasFilters`, `accounts`, `categories`, and **`onSelectFilters`** as follows (R5 — view-mode orphan-selection guard): pass the real handler `() => selectWidgetFilters(w.id)` ONLY when in edit mode, and a **no-op `() => {}` when NOT in edit mode**. Because the popover is gated on `editModeActive`, a chip click in view mode would otherwise draw a selection ring with no editor behind it. Concretely:
+  ```tsx
+  onSelectFilters={editModeActive ? () => selectWidgetFilters(w.id) : () => {}}
+  ```
+  Chips still RENDER in view mode (locked decision — they are status-is-data informational); they are just inert there.
+- **Mobile stack — NO chips, NO change (architect decision).** The mobile read-only stack (~lines 813–817) renders `renderWidgetByType(w, canvasFilters, false)` directly, NOT wrapped in `WidgetShell`. Do **NOT** wrap it in `WidgetShell` and do **NOT** thread chip props into the stack. Mobile is read-only and shows no chips. (This removes the prior draft's contradictory "also pass the same to the mobile-stack branch / pass a no-op onSelectFilters in the stack" instruction.)
+- Pass `requestedTab={requestedTab ?? undefined}` and `onTabConsumed={() => setRequestedTab(null)}` to `WidgetEditorPopover`. The popover's honor-request effect calls `onTabConsumed` the instant it consumes the request, so `requestedTab` returns to `null` immediately — making every chip click a fresh `null → "filters"` transition (fixes same-widget second click). ALSO clear `requestedTab` inside `closePopover` (`setRequestedTab(null)`) as harmless belt-and-suspenders.
+- Update the empty-state copy that says `"Canvas filters (date, accounts, categories) apply to every widget..."` (~lines 778–781) → `"Canvas date applies to every widget; accounts and categories are per-widget."`
 
 **Run-to-pass:** GREEN; `tsc --noEmit` GREEN.
 
@@ -360,7 +416,13 @@ it("opens on the Filters tab when requestedTab='filters'", () => {
 
 **Run-to-fail:** RED.
 
-**Implement:** same as Task 9 — fetch accounts/categories (shared SWR keys), add `requestedTab` state + `selectWidgetFilters`, thread `widget`/`canvasFilters`/`accounts`/`categories`/`onSelectFilters` into `WidgetShell`, pass `requestedTab` to the popover, clear on close, fix the empty-state copy. The draft page uses `widgetKit.renderWidgetByType`; the chip header is in `WidgetShell` (rendered inline on this page), so no `widgetKit` change needed — just the `WidgetShell` props.
+**Implement:** same as Task 9 —
+- fetch accounts/categories (shared SWR keys, default `[]`);
+- add `requestedTab` state + `selectWidgetFilters`;
+- thread `widget`/`canvasFilters`/`accounts`/`categories` into `WidgetShell`. The draft page is **always edit mode**, so `onSelectFilters` is the **real** handler `() => selectWidgetFilters(w.id)` (no view-mode no-op branch — there is no view mode here).
+- pass `requestedTab` + `onTabConsumed={() => setRequestedTab(null)}` to the popover; clear on `closePopover` as belt-and-suspenders.
+- **Fix the draft-page empty-state copy too (R4).** It is a SEPARATE string from the `[id]` page: `"Canvas filters (date, accounts, categories) apply to every widget."` at ~lines 289–292 of `new/page.tsx`. Change it to `"Canvas date applies to every widget; accounts and categories are per-widget."` (same wording as Task 9). Do not assume Task 9's edit covers this — the two copies are independent strings.
+- The draft page uses `renderWidgetByType`; the chip header is in `WidgetShell` (rendered inline on this page in the `Canvas` closure), so no widget-kit change needed — just the `WidgetShell` props. The draft page has no mobile read-only stack, so no mobile decision applies here.
 
 **Run-to-pass:** GREEN; `tsc --noEmit` GREEN.
 
@@ -393,12 +455,13 @@ Also drop the canvas `account_ids`/`category_ids` props from these fixtures (tho
 **Files:** any remaining references.
 
 1. **Grep sweep:** `docker compose exec -T frontend grep -rn "account_ids\|category_ids" app components lib tests` — confirm every `canvas`-side reference is gone (widget-side `WidgetFilters.account_ids`/`category_ids` stays). Check templates/draft seed (`lib/reports/draft.ts`, `lib/reports/api.ts`, any template fixtures, `ReportTemplate.canvas_filters_json` shapes) for canvas `account_ids`/`category_ids` literals and remove them. Check `series.ts`, `csv.ts`, `use-widget-anchor.ts` for any canvas-filter coupling (unlikely).
-2. **Full vitest suite** (NOT just touched files — per the full-suite verification rule; a cross-file rename can regress elsewhere):
+2. **Confirm `pickList` is fully removed** (no stragglers): `docker compose exec -T frontend grep -rn "pickList" app components lib tests` returns nothing.
+3. **Full vitest suite** (NOT just touched files — per the full-suite verification rule; a cross-file rename can regress elsewhere):
    `docker compose exec -T frontend npx vitest run`
-3. **Type-check:** `docker compose exec -T frontend npx tsc --noEmit`
-4. **Lint (CI gate):** `docker compose exec -T frontend npx eslint . --quiet`
+4. **Type-check:** `docker compose exec -T frontend npx tsc --noEmit`
+5. **Lint (CI gate):** `docker compose exec -T frontend npx eslint . --quiet`
 
-All three must be clean before opening the PR.
+All gates must be clean before opening the PR.
 
 **Commit (if sweep changes anything):** `chore(reports): drop residual canvas account/category references`
 
@@ -406,23 +469,26 @@ All three must be clean before opening the PR.
 
 ## Must-flag list (call out in the PR description / review)
 
-1. **No data migration** of saved reports. Old `canvas_filters_json` with `account_ids`/`category_ids` is silently ignored on read (keys no longer in `CanvasFilters`; `resolveFilters` no longer reads them). This is a **behavior change** for any saved report that relied on canvas-level account/category scoping — those filters effectively vanish until the user re-adds them per-widget. Pre-launch, no users, acceptable; flag explicitly.
+1. **No data migration** of saved reports. Old `canvas_filters_json` with `account_ids`/`category_ids` is silently ignored on read (keys no longer in `CanvasFilters`; the `as CanvasFilters` hydrate cast tolerates the extra keys; `resolveFilters` no longer reads them). This is a **behavior change** for any saved report that relied on canvas-level account/category scoping — those filters effectively vanish until the user re-adds them per-widget. Pre-launch, no users, acceptable; flag explicitly.
 2. **Backend sends nothing new** — confirm the query endpoint still accepts a `canvas_filters_json` lacking those keys (it does; note it). `saveLayout`/`createReport` now persist a date-only canvas blob.
 3. **Chip name resolution depends on shared SWR cache.** If a widget references a deleted/inactive account or category id, that id is dropped from the label (count fallback). Inactive accounts are already filtered out of `AccountFilter`'s selectable list, so a previously-selected-then-deactivated account could become a count-only chip — acceptable, note it.
 4. **`stopPropagation` on chip click** is required so the chip's `onSelectFilters` doesn't also trigger `WidgetShell`'s `onSelect` (which would set `selectedWidgetId` without the Filters tab). Verify the chip wins.
-5. **`requestedTab` lifecycle:** set on chip click, consumed by the popover on open, cleared on close. A subsequent plain widget click must default to the Data tab (regression risk against the #447 reset). Covered by Task 8 + Task 9 tests.
-6. **Mobile stack** shows chips but they're inert (read-only, no popover). Confirm no console error / no broken click.
-7. **Currency symbol on the amount chip** is a bare `$` prefix (not per-account currency) — consistent with the deferred chart currency-symbol work (roadmap §1b). Note the simplification.
-8. **Amount/date label formatting** has no shared formatter today (`grep` confirmed none in `lib/reports`); the new formatters live in `describe-filters.ts`. Don't duplicate `buildPresetRanges` — import it from `DatePresetChips`.
+5. **`requestedTab` consume-and-clear handshake.** Set on chip click (`null → "filters"`), consumed by the popover's honor-request effect which calls `onTabConsumed()` to clear it back to `null` in the same cycle. TWO separate effects in the popover: a reset effect keyed on `[widget.id]` ONLY (not `requestedTab`) and a honor-request effect keyed on `[requestedTab]`. This fixes both the dead-second-click race (every click is a genuine transition) and the clobber-to-Data race (the reset effect never re-fires when `requestedTab` clears). A subsequent plain widget click (no `requestedTab`) defaults to Data (#447 reset preserved). Covered by Task 8's two new cases + Task 9/10 tests.
+6. **Mobile stack shows NO chips.** The mobile read-only branch renders `renderWidgetByType` directly, NOT through `WidgetShell`, so chips never appear there — intended (read-only, no popover). We do not add `WidgetShell` to the stack. No inert-chip / mobile-click concern exists.
+7. **View-mode orphan-selection guard (`[id]` page).** In view mode the popover is gated on `editModeActive`, so `onSelectFilters` is passed as a no-op `() => {}` — a chip click in view mode draws no orphan selection ring with no editor behind it. Chips still render (informational). The draft page is always edit mode and passes the real handler.
+8. **Currency symbol on the amount chip** is a bare `$` prefix (not per-account currency) — consistent with the deferred chart currency-symbol work (roadmap §1b). Note the simplification.
+9. **Amount/date label formatting** has no shared formatter today (`grep` confirmed none in `lib/reports`); the new formatters live in `describe-filters.ts`. Don't duplicate `buildPresetRanges` — import it from `DatePresetChips`; don't duplicate the date inherit/override logic — import `pickDateRange` + `isFieldOverridden` from `resolve.ts`.
+10. **`Canvas.tsx` is NOT touched** — the page `renderWidget` closure supplies the new `WidgetShell` props. **`pickList` is deleted** (only used by the two removed cascade branches). **`pickDateRange` is now exported** from `resolve.ts` (single source of truth for date inherit/override, reused by the describe helper).
 
 ---
 
 ## Self-Review
 
-- **Does `describeWidgetFilters` mirror `resolveFilters`?** Both read `widget.config.filters`, both use `pickDateRange` for the effective date, both gate accounts/categories on widget-only presence, both treat empty arrays as unset. The describe helper must NOT show a chip for a filter `resolveFilters` wouldn't emit (e.g. empty `tag_names`). Tested in Task 5.
-- **Is the canvas→widget model shift total?** `CanvasFilters` shrinks (Task 1), `resolveFilters` drops the fallback (Task 3), `CanvasFiltersBar` drops the pickers (Task 4), and the repo sweep (Task 12) catches stragglers in templates/draft/api. `FilterEditor` still renders the account/category PICKERS (widget-only editing) — that's correct and unchanged; only its override PILLS for those fields go dark.
-- **Deep-link correctness:** chip → `onSelectFilters` → `selectedWidgetId` + `requestedTab="filters"` → popover opens on Filters. Plain widget click → `onSelect` → Data tab. The #447 reset-on-widget-change is preserved by initializing/resetting `tab` from `requestedTab ?? "data"`.
-- **Both pages:** Tasks 9 + 10 apply identical wiring. The draft page is always-edit; the `[id]` page gates the popover on `editModeActive` — chips still render on `[id]` in VIEW mode (locked decision), but clicking a chip in view mode can't open the popover (no `editModeActive`). **Decision:** in view mode, `onSelectFilters` still sets `selectedWidgetId`, but the popover is gated on `editModeActive`, so nothing opens. Either (a) leave it inert in view mode (chips are informational there), or (b) have the chip click flip into edit mode first. **Choose (a)** — keep view mode read-only; chips are status-is-data informational. Note this in the PR.
+- **Does `describeWidgetFilters` mirror `resolveFilters`?** Both read `widget.config.filters`, both use the SAME `pickDateRange` for the effective date (now imported, not reimplemented), both gate accounts/categories on widget-only presence, both treat empty arrays as unset. The describe helper must NOT show a chip for a filter `resolveFilters` wouldn't emit (e.g. empty `tag_names`). Tested in Task 5.
+- **Is the canvas→widget model shift total?** `CanvasFilters` shrinks (Task 1), `resolveFilters` drops the fallback + deletes `pickList` (Task 3), `CanvasFiltersBar` drops the pickers (Task 4), and the repo sweep (Task 12) catches stragglers in templates/draft/api. `FilterEditor` still renders the account/category PICKERS (widget-only editing) — that's correct and unchanged; only its override PILLS for those fields go dark.
+- **Deep-link correctness (race-free):** chip → `onSelectFilters` → `selectedWidgetId` + `requestedTab="filters"` → popover honor-request effect sets Filters AND calls `onTabConsumed()` → page clears `requestedTab` to `null` immediately. Same-widget second click is again `null → "filters"` (no dead click). The reset effect is keyed on `[widget.id]` ONLY, so the `"filters" → null` consume never clobbers the tab back to Data. Plain widget click (no chip) → `onSelect` only → Data default (#447 preserved).
+- **Both pages:** Tasks 9 + 10 apply equivalent wiring. The draft page is always-edit (real `onSelectFilters`); the `[id]` page gates the popover on `editModeActive` and passes a **no-op `onSelectFilters` in view mode** (R5) so chips stay informational without drawing an orphan selection ring. The mobile read-only stack on `[id]` shows **no chips** and is untouched.
+- **Empty-state copy fixed in BOTH places (R4):** the string is duplicated independently in `[id]/page.tsx` (~778–781) and `new/page.tsx` (~289–292); Tasks 9 and 10 each fix their own copy.
 - **No new dependency, one cohesive PR** — justified above.
 - **CI gates are pre-PR:** full `vitest run`, `tsc --noEmit`, `eslint . --quiet` (Task 12).
-- **Pre-launch hygiene:** no compat shims, no migration script (per locked feedback rules).
+- **Pre-launch hygiene:** no compat shims, no migration script (per locked feedback rules); `as CanvasFilters` hydrate cast tolerates legacy keys with no migration.


### PR DESCRIPTION
Reports v3 phase 4b: the canvas filter bar is reduced to a shared **date** control, accounts and categories become **fully per-widget**, and every widget shows a slim **filter-chip header** that deep-links to the widget popover's Filters tab.

## What changed
- **Filter model** (`lib/reports/types.ts`): `CanvasFilters` drops `account_ids`/`category_ids` (keeps `date_range`). `WidgetFilters` is unchanged.
- **Resolution** (`lib/reports/resolve.ts`): accounts/categories are widget-only (no canvas fallback); `pickList` deleted; `pickDateRange` is now exported as the single source of truth for the date inherit/override decision; `isFieldOverridden` short-circuits every non-date field to false.
- **Canvas bar** (`CanvasFiltersBar.tsx`): date-only (AccountFilter + CategoryPicker removed).
- **New** `describeWidgetFilters` (`lib/reports/describe-filters.ts`): pure helper producing ordered chip descriptors consistent with `resolveFilters` (imports `pickDateRange` + `isFieldOverridden`). Resolves ids → names via the warm `?for=reports-filter` SWR caches, count-fallback when unresolved.
- **New** `WidgetFilterChips.tsx`: presentational pill-button row; `stopPropagation` so a chip click selects-with-Filters instead of plain select.
- **WidgetShell**: mounts the chip header above the body in both view and edit mode.
- **WidgetEditorPopover**: new `requestedTab` + `onTabConsumed` props with a consume-and-clear handshake (two separate effects).
- **Both editor pages** ([id] + new): fetch accounts/categories once (shared SWR keys, threaded down), `requestedTab` state, chip→Filters wiring. The [id] page passes a no-op `onSelectFilters` in view mode to avoid an orphan selection ring; the always-edit draft page passes the real handler. Empty-state copy updated in both.

## Must-flag
- **No data migration** (pre-launch): saved `canvas_filters_json` carrying old `account_ids`/`category_ids` is silently ignored on read (tolerated by the `as CanvasFilters` hydrate cast). Canvas-level account/category scoping on any existing report effectively vanishes until re-added per-widget.
- **Backend: no change / no migration.** The query endpoint already ignores canvas account/category; the frontend simply stops sending them.
- **Mobile read-only stack shows no chips** (renders widgets without `WidgetShell`) — intended.
- **Amount chip** uses a bare `$` prefix (not per-account currency), consistent with the deferred chart currency-symbol work.

## Deep-link handshake (highest-risk part)
Reset effect keyed on `[widget.id]` only (resets to Data on identity change, never on `requestedTab` clear → no clobber-to-Data). Honor-request effect keyed on `[requestedTab]` only (sets the tab + calls `onTabConsumed()` so the page clears it back to null → every chip click is a genuine `null→"filters"` transition, so a second click on the already-selected widget re-opens Filters). Covered by dedicated tests for both races.