### PR TITLE
fix(accounts): keep balance reconcilable with opening_balance

### DIFF
--- a/backend/app/routers/accounts.py
+++ b/backend/app/routers/accounts.py
@@ -333,6 +333,11 @@ async def _apply_non_type_fields(
         account.is_default = False
 
     if body.opening_balance is not None and body.opening_balance != account.opening_balance:
+        # Opening balance is the foundation of the live balance
+        # (balance == opening_balance + Σ settled txns). Correcting it must
+        # shift the live balance by the same delta, otherwise the cached
+        # balance silently drifts from reality (2026-06-14 incident).
+        account.balance += body.opening_balance - account.opening_balance
         account.opening_balance = body.opening_balance
         opening_changed = True
     if (

--- a/backend/app/routers/accounts.py
+++ b/backend/app/routers/accounts.py
@@ -305,6 +305,26 @@ async def _apply_non_type_fields(
     if body.name is not None:
         account.name = body.name
 
+    # Apply the opening_balance shift BEFORE the is_active deactivate guard so
+    # the guard evaluates the FINAL (post-shift) balance. A single PUT that
+    # both edits opening_balance and deactivates must be judged on the balance
+    # the account will actually hold (finding 15): shifting up to a nonzero
+    # balance must block deactivation, and shifting down to zero must allow it.
+    if body.opening_balance is not None and body.opening_balance != account.opening_balance:
+        # Opening balance is the foundation of the live balance
+        # (balance == opening_balance + Σ settled txns). Correcting it must
+        # shift the live balance by the same delta, otherwise the cached
+        # balance silently drifts from reality (2026-06-14 incident).
+        account.balance += body.opening_balance - account.opening_balance
+        account.opening_balance = body.opening_balance
+        opening_changed = True
+    if (
+        body.opening_balance_date is not None
+        and body.opening_balance_date != account.opening_balance_date
+    ):
+        account.opening_balance_date = body.opening_balance_date
+        opening_changed = True
+
     if body.is_active is not None:
         if body.is_active is False and account.balance != 0:
             raise HTTPException(
@@ -331,21 +351,6 @@ async def _apply_non_type_fields(
             account.is_default = True
     elif body.is_default is False:
         account.is_default = False
-
-    if body.opening_balance is not None and body.opening_balance != account.opening_balance:
-        # Opening balance is the foundation of the live balance
-        # (balance == opening_balance + Σ settled txns). Correcting it must
-        # shift the live balance by the same delta, otherwise the cached
-        # balance silently drifts from reality (2026-06-14 incident).
-        account.balance += body.opening_balance - account.opening_balance
-        account.opening_balance = body.opening_balance
-        opening_changed = True
-    if (
-        body.opening_balance_date is not None
-        and body.opening_balance_date != account.opening_balance_date
-    ):
-        account.opening_balance_date = body.opening_balance_date
-        opening_changed = True
 
     return opening_changed
 

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -2149,5 +2149,10 @@ async def reconcile_account(
             Transaction.status == TransactionStatus.SETTLED,
         )
     )
-    computed = income - expense
+    # The live balance is seeded from opening_balance at creation and then
+    # moved by each settled row, so the invariant is
+    #   balance == opening_balance + Σ settled(income − expense).
+    # computed must include opening_balance or every account with a non-zero
+    # opening is falsely flagged inconsistent (2026-06-14 incident).
+    computed = account.opening_balance + income - expense
     return account.balance, computed, account.balance == computed

--- a/backend/tests/services/test_reconcile_opening_balance.py
+++ b/backend/tests/services/test_reconcile_opening_balance.py
@@ -1,0 +1,85 @@
+"""reconcile_account must reconcile against the SAME invariant the live
+balance is built on: ``balance == opening_balance + Σ settled(income − expense)``.
+
+Before the fix, ``computed`` omitted ``opening_balance``, so every account
+with a non-zero opening balance was falsely reported inconsistent (by exactly
+the opening balance). Regression guard for the 2026-06-14 investigation.
+"""
+import pytest
+import pytest_asyncio
+from datetime import date
+from decimal import Decimal
+
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models.base import Base
+from app.models import Account, AccountType, Category, Organization
+from app.models.category import CategoryType
+from app.schemas.transaction import TransactionCreate
+from app.services import transaction_service as ts
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False}, poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor(); cur.execute("PRAGMA foreign_keys=ON"); cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db, *, opening: str):
+    org = Organization(name="T", billing_cycle_day=1)
+    db.add(org); await db.flush()
+    at = AccountType(org_id=org.id, name="Bank", slug="bank", is_system=True)
+    db.add(at); await db.flush()
+    acct = Account(org_id=org.id, name="A", account_type_id=at.id,
+                   balance=Decimal(opening), currency="EUR",
+                   opening_balance=Decimal(opening), opening_balance_date=date(2026, 1, 1))
+    db.add(acct)
+    db.add(Category(org_id=org.id, name="G", slug="g", type=CategoryType.BOTH, is_system=True))
+    await db.flush(); await db.commit()
+    return org, acct
+
+
+@pytest.mark.asyncio
+async def test_reconcile_consistent_with_nonzero_opening_and_no_txns(db_session):
+    db = db_session
+    org, acct = await _seed(db, opening="1000.00")
+    stored, computed, consistent = await ts.reconcile_account(db, org.id, acct)
+    assert stored == Decimal("1000.00")
+    assert computed == Decimal("1000.00")   # opening included
+    assert consistent is True
+
+
+@pytest.mark.asyncio
+async def test_reconcile_consistent_opening_plus_settled_txns(db_session):
+    db = db_session
+    org, acct = await _seed(db, opening="1000.00")
+    from sqlalchemy import select
+    gid = await db.scalar(select(Category.id).where(Category.org_id == org.id))
+    await ts.create_transaction(db, org.id, TransactionCreate(
+        account_id=acct.id, category_id=gid, description="pay",
+        amount=Decimal("200.00"), type="income", status="settled", date=date(2026, 6, 1)))
+    await ts.create_transaction(db, org.id, TransactionCreate(
+        account_id=acct.id, category_id=gid, description="buy",
+        amount=Decimal("50.00"), type="expense", status="settled", date=date(2026, 6, 2)))
+    await db.refresh(acct)
+    stored, computed, consistent = await ts.reconcile_account(db, org.id, acct)
+    # balance = 1000 + 200 - 50 = 1150; computed must equal it.
+    assert stored == Decimal("1150.00")
+    assert computed == Decimal("1150.00")
+    assert consistent is True

--- a/backend/tests/services/test_reconcile_opening_balance.py
+++ b/backend/tests/services/test_reconcile_opening_balance.py
@@ -83,3 +83,74 @@ async def test_reconcile_consistent_opening_plus_settled_txns(db_session):
     assert stored == Decimal("1150.00")
     assert computed == Decimal("1150.00")
     assert consistent is True
+
+
+async def _seed_two(db, *, opening_a: str, opening_b: str):
+    """Seed an org with two accounts (nonzero openings) + a Transfer category."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db.add(org); await db.flush()
+    at = AccountType(org_id=org.id, name="Bank", slug="bank", is_system=True)
+    db.add(at); await db.flush()
+    acct_a = Account(org_id=org.id, name="A", account_type_id=at.id,
+                     balance=Decimal(opening_a), currency="EUR",
+                     opening_balance=Decimal(opening_a),
+                     opening_balance_date=date(2026, 1, 1))
+    acct_b = Account(org_id=org.id, name="B", account_type_id=at.id,
+                     balance=Decimal(opening_b), currency="EUR",
+                     opening_balance=Decimal(opening_b),
+                     opening_balance_date=date(2026, 1, 1))
+    db.add(acct_a); db.add(acct_b)
+    db.add(Category(org_id=org.id, name="Transfer", slug="transfer",
+                    type=CategoryType.BOTH, is_system=True))
+    await db.flush(); await db.commit()
+    return org, acct_a, acct_b
+
+
+@pytest.mark.asyncio
+async def test_reconcile_consistent_with_transfer_legs(db_session):
+    """A transfer creates settled EXPENSE+INCOME legs counted by reconcile.
+    Both source and destination accounts must stay consistent: each balance
+    moved by the transfer amount, and computed includes the matching leg."""
+    db = db_session
+    org, acct_a, acct_b = await _seed_two(db, opening_a="1000.00", opening_b="400.00")
+
+    from app.schemas.transaction import TransferCreate
+    await ts.create_transfer(db, org.id, TransferCreate(
+        from_account_id=acct_a.id, to_account_id=acct_b.id,
+        amount=Decimal("250.00"), status="settled", date=date(2026, 6, 1)))
+    await db.refresh(acct_a)
+    await db.refresh(acct_b)
+
+    # Source: 1000 - 250 = 750 (expense leg). Dest: 400 + 250 = 650 (income leg).
+    s_a, c_a, ok_a = await ts.reconcile_account(db, org.id, acct_a)
+    assert s_a == Decimal("750.00")
+    assert c_a == Decimal("750.00")
+    assert ok_a is True
+
+    s_b, c_b, ok_b = await ts.reconcile_account(db, org.id, acct_b)
+    assert s_b == Decimal("650.00")
+    assert c_b == Decimal("650.00")
+    assert ok_b is True
+
+
+@pytest.mark.asyncio
+async def test_reconcile_consistent_after_negative_opening_delta(db_session):
+    """Lowering opening_balance (1000 -> 300) must shift balance down by 700 and
+    keep reconcile consistent. Mirrors the router's opening-shift path applied
+    to a freshly-seeded account (no txns: balance tracks opening directly)."""
+    db = db_session
+    org, acct = await _seed(db, opening="1000.00")
+    assert acct.balance == Decimal("1000.00")
+
+    # Apply the same shift the router's _apply_non_type_fields performs.
+    new_opening = Decimal("300.00")
+    acct.balance += new_opening - acct.opening_balance
+    acct.opening_balance = new_opening
+    await db.commit()
+    await db.refresh(acct)
+
+    assert acct.balance == Decimal("300.00")  # shifted down by 700
+    stored, computed, consistent = await ts.reconcile_account(db, org.id, acct)
+    assert stored == Decimal("300.00")
+    assert computed == Decimal("300.00")
+    assert consistent is True

--- a/backend/tests/test_account_opening_balance.py
+++ b/backend/tests/test_account_opening_balance.py
@@ -350,3 +350,158 @@ def test_update_account_rejects_oversized_opening_balance(session_factory, seede
             json={"opening_balance": "999999999999.99"},
         )
     assert res.status_code == 422
+
+
+# ── Deactivate guard vs. opening-balance shift (finding 15) ─────────────────
+
+
+def test_deactivate_blocked_when_opening_shift_makes_balance_nonzero(
+    session_factory, seeded
+):
+    """A single PUT that sets opening_balance > 0 AND is_active=false must be
+    REJECTED: the post-shift balance is nonzero, so the account is not empty.
+    Under the old field order the guard ran before the shift, saw the
+    pre-shift balance (0), and wrongly let the deactivation through."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['account_id']}",
+            json={"opening_balance": "500.00", "is_active": False},
+        )
+    assert res.status_code == 409, res.text
+
+    # The whole PUT must roll back atomically: opening_balance and is_active
+    # both unchanged, balance still 0.
+    import asyncio
+
+    async def _reload():
+        async with session_factory() as db:
+            return await db.get(Account, seeded["account_id"])
+
+    acct = asyncio.get_event_loop().run_until_complete(_reload())
+    assert acct.is_active is True
+    assert acct.balance == Decimal("0.00")
+    assert acct.opening_balance == Decimal("0.00")
+
+
+def test_deactivate_allowed_when_opening_shift_zeroes_balance(
+    session_factory, seeded
+):
+    """A single PUT that lowers opening_balance to 0 (zeroing the live balance)
+    AND sets is_active=false must be ALLOWED: the post-shift balance is 0.
+    Under the old order the guard saw the pre-shift balance (500) and wrongly
+    raised 409."""
+    import asyncio
+
+    # Prime: balance(500) == opening(500) + 0 settled activity.
+    async def _prime():
+        async with session_factory() as db:
+            acct = await db.get(Account, seeded["account_id"])
+            acct.opening_balance = Decimal("500.00")
+            acct.balance = Decimal("500.00")
+            await db.commit()
+
+    asyncio.get_event_loop().run_until_complete(_prime())
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['account_id']}",
+            json={"opening_balance": "0.00", "is_active": False},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["is_active"] is False
+    assert Decimal(body["balance"]) == Decimal("0.00")
+    assert Decimal(body["opening_balance"]) == Decimal("0.00")
+
+
+def test_deactivate_only_still_blocks_nonzero_account(session_factory, seeded):
+    """Guard regression: an is_active-only PUT (no opening edit) must still 409
+    when the account holds a nonzero balance — the shift is a no-op so the
+    guard sees the unchanged balance."""
+    import asyncio
+
+    async def _prime():
+        async with session_factory() as db:
+            acct = await db.get(Account, seeded["account_id"])
+            acct.opening_balance = Decimal("100.00")
+            acct.balance = Decimal("300.00")
+            await db.commit()
+
+    asyncio.get_event_loop().run_until_complete(_prime())
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['account_id']}",
+            json={"is_active": False},
+        )
+    assert res.status_code == 409, res.text
+
+
+# ── End-to-end: both fixed paths uphold the invariant (finding 16) ──────────
+
+
+def test_opening_edit_shifts_balance_and_reconcile_stays_consistent(
+    session_factory, seeded
+):
+    """End-to-end coupling of both fixes: with real settled transactions giving
+    ``balance == opening + Σtxns``, editing opening_balance shifts the live
+    balance by the delta AND reconcile_account reports stored == computed."""
+    import asyncio
+
+    from app.schemas.transaction import TransactionCreate
+    from app.services import transaction_service as ts
+    from app.models import Category
+    from app.models.category import CategoryType
+
+    async def _prime():
+        async with session_factory() as db:
+            acct = await db.get(Account, seeded["account_id"])
+            acct.opening_balance = Decimal("1000.00")
+            acct.balance = Decimal("1000.00")
+            cat = Category(
+                org_id=seeded["org_id"], name="Gen", slug="gen",
+                type=CategoryType.BOTH, is_system=True,
+            )
+            db.add(cat)
+            await db.flush()
+            cat_id = cat.id
+            await ts.create_transaction(db, seeded["org_id"], TransactionCreate(
+                account_id=acct.id, category_id=cat_id, description="pay",
+                amount=Decimal("200.00"), type="income", status="settled",
+                date=date(2026, 6, 1)))
+            await ts.create_transaction(db, seeded["org_id"], TransactionCreate(
+                account_id=acct.id, category_id=cat_id, description="buy",
+                amount=Decimal("50.00"), type="expense", status="settled",
+                date=date(2026, 6, 2)))
+            await db.commit()
+
+    asyncio.get_event_loop().run_until_complete(_prime())
+
+    # balance now = 1000 + 200 - 50 = 1150.
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['account_id']}",
+            json={"opening_balance": "1300.00"},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    # delta = 1300 - 1000 = +300 → balance 1150 -> 1450.
+    assert Decimal(body["balance"]) == Decimal("1450.00")
+
+    from app.services import transaction_service as ts2
+
+    async def _reconcile():
+        async with session_factory() as db:
+            acct = await db.get(Account, seeded["account_id"])
+            return await ts2.reconcile_account(db, seeded["org_id"], acct)
+
+    stored, computed, consistent = asyncio.get_event_loop().run_until_complete(
+        _reconcile()
+    )
+    assert stored == Decimal("1450.00")
+    assert computed == Decimal("1450.00")
+    assert consistent is True

--- a/backend/tests/test_account_opening_balance.py
+++ b/backend/tests/test_account_opening_balance.py
@@ -249,6 +249,37 @@ def test_update_account_opening_balance_writes_audit_row(session_factory, seeded
     assert detail["new_opening_balance_date"] == "2025-06-15"
 
 
+def test_update_opening_balance_shifts_live_balance_by_delta(session_factory, seeded):
+    """Editing opening_balance must move the live balance by the same delta so
+    the invariant ``balance == opening_balance + Σ settled txns`` holds.
+    Regression for the 2026-06-14 drift: opening edits left ``balance`` stale,
+    silently de/inflating the account."""
+    import asyncio
+
+    # Simulate an account that already carries transactions:
+    # balance(500) = opening(100) + 400 of net settled activity.
+    async def _prime():
+        async with session_factory() as db:
+            acct = await db.get(Account, seeded["account_id"])
+            acct.opening_balance = Decimal("100.00")
+            acct.balance = Decimal("500.00")
+            await db.commit()
+
+    asyncio.get_event_loop().run_until_complete(_prime())
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['account_id']}",
+            json={"opening_balance": "300.00"},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert Decimal(body["opening_balance"]) == Decimal("300.00")
+    # delta = 300 - 100 = +200 → balance 500 -> 700; the +400 txn component is preserved.
+    assert Decimal(body["balance"]) == Decimal("700.00")
+
+
 def test_update_account_opening_balance_no_change_no_audit(session_factory, seeded):
     """Submitting the same values is a no-op — no audit row."""
     app = _make_app(session_factory)


### PR DESCRIPTION
## Problem

Found during the 2026-06-14 balance-drift investigation. The system maintains the invariant **`balance == opening_balance + Σ settled(income − expense)`**, but two paths violated it:

1. **`reconcile_account` omitted `opening_balance`** (`transaction_service.py`) — `computed` summed only settled income−expense, so the in-app consistency check (`GET /accounts/{id}/reconcile`) falsely reported **every account with a non-zero opening balance** as inconsistent, off by exactly the opening amount.
2. **Editing `opening_balance` left the live `balance` stale** (`accounts.py:_apply_non_type_fields`) — the column changed but the cached balance didn't shift by the delta, silently de/inflating the account on every opening-balance correction.

## Fix

- `reconcile_account`: `computed = opening_balance + income − expense`.
- Opening-balance edit: `balance += (new_opening − old_opening)`, preserving the transaction component.

Both covered by regression tests (`test_reconcile_opening_balance.py`, `test_update_opening_balance_shifts_live_balance_by_delta`). Full balance/account/forecast suite green (468 passed).