### PR TITLE
feat(reports): accounts data source + inline report-title editing

### DIFF
--- a/backend/app/reports/sources/__init__.py
+++ b/backend/app/reports/sources/__init__.py
@@ -26,3 +26,4 @@ def all_sources() -> list[ReportSource]:
 # Import concrete sources so they self-register. Kept at the bottom to
 # avoid a circular import (transactions.py imports from .base + __init__).
 from app.reports.sources import transactions as _transactions  # noqa: E402,F401
+from app.reports.sources import accounts as _accounts  # noqa: E402,F401

--- a/backend/app/reports/sources/accounts.py
+++ b/backend/app/reports/sources/accounts.py
@@ -1,0 +1,202 @@
+"""Accounts source — balance / count over the accounts snapshot.
+
+Accounts is a *snapshot* table: one row per account, with ``balance``
+stored as a column. So this source compiles to a single ``Account JOIN
+AccountType`` SELECT — no transaction reconstruction. ``org_id`` is
+injected here (HARD requirement) and scoped on ``accounts.org_id`` only;
+AccountType is reachable solely through the FK, so it needs no separate
+org filter.
+
+The compiler is structurally incapable of emitting SQL for any field
+outside its own catalog (date / category_id / … are silently ignored),
+which is what makes the shared-canvas date-bar drop a stray date filter
+instead of erroring — the Phase-5 contract.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from sqlalchemy import case, distinct, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account, AccountType
+from app.reports.sources import register
+from app.reports.sources.base import (
+    ReportSource, SourceDimension, SourceFilter, SourceMeasure,
+    validate_against_catalog,
+)
+from app.schemas.reports_query import (
+    MAX_LIMIT,
+    Aggregation,
+    Dimension,
+    FilterField,
+    FilterOp,
+    MeasureField,
+    ReportsQuery,
+)
+
+_DIMENSIONS = [
+    SourceDimension("account", "Account", "account"),
+    SourceDimension("account_type", "Account type", "account_type"),
+    SourceDimension("currency", "Currency", "currency"),
+    SourceDimension("account_active", "Status", "boolean"),
+]
+
+_MEASURES = [
+    SourceMeasure("sum_balance", "Total balance", "sum", "balance", "currency"),
+    SourceMeasure("avg_balance", "Average balance", "avg", "balance", "currency"),
+    SourceMeasure("count_accounts", "Account count", "count", "id", "number"),
+]
+
+_FILTERS = [
+    SourceFilter("account_id", "Account", ("in",), "account"),
+    SourceFilter("account_type", "Account type", ("eq", "in"), "account_type"),
+    SourceFilter("currency", "Currency", ("eq", "in"), "currency"),
+    SourceFilter("account_active", "Status", ("eq",), "boolean"),
+    SourceFilter("balance", "Balance", ("between", "gte", "lte"), "number"),
+]
+
+# Dimension → (response key, SQL expression). account_active normalizes
+# the boolean to stable "Active"/"Inactive" strings in the SELECT via a
+# CASE so we never depend on the driver returning a Python bool.
+_DIM_EXPR = {
+    Dimension.ACCOUNT: ("account", Account.name),
+    Dimension.ACCOUNT_TYPE: ("account_type", AccountType.name),
+    Dimension.CURRENCY: ("currency", Account.currency),
+    Dimension.ACCOUNT_ACTIVE: (
+        "account_active",
+        case((Account.is_active.is_(True), "Active"), else_="Inactive"),
+    ),
+}
+
+# Only the source's OWN filter fields are compiled. Anything else
+# (date, category_id, txn_type, …) is silently ignored.
+_OWN_FILTER_FIELDS = {
+    FilterField.ACCOUNT_ID,
+    FilterField.ACCOUNT_TYPE,
+    FilterField.CURRENCY,
+    FilterField.ACCOUNT_ACTIVE,
+    FilterField.BALANCE,
+}
+
+
+def _measure_expr(measure):
+    col_map = {
+        MeasureField.BALANCE: Account.balance,
+        MeasureField.ID: Account.id,
+    }
+    col = col_map[measure.field]
+    agg = measure.agg
+    if agg is Aggregation.SUM:
+        return func.coalesce(func.sum(col), 0).label("value")
+    if agg is Aggregation.AVG:
+        return func.coalesce(func.avg(col), 0).label("value")
+    if agg is Aggregation.DISTINCT:
+        return func.count(distinct(col)).label("value")
+    if agg is Aggregation.COUNT:
+        return func.count(col).label("value")
+    raise ValueError(f"unsupported aggregation {agg!r}")
+
+
+def _apply_filter(stmt, f):
+    field, op, value = f.field, f.op, f.value
+    if field is FilterField.ACCOUNT_ID:
+        if op is FilterOp.IN:
+            return stmt.where(Account.id.in_(value))
+        return stmt.where(Account.id == value)
+    if field is FilterField.ACCOUNT_TYPE:
+        if op is FilterOp.IN:
+            return stmt.where(Account.account_type_id.in_(value))
+        return stmt.where(Account.account_type_id == value)
+    if field is FilterField.CURRENCY:
+        if op is FilterOp.IN:
+            return stmt.where(Account.currency.in_(value))
+        return stmt.where(Account.currency == value)
+    if field is FilterField.ACCOUNT_ACTIVE:
+        return stmt.where(Account.is_active.is_(bool(value)))
+    if field is FilterField.BALANCE:
+        if op is FilterOp.BETWEEN:
+            lo, hi = value
+            return stmt.where(Account.balance.between(lo, hi))
+        if op is FilterOp.GTE:
+            return stmt.where(Account.balance >= value)
+        if op is FilterOp.LTE:
+            return stmt.where(Account.balance <= value)
+    return stmt  # defensive: unreachable given _OWN_FILTER_FIELDS gate
+
+
+class AccountsSource:
+    key = "accounts"
+    label = "Accounts"
+
+    def dimensions(self) -> list[SourceDimension]:
+        return list(_DIMENSIONS)
+
+    def measures(self) -> list[SourceMeasure]:
+        return list(_MEASURES)
+
+    def filters(self) -> list[SourceFilter]:
+        return list(_FILTERS)
+
+    def validate(self, query: ReportsQuery) -> None:
+        validate_against_catalog(self, query)
+
+    async def build_rows(
+        self, db: AsyncSession, org_id: int, query: ReportsQuery
+    ) -> tuple[list[dict], dict]:
+        dim_exprs: list[tuple[str, Any]] = []
+        for dim in query.dimensions:
+            key, expr = _DIM_EXPR[dim]
+            dim_exprs.append((key, expr.label(key)))
+
+        measure_expr = _measure_expr(query.measure)
+
+        stmt = (
+            select(*[expr for _, expr in dim_exprs], measure_expr)
+            .select_from(Account)
+            .join(AccountType, AccountType.id == Account.account_type_id)
+            .where(Account.org_id == org_id)  # org-scope on accounts ONLY
+        )
+
+        for f in query.filters:
+            if f.field in _OWN_FILTER_FIELDS:
+                stmt = _apply_filter(stmt, f)
+            # else: stray shared-canvas field (date, …) — silently dropped
+
+        if dim_exprs:
+            raw_group_cols = [_DIM_EXPR[dim][1] for dim in query.dimensions]
+            stmt = stmt.group_by(*raw_group_cols)
+
+        stmt = stmt.limit(min(query.limit, MAX_LIMIT))
+
+        started = time.perf_counter()
+        result = await db.execute(stmt)
+        rows = result.mappings().all()
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+
+        out_rows = []
+        for r in rows:
+            d = {}
+            for key, _ in dim_exprs:
+                d[key] = r.get(key)
+            val = r.get("value")
+            if hasattr(val, "as_tuple"):  # Decimal-like
+                try:
+                    d["value"] = float(val)
+                except Exception:  # pragma: no cover - defensive
+                    d["value"] = str(val)
+            else:
+                d["value"] = val
+            out_rows.append(d)
+
+        meta = {
+            "row_count": len(out_rows),
+            "truncated": len(out_rows) >= query.limit,
+            "query_ms": elapsed_ms,
+        }
+        return out_rows, meta
+
+
+_INSTANCE: ReportSource = AccountsSource()
+register(_INSTANCE)

--- a/backend/app/reports/sources/accounts.py
+++ b/backend/app/reports/sources/accounts.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import time
 from typing import Any
 
-from sqlalchemy import case, distinct, func, select
+from sqlalchemy import case, distinct, func, literal_column, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account, AccountType
@@ -100,21 +100,44 @@ def _measure_expr(measure):
 
 
 def _apply_filter(stmt, f):
+    """Compile one of this source's OWN filters into a WHERE clause.
+
+    Each branch is op-explicit and raises on an op the source does not
+    support, so a future caller that skips ``validate()`` gets a loud
+    error rather than a silently-dropped or mis-applied predicate
+    (defense-in-depth; ``validate_against_catalog`` already op-checks).
+
+    A field this source does not own (e.g. a dropped shared-canvas
+    ``date``) still falls through to a bare ``return stmt`` — that is the
+    Phase-5 shared-canvas drop contract, kept distinct from an op
+    mismatch on an OWNED field.
+    """
     field, op, value = f.field, f.op, f.value
     if field is FilterField.ACCOUNT_ID:
         if op is FilterOp.IN:
             return stmt.where(Account.id.in_(value))
-        return stmt.where(Account.id == value)
+        if op is FilterOp.EQ:
+            return stmt.where(Account.id == value)
+        raise ValueError(f"accounts: unsupported op {op.value!r} for account_id")
     if field is FilterField.ACCOUNT_TYPE:
         if op is FilterOp.IN:
             return stmt.where(Account.account_type_id.in_(value))
-        return stmt.where(Account.account_type_id == value)
+        if op is FilterOp.EQ:
+            return stmt.where(Account.account_type_id == value)
+        raise ValueError(f"accounts: unsupported op {op.value!r} for account_type")
     if field is FilterField.CURRENCY:
         if op is FilterOp.IN:
             return stmt.where(Account.currency.in_(value))
-        return stmt.where(Account.currency == value)
+        if op is FilterOp.EQ:
+            return stmt.where(Account.currency == value)
+        raise ValueError(f"accounts: unsupported op {op.value!r} for currency")
     if field is FilterField.ACCOUNT_ACTIVE:
-        return stmt.where(Account.is_active.is_(bool(value)))
+        if op is FilterOp.EQ and isinstance(value, bool):
+            return stmt.where(Account.is_active.is_(value))
+        raise ValueError(
+            f"accounts: account_active requires op 'eq' with a bool; "
+            f"got op {op.value!r} value {value!r}"
+        )
     if field is FilterField.BALANCE:
         if op is FilterOp.BETWEEN:
             lo, hi = value
@@ -123,7 +146,8 @@ def _apply_filter(stmt, f):
             return stmt.where(Account.balance >= value)
         if op is FilterOp.LTE:
             return stmt.where(Account.balance <= value)
-    return stmt  # defensive: unreachable given _OWN_FILTER_FIELDS gate
+        raise ValueError(f"accounts: unsupported op {op.value!r} for balance")
+    return stmt  # field this source doesn't own → drop (shared-canvas contract)
 
 
 class AccountsSource:
@@ -167,6 +191,31 @@ class AccountsSource:
         if dim_exprs:
             raw_group_cols = [_DIM_EXPR[dim][1] for dim in query.dimensions]
             stmt = stmt.group_by(*raw_group_cols)
+
+        # ORDER BY — mirror reports_query_service so grouped + limited
+        # results are deterministic, not arbitrarily ordered/truncated.
+        sort = query.sort
+        if sort is not None:
+            if sort.by.value == "value":
+                order_col = literal_column("value")
+            else:  # by == "dimension"
+                if not dim_exprs:
+                    raise ValueError(
+                        "sort.by='dimension' requires at least one dimension"
+                    )
+                order_col = literal_column(dim_exprs[0][0])
+            order_col = order_col.asc() if sort.dir.value == "asc" else order_col.desc()
+            stmt = stmt.order_by(order_col)
+        elif dim_exprs:
+            # Stable default order by value desc (matches transactions).
+            stmt = stmt.order_by(literal_column("value").desc())
+
+        # Deterministic tiebreaker so truncation on ties is stable across
+        # runs. Only meaningful when grouping (multiple rows): a no-dimension
+        # query is a single aggregate row where Account.id is neither
+        # selected nor grouped, so an ORDER BY on it would be invalid SQL.
+        if dim_exprs:
+            stmt = stmt.order_by(func.min(Account.id).asc())
 
         stmt = stmt.limit(min(query.limit, MAX_LIMIT))
 

--- a/backend/app/reports/sources/base.py
+++ b/backend/app/reports/sources/base.py
@@ -33,6 +33,20 @@ class SourceMeasure:
     format: str    # currency|number|percent
 
 
+# Filter fields the shared canvas date-bar can stamp onto any widget. A
+# source that does not publish one of these (e.g. a date-less accounts
+# source) drops the stray filter at build time rather than 422-ing.
+SHARED_CANVAS_FILTER_FIELDS = frozenset({"date", "account_id", "category_id"})
+
+
+@dataclass(frozen=True)
+class SourceFilter:
+    field: str            # AST FilterField value, e.g. "currency"
+    label: str            # human label for the editor
+    ops: tuple[str, ...]  # allowed FilterOp values, e.g. ("eq", "in")
+    kind: str             # control hint: account|account_type|currency|boolean|...
+
+
 @runtime_checkable
 class ReportSource(Protocol):
     key: str
@@ -42,6 +56,38 @@ class ReportSource(Protocol):
 
     def measures(self) -> list[SourceMeasure]: ...
 
+    def filters(self) -> list[SourceFilter]: ...
+
+    def validate(self, query: ReportsQuery) -> None:
+        """Raise ValueError if the AST references a dimension / measure field /
+        filter field this source does not publish. Shared-canvas fields that
+        don't apply to this source are dropped, not rejected."""
+        ...
+
     async def build_rows(
         self, db: AsyncSession, org_id: int, query: ReportsQuery
     ) -> tuple[list[dict], dict]: ...  # meta dict carries row_count, truncated, query_ms — coerced to QueryMeta at the router
+
+
+def validate_against_catalog(source: "ReportSource", query: ReportsQuery) -> None:
+    dim_keys = {d.key for d in source.dimensions()}
+    for dim in query.dimensions:
+        if dim.value not in dim_keys:
+            raise ValueError(
+                f"source {source.key!r} does not support dimension {dim.value!r}"
+            )
+    measure_fields = {m.field for m in source.measures()}
+    if query.measure.field.value not in measure_fields:
+        raise ValueError(
+            f"source {source.key!r} does not support measure field "
+            f"{query.measure.field.value!r}"
+        )
+    filter_fields = {f.field for f in source.filters()}
+    for f in query.filters:
+        if f.field.value in filter_fields:
+            continue
+        if f.field.value in SHARED_CANVAS_FILTER_FIELDS:
+            continue  # shared-bar artifact → dropped at build time
+        raise ValueError(
+            f"source {source.key!r} does not support filter field {f.field.value!r}"
+        )

--- a/backend/app/reports/sources/base.py
+++ b/backend/app/reports/sources/base.py
@@ -82,9 +82,22 @@ def validate_against_catalog(source: "ReportSource", query: ReportsQuery) -> Non
             f"source {source.key!r} does not support measure field "
             f"{query.measure.field.value!r}"
         )
-    filter_fields = {f.field for f in source.filters()}
+    # Two-tier filter validation:
+    #   1) a field the source publishes → also enforce the OP against that
+    #      SourceFilter's allowed ops, so a published field with an op the
+    #      source can't compile is rejected at 422 rather than silently
+    #      dropped (or worse, mis-applied) in build_rows.
+    #   2) else a shared-canvas field → dropped at build time (no op-check).
+    #   3) else → reject the unknown field.
+    filters_by_field = {sf.field: sf for sf in source.filters()}
     for f in query.filters:
-        if f.field.value in filter_fields:
+        sf = filters_by_field.get(f.field.value)
+        if sf is not None:
+            if f.op.value not in sf.ops:
+                raise ValueError(
+                    f"source {source.key!r} filter {f.field.value!r} does not "
+                    f"support op {f.op.value!r}"
+                )
             continue
         if f.field.value in SHARED_CANVAS_FILTER_FIELDS:
             continue  # shared-bar artifact → dropped at build time

--- a/backend/app/reports/sources/base.py
+++ b/backend/app/reports/sources/base.py
@@ -21,7 +21,7 @@ from app.schemas.reports_query import ReportsQuery
 class SourceDimension:
     key: str       # matches the AST Dimension value, e.g. "category"
     label: str     # human label for the editor, e.g. "Category"
-    kind: str      # control hint: category|account|status|type|tag|time|account_type
+    kind: str      # control hint: category|account|status|type|tag|time|account_type|currency|boolean
 
 
 @dataclass(frozen=True)

--- a/backend/app/reports/sources/transactions.py
+++ b/backend/app/reports/sources/transactions.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.reports.sources import register
-from app.reports.sources.base import ReportSource, SourceDimension, SourceMeasure
+from app.reports.sources.base import (
+    ReportSource, SourceDimension, SourceFilter, SourceMeasure,
+    validate_against_catalog,
+)
 from app.schemas.reports_query import ReportsQuery
 from app.services.reports_query_service import execute_query
 
@@ -32,6 +35,16 @@ _MEASURES = [
     SourceMeasure("count_rows", "Transaction count", "count", "id", "number"),
 ]
 
+_FILTERS = [
+    SourceFilter("date", "Date", ("between", "gte", "lte"), "time"),
+    SourceFilter("amount", "Amount", ("between", "gte", "lte", "eq"), "amount"),
+    SourceFilter("category_id", "Category", ("eq", "in"), "category"),
+    SourceFilter("account_id", "Account", ("eq", "in"), "account"),
+    SourceFilter("txn_type", "Type", ("eq", "in"), "type"),
+    SourceFilter("status", "Status", ("eq",), "status"),
+    SourceFilter("tag_name", "Tag", ("eq", "in"), "tag"),
+]
+
 
 class TransactionsSource:
     key = "transactions"
@@ -42,6 +55,12 @@ class TransactionsSource:
 
     def measures(self) -> list[SourceMeasure]:
         return list(_MEASURES)
+
+    def filters(self) -> list[SourceFilter]:
+        return list(_FILTERS)
+
+    def validate(self, query: ReportsQuery) -> None:
+        validate_against_catalog(self, query)
 
     async def build_rows(
         self, db: AsyncSession, org_id: int, query: ReportsQuery

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -61,6 +61,7 @@ from app.reports.sources import all_sources, get_source
 from app.schemas.report_sources import (
     SourceCatalogEntry,
     SourceDimensionOut,
+    SourceFilterOut,
     SourceMeasureOut,
 )
 from app.schemas.reports_query import ReportsQuery, ReportsQueryResponse
@@ -164,8 +165,16 @@ async def _run_source_query(db: AsyncSession, ast: ReportsQuery, *, org_id: int)
     Unknown dataset is impossible from the wire (the Dataset enum is
     closed and Pydantic-validated), so a KeyError here is a server bug,
     not user input — let it surface as 500.
+
+    Pydantic proves the AST is well-formed; ``source.validate`` proves it
+    stays within THIS source's published catalog. A catalog violation is
+    user input — mapped to 422 (a raw ValueError would otherwise 500).
     """
     source = get_source(ast.dataset.value)
+    try:
+        source.validate(ast)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     return await source.build_rows(db, org_id, ast)
 
 
@@ -268,6 +277,7 @@ async def list_sources(current_user: User = Depends(get_current_user)):
             label=s.label,
             dimensions=[SourceDimensionOut(**dataclasses.asdict(d)) for d in s.dimensions()],
             measures=[SourceMeasureOut(**dataclasses.asdict(m)) for m in s.measures()],
+            filters=[SourceFilterOut(**dataclasses.asdict(f)) for f in s.filters()],
         )
         for s in all_sources()
     ]

--- a/backend/app/schemas/report_layout.py
+++ b/backend/app/schemas/report_layout.py
@@ -44,6 +44,11 @@ from pydantic import (
     field_validator,
 )
 
+# Dataset / Aggregation / MeasureField / Dimension are the shared closed
+# enum atoms — defined once in ``reports_enums`` so the saved-layout shape
+# and the live ``/query`` AST (``reports_query``) cannot drift.
+from app.schemas.reports_enums import Aggregation, Dataset, Dimension, MeasureField
+
 
 # ─── closed enums (mirror frontend unions) ──────────────────────────
 
@@ -57,36 +62,6 @@ class WidgetType(str, enum.Enum):
     PIE = "pie"
     SPARKLINE = "sparkline"
     TABLE = "table"
-
-
-class Dataset(str, enum.Enum):
-    TRANSACTIONS = "transactions"
-
-
-class Aggregation(str, enum.Enum):
-    SUM = "sum"
-    COUNT = "count"
-    AVG = "avg"
-    DISTINCT = "distinct"
-
-
-class MeasureField(str, enum.Enum):
-    AMOUNT = "amount"
-    ID = "id"
-    CATEGORY_ID = "category_id"
-    ACCOUNT_ID = "account_id"
-
-
-class Dimension(str, enum.Enum):
-    CATEGORY = "category"
-    CATEGORY_MASTER = "category_master"
-    ACCOUNT = "account"
-    TAG = "tag"
-    TXN_TYPE = "txn_type"
-    STATUS = "status"
-    MONTH = "month"
-    WEEK = "week"
-    DAY = "day"
 
 
 class WidgetFormat(str, enum.Enum):

--- a/backend/app/schemas/report_sources.py
+++ b/backend/app/schemas/report_sources.py
@@ -15,8 +15,16 @@ class SourceMeasureOut(BaseModel):
     format: str
 
 
+class SourceFilterOut(BaseModel):
+    field: str
+    label: str
+    ops: list[str]
+    kind: str
+
+
 class SourceCatalogEntry(BaseModel):
     key: str
     label: str
     dimensions: list[SourceDimensionOut]
     measures: list[SourceMeasureOut]
+    filters: list[SourceFilterOut]

--- a/backend/app/schemas/reports_enums.py
+++ b/backend/app/schemas/reports_enums.py
@@ -8,10 +8,18 @@ import enum
 
 
 class Dataset(str, enum.Enum):
+    """Closed source set. Adding a value here EXPANDS what data the reports
+    AST can reach and is a security-review event — every new dataset must
+    have a registered ReportSource that org-scopes its own queries."""
+
     TRANSACTIONS = "transactions"
+    ACCOUNTS = "accounts"
 
 
 class Aggregation(str, enum.Enum):
+    """Closed aggregation set. ``distinct`` is the short form of
+    ``count_distinct`` (distinct-count of the targeted field)."""
+
     SUM = "sum"
     COUNT = "count"
     AVG = "avg"
@@ -20,6 +28,7 @@ class Aggregation(str, enum.Enum):
 
 class MeasureField(str, enum.Enum):
     AMOUNT = "amount"
+    BALANCE = "balance"
     ID = "id"
     CATEGORY_ID = "category_id"
     ACCOUNT_ID = "account_id"
@@ -29,6 +38,9 @@ class Dimension(str, enum.Enum):
     CATEGORY = "category"
     CATEGORY_MASTER = "category_master"
     ACCOUNT = "account"
+    ACCOUNT_TYPE = "account_type"
+    CURRENCY = "currency"
+    ACCOUNT_ACTIVE = "account_active"
     TAG = "tag"
     TXN_TYPE = "txn_type"
     STATUS = "status"

--- a/backend/app/schemas/reports_enums.py
+++ b/backend/app/schemas/reports_enums.py
@@ -1,0 +1,37 @@
+"""Shared closed enum atoms for the reports query AST and the saved-layout
+JSON validator. Both surfaces draw dataset / dimension / measure-field /
+aggregation from these closed enums so a value cannot drift between "what a
+saved widget references" and "what the live compiler accepts"."""
+from __future__ import annotations
+
+import enum
+
+
+class Dataset(str, enum.Enum):
+    TRANSACTIONS = "transactions"
+
+
+class Aggregation(str, enum.Enum):
+    SUM = "sum"
+    COUNT = "count"
+    AVG = "avg"
+    DISTINCT = "distinct"
+
+
+class MeasureField(str, enum.Enum):
+    AMOUNT = "amount"
+    ID = "id"
+    CATEGORY_ID = "category_id"
+    ACCOUNT_ID = "account_id"
+
+
+class Dimension(str, enum.Enum):
+    CATEGORY = "category"
+    CATEGORY_MASTER = "category_master"
+    ACCOUNT = "account"
+    TAG = "tag"
+    TXN_TYPE = "txn_type"
+    STATUS = "status"
+    MONTH = "month"
+    WEEK = "week"
+    DAY = "day"

--- a/backend/app/schemas/reports_query.py
+++ b/backend/app/schemas/reports_query.py
@@ -48,6 +48,10 @@ MAX_FILTERS = 20
 MAX_DIMENSIONS = 2
 MAX_DATE_WINDOW_DAYS = 5 * 365 + 2  # 5 years inclusive of two leap days.
 
+# Fields a SUM / AVG may target. Source-agnostic numeric sanity gate — the
+# per-source validate() still rejects a field the source does not publish.
+NUMERIC_MEASURE_FIELDS = {MeasureField.AMOUNT, MeasureField.BALANCE}
+
 
 class FilterField(str, enum.Enum):
     """Filter columns. Closed enum — ``org_id`` / ``user_id`` /
@@ -62,6 +66,10 @@ class FilterField(str, enum.Enum):
     ACCOUNT_ID = "account_id"
     TXN_TYPE = "txn_type"
     STATUS = "status"
+    ACCOUNT_TYPE = "account_type"
+    CURRENCY = "currency"
+    ACCOUNT_ACTIVE = "account_active"
+    BALANCE = "balance"
     # Tag filter uses normalized tag name (lowercased), matching the
     # transactions list semantics at
     # ``backend/app/routers/transactions.py:90`` and
@@ -94,15 +102,13 @@ class Measure(BaseModel):
 
     @model_validator(mode="after")
     def _validate_agg_field(self):
-        # SUM / AVG require a numeric column. ``amount`` is the only
-        # numeric column we expose on transactions.
         if self.agg in (Aggregation.SUM, Aggregation.AVG):
-            if self.field is not MeasureField.AMOUNT:
+            if self.field not in NUMERIC_MEASURE_FIELDS:
                 raise ValueError(
-                    f"agg={self.agg.value} requires field='amount'; "
+                    f"agg={self.agg.value} requires a numeric field "
+                    f"{sorted(f.value for f in NUMERIC_MEASURE_FIELDS)}; "
                     f"got field={self.field.value!r}"
                 )
-        # COUNT and DISTINCT accept any whitelisted field.
         return self
 
 
@@ -298,5 +304,26 @@ def _coerce_filter_scalar(field: FilterField, value):
         if not v:
             raise ValueError("tag_name must be a non-empty string")
         return v
+    if field is FilterField.ACCOUNT_TYPE:
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("account_type must be an integer id") from exc
+    if field is FilterField.CURRENCY:
+        v = str(value).strip().upper()
+        if not (len(v) == 3 and v.isalpha()):
+            raise ValueError("currency must be a 3-letter code")
+        return v
+    if field is FilterField.ACCOUNT_ACTIVE:
+        if isinstance(value, bool):
+            return value
+        v = str(value).strip().lower()
+        if v in ("true", "1", "active"):
+            return True
+        if v in ("false", "0", "inactive"):
+            return False
+        raise ValueError("account_active must be a boolean")
+    if field is FilterField.BALANCE:
+        return _coerce_decimal(value)
     # Should be unreachable given the FilterField enum is closed.
     raise ValueError(f"unsupported filter field {field!r}")

--- a/backend/app/schemas/reports_query.py
+++ b/backend/app/schemas/reports_query.py
@@ -151,9 +151,10 @@ class Filter(BaseModel):
         # Type narrowing. The schema layer's job is to reject anything
         # the compiler can't safely handle.
         if op is FilterOp.BETWEEN:
-            if f not in (FilterField.DATE, FilterField.AMOUNT):
+            if f not in (FilterField.DATE, FilterField.AMOUNT, FilterField.BALANCE):
                 raise ValueError(
-                    f"op='between' only valid on date / amount; got field={f.value!r}"
+                    f"op='between' only valid on date / amount / balance; "
+                    f"got field={f.value!r}"
                 )
             if not isinstance(self.value, list) or len(self.value) != 2:
                 raise ValueError(
@@ -175,13 +176,13 @@ class Filter(BaseModel):
                         f"date BETWEEN window must be <= {MAX_DATE_WINDOW_DAYS} days "
                         "(5 years)"
                     )
-            else:  # amount
+            else:  # amount / balance (numeric pair)
                 lo, hi = self.value
                 if not isinstance(lo, (int, float, str, Decimal)) or not isinstance(
                     hi, (int, float, str, Decimal)
                 ):
                     raise ValueError(
-                        "amount BETWEEN bounds must be numeric"
+                        "numeric BETWEEN bounds must be numeric"
                     )
                 self.value = [_coerce_decimal(lo), _coerce_decimal(hi)]
 

--- a/backend/app/schemas/reports_query.py
+++ b/backend/app/schemas/reports_query.py
@@ -35,6 +35,11 @@ from pydantic import (
     model_validator,
 )
 
+# Dataset / Aggregation / MeasureField / Dimension are the shared closed
+# enum atoms — defined once in ``reports_enums`` so the live ``/query`` AST
+# and the saved-layout JSON validator (``report_layout``) cannot drift.
+from app.schemas.reports_enums import Aggregation, Dataset, Dimension, MeasureField
+
 
 # Hard caps. Module-level constants so tests can import + assert them.
 MAX_LIMIT = 500
@@ -42,62 +47,6 @@ DEFAULT_LIMIT = 100
 MAX_FILTERS = 20
 MAX_DIMENSIONS = 2
 MAX_DATE_WINDOW_DAYS = 5 * 365 + 2  # 5 years inclusive of two leap days.
-
-
-class Dataset(str, enum.Enum):
-    """Closed source set. v1 only exposes ``transactions``; opening
-    new datasets is a v2 spec decision (budgets, recurring, forecast).
-    Admin / internal tables are deliberately excluded — adding one
-    here is a security review event.
-    """
-
-    TRANSACTIONS = "transactions"
-
-
-class Aggregation(str, enum.Enum):
-    """Closed aggregation set. Anything outside this enum is rejected
-    by Pydantic at schema-validation time, so the compiler never sees
-    user-supplied aggregation strings.
-    """
-
-    SUM = "sum"
-    COUNT = "count"
-    AVG = "avg"
-    # ``distinct`` is shorthand for COUNT(DISTINCT field) — the
-    # compiler expands it. Spec section 3 lists ``count_distinct``
-    # as the long form; we accept the short form on the wire for
-    # symmetry with the other aggs.
-    DISTINCT = "distinct"
-
-
-class MeasureField(str, enum.Enum):
-    """Columns an aggregation may target on the transactions source.
-    Closed enum so a misspelled field cannot reach SQL.
-    """
-
-    AMOUNT = "amount"
-    ID = "id"
-    CATEGORY_ID = "category_id"
-    ACCOUNT_ID = "account_id"
-
-
-class Dimension(str, enum.Enum):
-    """GROUP BY dimensions. Closed enum.
-
-    Time bucket dimensions (``month``, ``week``, ``day``) compile to
-    SQLAlchemy ``func.date_format`` expressions in MySQL and SQLite-
-    compatible ``strftime`` equivalents in the test harness.
-    """
-
-    CATEGORY = "category"
-    CATEGORY_MASTER = "category_master"
-    ACCOUNT = "account"
-    TAG = "tag"
-    TXN_TYPE = "txn_type"
-    STATUS = "status"
-    MONTH = "month"
-    WEEK = "week"
-    DAY = "day"
 
 
 class FilterField(str, enum.Enum):

--- a/backend/tests/routers/test_report_sources_endpoint.py
+++ b/backend/tests/routers/test_report_sources_endpoint.py
@@ -151,6 +151,20 @@ async def test_sources_endpoint_lists_transactions_catalog(session_factory):
         assert "field" in m
         assert "format" in m
 
+    # Filters: every catalog entry carries a non-empty filter list whose
+    # items expose field/label/ops/kind.
+    for s in body:
+        assert isinstance(s["filters"], list)
+        assert s["filters"]
+        for f in s["filters"]:
+            assert "field" in f
+            assert "label" in f
+            assert "ops" in f and isinstance(f["ops"], list)
+            assert "kind" in f
+
+    # Transactions must publish a "date" filter.
+    assert any(f["field"] == "date" for f in tx["filters"])
+
 
 @pytest.mark.asyncio
 async def test_sources_endpoint_404_when_flag_off(session_factory, monkeypatch):

--- a/backend/tests/routers/test_reports_query_validation.py
+++ b/backend/tests/routers/test_reports_query_validation.py
@@ -1,0 +1,39 @@
+"""Per-source validity is enforced after Pydantic parse and surfaces as 422."""
+import pytest
+
+from app.reports import sources as registry
+from app.schemas.reports_query import (
+    Aggregation, Dataset, Dimension, Filter, FilterField, FilterOp,
+    Measure, MeasureField, ReportsQuery,
+)
+
+
+def _q(dataset, measure, dims=None, filters=None):
+    return ReportsQuery(
+        dataset=dataset, measure=measure,
+        dimensions=dims or [], filters=filters or [],
+    )
+
+
+def test_transactions_rejects_balance_measure():
+    src = registry.get_source("transactions")
+    q = _q(Dataset.TRANSACTIONS, Measure(agg=Aggregation.SUM, field=MeasureField.BALANCE))
+    with pytest.raises(ValueError):
+        src.validate(q)
+
+
+def test_transactions_rejects_currency_dimension():
+    src = registry.get_source("transactions")
+    q = _q(Dataset.TRANSACTIONS,
+           Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+           dims=[Dimension.CURRENCY])
+    with pytest.raises(ValueError):
+        src.validate(q)
+
+
+def test_transactions_accepts_its_own_surface():
+    src = registry.get_source("transactions")
+    q = _q(Dataset.TRANSACTIONS,
+           Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+           dims=[Dimension.CATEGORY])
+    src.validate(q)  # no raise

--- a/backend/tests/schemas/test_measure_numeric_validation.py
+++ b/backend/tests/schemas/test_measure_numeric_validation.py
@@ -1,0 +1,20 @@
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.reports_query import (
+    Aggregation, Measure, MeasureField, NUMERIC_MEASURE_FIELDS,
+)
+
+
+def test_sum_balance_is_numerically_sane():
+    m = Measure(agg=Aggregation.SUM, field=MeasureField.BALANCE)
+    assert m.field is MeasureField.BALANCE
+
+
+def test_sum_id_still_rejected_at_pydantic():
+    with pytest.raises(ValidationError):
+        Measure(agg=Aggregation.SUM, field=MeasureField.ID)
+
+
+def test_numeric_set_is_amount_and_balance():
+    assert NUMERIC_MEASURE_FIELDS == {MeasureField.AMOUNT, MeasureField.BALANCE}

--- a/backend/tests/schemas/test_reports_enums_consistency.py
+++ b/backend/tests/schemas/test_reports_enums_consistency.py
@@ -10,5 +10,12 @@ def test_shared_enum_atoms_are_the_same_object():
     assert reports_query.Aggregation is report_layout.Aggregation
 
 
-def test_dataset_values_unchanged_for_now():
-    assert {d.value for d in reports_query.Dataset} == {"transactions"}
+def test_dataset_values():
+    assert {d.value for d in reports_query.Dataset} == {"transactions", "accounts"}
+
+
+def test_accounts_dataset_and_new_dimensions_present():
+    from app.schemas.reports_query import Dataset, Dimension, MeasureField
+    assert "accounts" in {d.value for d in Dataset}
+    assert {"account_type", "currency", "account_active"}.issubset({d.value for d in Dimension})
+    assert "balance" in {f.value for f in MeasureField}

--- a/backend/tests/schemas/test_reports_enums_consistency.py
+++ b/backend/tests/schemas/test_reports_enums_consistency.py
@@ -1,0 +1,14 @@
+"""Guard against the two-copy enum drift the shared module exists to kill."""
+from app.schemas import reports_query, report_layout
+
+
+def test_shared_enum_atoms_are_the_same_object():
+    # After consolidation both modules re-export the SAME enum class.
+    assert reports_query.Dataset is report_layout.Dataset
+    assert reports_query.Dimension is report_layout.Dimension
+    assert reports_query.MeasureField is report_layout.MeasureField
+    assert reports_query.Aggregation is report_layout.Aggregation
+
+
+def test_dataset_values_unchanged_for_now():
+    assert {d.value for d in reports_query.Dataset} == {"transactions"}

--- a/backend/tests/services/test_accounts_source.py
+++ b/backend/tests/services/test_accounts_source.py
@@ -1,0 +1,180 @@
+"""AccountsSource — balance/count over the accounts snapshot.
+
+Self-contained in-memory aiosqlite fixture (mirrors
+test_transaction_service_pair.py): engine + PRAGMA foreign_keys=ON +
+StaticPool. Does NOT rely on conftest fixtures.
+"""
+import pytest
+import pytest_asyncio
+from decimal import Decimal
+
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models.base import Base
+from app.models import Account, AccountType, Organization
+from app.reports import sources as registry
+from app.schemas.reports_query import (
+    Aggregation,
+    Dataset,
+    Dimension,
+    Filter,
+    FilterField,
+    FilterOp,
+    Measure,
+    MeasureField,
+    ReportsQuery,
+)
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded(db_session):
+    """Org 1: Bank type (Checking 500, Savings 1500, both active/EUR),
+    Card type (OldCard -200, inactive/EUR). Org 2: one account for
+    org-isolation."""
+    org1 = Organization(name="Org1", billing_cycle_day=1)
+    org2 = Organization(name="Org2", billing_cycle_day=1)
+    db_session.add_all([org1, org2])
+    await db_session.flush()
+
+    bank = AccountType(org_id=org1.id, name="Bank", slug="bank", is_system=False)
+    card = AccountType(org_id=org1.id, name="Card", slug="card", is_system=False)
+    other_at = AccountType(org_id=org2.id, name="Other", slug="other", is_system=False)
+    db_session.add_all([bank, card, other_at])
+    await db_session.flush()
+
+    checking = Account(
+        org_id=org1.id, name="Checking", account_type_id=bank.id,
+        balance=Decimal("500"), currency="EUR", is_active=True,
+    )
+    savings = Account(
+        org_id=org1.id, name="Savings", account_type_id=bank.id,
+        balance=Decimal("1500"), currency="EUR", is_active=True,
+    )
+    oldcard = Account(
+        org_id=org1.id, name="OldCard", account_type_id=card.id,
+        balance=Decimal("-200"), currency="EUR", is_active=False,
+    )
+    other = Account(
+        org_id=org2.id, name="OtherAcct", account_type_id=other_at.id,
+        balance=Decimal("999"), currency="EUR", is_active=True,
+    )
+    db_session.add_all([checking, savings, oldcard, other])
+    await db_session.flush()
+
+    return {"org1_id": org1.id, "org2_id": org2.id}
+
+
+def _source():
+    return registry.get_source("accounts")
+
+
+def _query(**kwargs):
+    base = dict(
+        dataset=Dataset.ACCOUNTS,
+        measure=Measure(agg=Aggregation.COUNT, field=MeasureField.ID),
+    )
+    base.update(kwargs)
+    return ReportsQuery(**base)
+
+
+@pytest.mark.asyncio
+async def test_sum_balance_by_account_type(db_session, seeded):
+    src = _source()
+    ast = _query(
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.BALANCE),
+        dimensions=[Dimension.ACCOUNT_TYPE],
+    )
+    rows, meta = await src.build_rows(db_session, seeded["org1_id"], ast)
+    by_type = {r["account_type"]: r["value"] for r in rows}
+    assert by_type == {"Bank": 2000.0, "Card": -200.0}
+    assert meta["row_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_count_by_account_active(db_session, seeded):
+    src = _source()
+    ast = _query(dimensions=[Dimension.ACCOUNT_ACTIVE])
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    by_active = {r["account_active"]: r["value"] for r in rows}
+    assert by_active == {"Active": 2, "Inactive": 1}
+
+
+@pytest.mark.asyncio
+async def test_count_no_dims_org_isolation(db_session, seeded):
+    src = _source()
+    ast = _query()
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert len(rows) == 1
+    assert rows[0]["value"] == 3  # org2's account excluded
+
+
+@pytest.mark.asyncio
+async def test_date_filter_tolerated_and_dropped(db_session, seeded):
+    """A date filter against accounts must validate() without raising and
+    build_rows must return rows (date dropped) — the Phase-5 shared-canvas
+    bar contract."""
+    src = _source()
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.DATE, op=FilterOp.BETWEEN,
+                   value=["2024-01-01", "2026-01-01"]),
+        ],
+    )
+    src.validate(ast)  # must not raise
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert len(rows) == 1
+    assert rows[0]["value"] == 3
+
+
+@pytest.mark.asyncio
+async def test_sum_balance_by_currency_with_currency_filter(db_session, seeded):
+    src = _source()
+    ast = _query(
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.BALANCE),
+        dimensions=[Dimension.CURRENCY],
+        filters=[Filter(field=FilterField.CURRENCY, op=FilterOp.EQ, value="EUR")],
+    )
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert {r["currency"] for r in rows} == {"EUR"}
+    assert rows[0]["value"] == 1800.0  # 500 + 1500 - 200, all EUR
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_sum_amount(db_session, seeded):
+    src = _source()
+    ast = _query(measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT))
+    with pytest.raises(ValueError):
+        src.validate(ast)
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_category_dimension(db_session, seeded):
+    src = _source()
+    ast = _query(dimensions=[Dimension.CATEGORY])
+    with pytest.raises(ValueError):
+        src.validate(ast)

--- a/backend/tests/services/test_accounts_source.py
+++ b/backend/tests/services/test_accounts_source.py
@@ -164,6 +164,39 @@ async def test_sum_balance_by_currency_with_currency_filter(db_session, seeded):
     assert rows[0]["value"] == 1800.0  # 500 + 1500 - 200, all EUR
 
 
+def test_balance_between_filter_constructs():
+    """The AST Filter validator must accept ``balance BETWEEN``. Also
+    confirms scalar ``gte``/``lte`` on balance still construct."""
+    # BETWEEN — was rejected with 422 before the validator fix.
+    f = Filter(
+        field=FilterField.BALANCE,
+        op=FilterOp.BETWEEN,
+        value=[Decimal("0"), Decimal("1000")],
+    )
+    assert f.value == [Decimal("0"), Decimal("1000")]
+
+    # Scalar range ops are unaffected and should still construct.
+    Filter(field=FilterField.BALANCE, op=FilterOp.GTE, value=Decimal("0"))
+    Filter(field=FilterField.BALANCE, op=FilterOp.LTE, value=Decimal("1000"))
+
+
+@pytest.mark.asyncio
+async def test_balance_between_filter_applied(db_session, seeded):
+    """End-to-end: ``balance BETWEEN [0, 1000]`` validates and only counts
+    accounts in range (Checking 500 -> 1; Savings 1500 and OldCard -200
+    excluded)."""
+    src = _source()
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.BALANCE, op=FilterOp.BETWEEN, value=[0, 1000]),
+        ],
+    )
+    src.validate(ast)  # must not raise
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert len(rows) == 1
+    assert rows[0]["value"] == 1
+
+
 @pytest.mark.asyncio
 async def test_validate_rejects_sum_amount(db_session, seeded):
     src = _source()

--- a/backend/tests/services/test_accounts_source.py
+++ b/backend/tests/services/test_accounts_source.py
@@ -26,6 +26,9 @@ from app.schemas.reports_query import (
     Measure,
     MeasureField,
     ReportsQuery,
+    SortBy,
+    SortDir,
+    SortSpec,
 )
 
 
@@ -211,3 +214,200 @@ async def test_validate_rejects_category_dimension(db_session, seeded):
     ast = _query(dimensions=[Dimension.CATEGORY])
     with pytest.raises(ValueError):
         src.validate(ast)
+
+
+# ─── helpers for IN / type filters ──────────────────────────────────
+
+
+async def _ids(db_session, org_id):
+    """Return {name -> account.id} and {slug -> account_type.id} for org1."""
+    from sqlalchemy import select as _select
+
+    acct_rows = (
+        await db_session.execute(
+            _select(Account.name, Account.id).where(Account.org_id == org_id)
+        )
+    ).all()
+    type_rows = (
+        await db_session.execute(
+            _select(AccountType.slug, AccountType.id).where(
+                AccountType.org_id == org_id
+            )
+        )
+    ).all()
+    return {n: i for n, i in acct_rows}, {s: i for s, i in type_rows}
+
+
+# ─── Fix 1: validate enforces catalog filter OPS ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_balance_eq_op(db_session, seeded):
+    """balance is published but only supports between/gte/lte. An `eq`
+    op must be rejected by validate() (→422), not silently dropped by the
+    BALANCE branch of _apply_filter."""
+    src = _source()
+    ast = _query(
+        filters=[Filter(field=FilterField.BALANCE, op=FilterOp.EQ, value=100)],
+    )
+    with pytest.raises(ValueError):
+        src.validate(ast)
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_account_active_in_op(db_session, seeded):
+    """account_active is published but only supports eq. An `in` op must
+    be rejected (it would otherwise become a constant-TRUE predicate via
+    bool([False]))."""
+    src = _source()
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.ACCOUNT_ACTIVE, op=FilterOp.IN, value=[False]),
+        ],
+    )
+    with pytest.raises(ValueError):
+        src.validate(ast)
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_non_shared_field(db_session, seeded):
+    """A transactions-only field (status) that accounts does not publish
+    and is not a shared-canvas field must be rejected outright."""
+    src = _source()
+    ast = _query(
+        filters=[Filter(field=FilterField.STATUS, op=FilterOp.EQ, value="settled")],
+    )
+    with pytest.raises(ValueError):
+        src.validate(ast)
+
+
+# ─── Fix 2 / finding 6: account_active eq filter ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_account_active_eq_false_filter(db_session, seeded):
+    """account_active eq false returns only the inactive account (OldCard)."""
+    src = _source()
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.ACCOUNT_ACTIVE, op=FilterOp.EQ, value=False),
+        ],
+    )
+    src.validate(ast)  # must not raise
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert len(rows) == 1
+    assert rows[0]["value"] == 1  # only OldCard is inactive
+
+
+# ─── finding 7: avg + IN filters ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_avg_balance_over_bank_accounts(db_session, seeded):
+    """avg over the two Bank accounts (Checking 500 + Savings 1500) = 1000.0."""
+    src = _source()
+    _, types = await _ids(db_session, seeded["org1_id"])
+    ast = _query(
+        measure=Measure(agg=Aggregation.AVG, field=MeasureField.BALANCE),
+        filters=[
+            Filter(
+                field=FilterField.ACCOUNT_TYPE,
+                op=FilterOp.EQ,
+                value=types["bank"],
+            ),
+        ],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert len(rows) == 1
+    assert rows[0]["value"] == 1000.0
+
+
+@pytest.mark.asyncio
+async def test_account_id_in_filter(db_session, seeded):
+    src = _source()
+    accts, _ = await _ids(db_session, seeded["org1_id"])
+    ast = _query(
+        filters=[
+            Filter(
+                field=FilterField.ACCOUNT_ID,
+                op=FilterOp.IN,
+                value=[accts["Checking"], accts["Savings"]],
+            ),
+        ],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert rows[0]["value"] == 2
+
+
+@pytest.mark.asyncio
+async def test_currency_in_filter(db_session, seeded):
+    src = _source()
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.CURRENCY, op=FilterOp.IN, value=["EUR"]),
+        ],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert rows[0]["value"] == 3  # all three org1 accounts are EUR
+
+
+@pytest.mark.asyncio
+async def test_account_type_in_filter(db_session, seeded):
+    src = _source()
+    _, types = await _ids(db_session, seeded["org1_id"])
+    ast = _query(
+        filters=[
+            Filter(
+                field=FilterField.ACCOUNT_TYPE,
+                op=FilterOp.IN,
+                value=[types["bank"]],
+            ),
+        ],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert rows[0]["value"] == 2  # Checking + Savings are Bank
+
+
+# ─── Fix 3: honor query.sort + stable tiebreaker ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sort_by_value_asc(db_session, seeded):
+    """Grouped query (dim=account) sorted ascending by value returns rows
+    ordered low → high balance."""
+    src = _source()
+    ast = _query(
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.BALANCE),
+        dimensions=[Dimension.ACCOUNT],
+        sort=SortSpec(by=SortBy.VALUE, dir=SortDir.ASC),
+    )
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    values = [r["value"] for r in rows]
+    assert values == sorted(values)
+    # OldCard (-200) first, Savings (1500) last.
+    assert rows[0]["account"] == "OldCard"
+    assert rows[-1]["account"] == "Savings"
+
+
+@pytest.mark.asyncio
+async def test_sort_truncation_is_deterministic(db_session, seeded):
+    """With a small limit, the truncated set is identical across runs
+    (stable tiebreaker)."""
+    src = _source()
+
+    def _ast():
+        return _query(
+            measure=Measure(agg=Aggregation.SUM, field=MeasureField.BALANCE),
+            dimensions=[Dimension.ACCOUNT],
+            sort=SortSpec(by=SortBy.VALUE, dir=SortDir.ASC),
+            limit=2,
+        )
+
+    rows_a, _ = await src.build_rows(db_session, seeded["org1_id"], _ast())
+    rows_b, _ = await src.build_rows(db_session, seeded["org1_id"], _ast())
+    assert len(rows_a) == 2
+    assert [r["account"] for r in rows_a] == [r["account"] for r in rows_b]

--- a/backend/tests/services/test_report_sources_registry.py
+++ b/backend/tests/services/test_report_sources_registry.py
@@ -48,6 +48,48 @@ def test_transactions_source_catalog_matches_ast_enums():
     assert (by_key["count_rows"].agg, by_key["count_rows"].field, by_key["count_rows"].format) == ("count", "id", "number")
 
 
+def test_accounts_source_catalog():
+    src = source_registry.get_source("accounts")
+    assert src.key == "accounts"
+    assert {d.key for d in src.dimensions()} == {
+        "account", "account_type", "currency", "account_active",
+    }
+    assert {m.key for m in src.measures()} == {
+        "sum_balance", "avg_balance", "count_accounts",
+    }
+    assert {f.field for f in src.filters()} == {
+        "account_id", "account_type", "currency", "account_active", "balance",
+    }
+
+
+def test_all_catalog_keys_are_known_kinds():
+    known_kinds = {
+        "category", "account", "status", "type", "tag", "time",
+        "account_type", "currency", "boolean", "amount", "number",
+    }
+    for src in source_registry.all_sources():
+        for d in src.dimensions():
+            assert d.kind in known_kinds, f"{src.key}: bad dim kind {d.kind!r}"
+        for f in src.filters():
+            assert f.kind in known_kinds, f"{src.key}: bad filter kind {f.kind!r}"
+
+
+def test_every_source_catalog_keys_subset_of_closed_enums():
+    from app.schemas.reports_query import (
+        Dimension as AstDimension,
+        FilterField as AstFilterField,
+        MeasureField as AstMeasureField,
+    )
+
+    dim_values = {d.value for d in AstDimension}
+    field_values = {f.value for f in AstMeasureField}
+    filter_values = {f.value for f in AstFilterField}
+    for src in source_registry.all_sources():
+        assert {d.key for d in src.dimensions()}.issubset(dim_values), src.key
+        assert {m.field for m in src.measures()}.issubset(field_values), src.key
+        assert {f.field for f in src.filters()}.issubset(filter_values), src.key
+
+
 def test_every_dataset_enum_value_has_a_registered_source():
     from app.reports import sources as source_registry
     from app.schemas.reports_query import Dataset

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -310,7 +310,7 @@ export default function ReportEditorPage({ params }: PageProps) {
   // mid-typing PATCH response can't clobber what the user is typing.
   const [titleDraft, setTitleDraft] = useState("");
   // Synchronous re-entry guard so Enter-then-blur in the same tick can't
-  // fire two PATCHes (the ``renamingTitle`` state flips a tick too late).
+  // fire two PATCHes — a state flag would flip a tick too late, so we use a ref.
   const titleCommitInFlight = useRef(false);
   const [layout, setLayout] = useState<LayoutJson>(DEFAULT_LAYOUT);
   const [canvasFilters, setCanvasFilters] = useState<CanvasFilters>({});

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -497,7 +497,13 @@ export default function ReportEditorPage({ params }: PageProps) {
       setTitleDraft(report.name);
       return;
     }
-    if (trimmed === report.name) return;
+    if (trimmed === report.name) {
+      // Unchanged once trimmed: normalize the visible draft back to the
+      // canonical name so surrounding whitespace the user typed (e.g.
+      // "My Report ") doesn't linger in the input.
+      setTitleDraft(report.name);
+      return;
+    }
     const prevName = report.name;
     titleCommitInFlight.current = true;
     try {
@@ -688,8 +694,9 @@ export default function ReportEditorPage({ params }: PageProps) {
                 }
               }}
               aria-label="Report title"
+              placeholder="Report title"
               data-testid="report-editor-title"
-              className="rounded-md border border-transparent bg-transparent px-2 py-1 text-sm font-semibold text-text-primary hover:border-border focus:border-border focus:bg-bg focus:outline-none"
+              className="rounded-md border border-transparent bg-transparent px-2 py-1 text-sm font-semibold text-text-primary hover:border-border focus:border-border focus:bg-bg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
             />
           ) : (
             <span className="text-sm font-semibold text-text-primary">

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -21,7 +21,7 @@
  * button in the header; the rollout-table PR2 row says "Save layout
  * (PATCH)" — both align with explicit-save.
  */
-import { use, useCallback, useEffect, useMemo, useState } from "react";
+import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 
@@ -304,6 +304,14 @@ export default function ReportEditorPage({ params }: PageProps) {
   const isSmallScreen = useIsSmallScreen();
 
   const [report, setReport] = useState<ReportSummary | null>(null);
+  // Draft value of the inline-editable title. Seeded from the loaded
+  // report and re-synced whenever the report identity changes (load,
+  // restore, duplicate-in-place) — NOT on every ``report`` write, so a
+  // mid-typing PATCH response can't clobber what the user is typing.
+  const [titleDraft, setTitleDraft] = useState("");
+  // Synchronous re-entry guard so Enter-then-blur in the same tick can't
+  // fire two PATCHes (the ``renamingTitle`` state flips a tick too late).
+  const titleCommitInFlight = useRef(false);
   const [layout, setLayout] = useState<LayoutJson>(DEFAULT_LAYOUT);
   const [canvasFilters, setCanvasFilters] = useState<CanvasFilters>({});
   const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
@@ -341,6 +349,7 @@ export default function ReportEditorPage({ params }: PageProps) {
   // snapshot).
   function hydrateFromReport(r: ReportSummary) {
     setReport(r);
+    setTitleDraft(r.name);
     const lj = (r.layout_json ?? {}) as Partial<LayoutJson>;
     setLayout(
       lj && Array.isArray(lj.widgets)
@@ -473,6 +482,35 @@ export default function ReportEditorPage({ params }: PageProps) {
   function updateCanvasFilters(next: CanvasFilters) {
     setCanvasFilters(next);
     setDirty(true);
+  }
+
+  // Inline title rename. Independent of the layout dirty/Save flow: a
+  // rename is its own immediate PATCH (the backend treats a name change
+  // as a non-snapshotting metadata edit). Commit on blur AND Enter; if
+  // the trimmed value is empty or unchanged, do nothing (revert blank
+  // back to the current name). On error, revert the draft to the prior
+  // name so the input never strands an unpersisted value.
+  async function commitTitle() {
+    if (!report || titleCommitInFlight.current) return;
+    const trimmed = titleDraft.trim();
+    if (!trimmed) {
+      setTitleDraft(report.name);
+      return;
+    }
+    if (trimmed === report.name) return;
+    const prevName = report.name;
+    titleCommitInFlight.current = true;
+    try {
+      const updated = await updateReport(report.id, { name: trimmed });
+      setReport(updated);
+      setTitleDraft(updated.name);
+    } catch (err) {
+      setTitleDraft(prevName);
+      const e = err as Error;
+      setSaveError(e.message || "Couldn't rename report");
+    } finally {
+      titleCommitInFlight.current = false;
+    }
   }
 
   async function handleSave() {
@@ -634,9 +672,30 @@ export default function ReportEditorPage({ params }: PageProps) {
             Reports
           </Link>
           <span className="text-text-muted">/</span>
-          <span className="text-sm font-semibold text-text-primary">
-            {report.name}
-          </span>
+          {editModeActive ? (
+            <input
+              type="text"
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              onBlur={commitTitle}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  // Commit directly (don't rely on blur firing): then drop
+                  // focus so the field reads as committed.
+                  void commitTitle();
+                  e.currentTarget.blur();
+                }
+              }}
+              aria-label="Report title"
+              data-testid="report-editor-title"
+              className="rounded-md border border-transparent bg-transparent px-2 py-1 text-sm font-semibold text-text-primary hover:border-border focus:border-border focus:bg-bg focus:outline-none"
+            />
+          ) : (
+            <span className="text-sm font-semibold text-text-primary">
+              {report.name}
+            </span>
+          )}
           {dirty && (
             <span
               data-testid="report-editor-dirty"

--- a/frontend/components/reports/WidgetFilterChips.tsx
+++ b/frontend/components/reports/WidgetFilterChips.tsx
@@ -16,6 +16,8 @@
  * nothing when the widget has no set filters.
  */
 import { describeWidgetFilters } from "@/lib/reports/describe-filters";
+import { sourceSupportsDateFilter } from "@/lib/reports/resolve";
+import { useReportSources } from "@/lib/reports/use-report-sources";
 import type { CanvasFilters, Widget } from "@/lib/reports/types";
 import type { Account, Category } from "@/lib/types";
 
@@ -50,10 +52,23 @@ export default function WidgetFilterChips({
   interactive,
   onSelectFilters,
 }: Props) {
-  const chips = describeWidgetFilters(widget, canvasFilters, {
-    accounts,
-    categories,
-  });
+  // A date-less source (accounts) gets no date chip — the resolver
+  // already drops the date filter at query time, so the chip would
+  // show but do nothing. Threaded into ``describeWidgetFilters`` so the
+  // chips never claim a filter the widget doesn't actually run.
+  const { sources } = useReportSources();
+  const supportsDate = sourceSupportsDateFilter(
+    sources,
+    widget.config.dataset,
+  );
+
+  const chips = describeWidgetFilters(
+    widget,
+    canvasFilters,
+    { accounts, categories },
+    undefined,
+    supportsDate,
+  );
 
   if (chips.length === 0) return null;
 

--- a/frontend/components/reports/config/DataTab.tsx
+++ b/frontend/components/reports/config/DataTab.tsx
@@ -14,7 +14,9 @@ import {
   DIMENSION_OPTIONS,
   dimensionOptionsFor,
   isMultiSeries,
+  measureFieldOptionsFor,
 } from "@/components/reports/config/controlConstants";
+import { dimensionHeader } from "@/lib/reports/series";
 import { buildWidgetMutations } from "@/components/reports/config/useWidgetMutations";
 import { useReportSources } from "@/lib/reports/use-report-sources";
 import type {
@@ -27,6 +29,26 @@ import type {
   TableConfig,
   Widget,
 } from "@/lib/reports/types";
+
+/**
+ * Catalog-free dimension options: the static ``DIMENSION_OPTIONS`` plus
+ * any of the widget's CURRENT dimension keys that aren't already in that
+ * list (e.g. accounts-only ``account_type`` on a persisted accounts widget
+ * loaded before ``/sources`` resolves). Ensures every controlled select
+ * value has a matching option even without a catalog entry.
+ */
+function dimensionOptionsWithCurrent(
+  current: Dimension[],
+): Array<{ value: string; label: string }> {
+  const out: Array<{ value: string; label: string }> = [...DIMENSION_OPTIONS];
+  const seen = new Set(out.map((o) => o.value));
+  for (const key of current) {
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ value: key, label: dimensionHeader(key) });
+  }
+  return out;
+}
 
 export default function DataTab({
   widget,
@@ -46,11 +68,26 @@ export default function DataTab({
   const { sources } = useReportSources();
   // The catalog entry for the widget's current source. While the
   // catalog is still loading (``sources`` empty) this is undefined and
-  // the dimension pickers fall back to the static ``DIMENSION_OPTIONS``.
+  // the pickers fall back to a catalog-free option set.
   const selected = sources.find((s) => s.key === widget.config.dataset);
+
+  // Dimension options. When a catalog entry is known, narrow to its
+  // dimensions. Otherwise (catalog still loading) fall back to the static
+  // ``DIMENSION_OPTIONS`` UNIONED with the widget's current dimensions, so
+  // a persisted accounts widget loaded before ``/sources`` resolves
+  // doesn't render a select value (e.g. ``account_type``) with no matching
+  // option — that mismatch trips React's "value not in options" warning.
+  const currentDims = (
+    (widget.config as { dimensions?: Dimension[] }).dimensions ?? []
+  ) as Dimension[];
   const dimOptions = selected
     ? dimensionOptionsFor(selected)
-    : DIMENSION_OPTIONS;
+    : dimensionOptionsWithCurrent(currentDims);
+
+  // Field options narrowed to the selected source's published measures.
+  // Undefined while the catalog loads → the editors fall back to the
+  // static ``FIELD_OPTIONS``.
+  const fieldOptions = selected ? measureFieldOptionsFor(selected) : undefined;
 
   function onSourceChange(key: string) {
     const entry = sources.find((s) => s.key === key);
@@ -92,6 +129,7 @@ export default function DataTab({
         <MeasuresEditor
           widget={widget}
           onChange={setSeries}
+          fieldOptions={fieldOptions}
         />
       ) : (
         <SingleMeasureEditor
@@ -100,6 +138,7 @@ export default function DataTab({
               .measure
           }
           onChange={setSingleMeasure}
+          fieldOptions={fieldOptions}
         />
       )}
 

--- a/frontend/components/reports/config/DataTab.tsx
+++ b/frontend/components/reports/config/DataTab.tsx
@@ -12,11 +12,14 @@ import SingleMeasureEditor from "@/components/reports/config/SingleMeasureEditor
 import MeasuresEditor from "@/components/reports/config/MeasuresEditor";
 import {
   DIMENSION_OPTIONS,
+  dimensionOptionsFor,
   isMultiSeries,
 } from "@/components/reports/config/controlConstants";
 import { buildWidgetMutations } from "@/components/reports/config/useWidgetMutations";
+import { useReportSources } from "@/lib/reports/use-report-sources";
 import type {
   BarConfig,
+  Dataset,
   Dimension,
   KPIConfig,
   PieConfig,
@@ -37,18 +40,48 @@ export default function DataTab({
     setSeries,
     setPrimaryDimension,
     setSecondaryDimension,
+    setDataset,
   } = buildWidgetMutations(widget, onUpdate);
+
+  const { sources } = useReportSources();
+  // The catalog entry for the widget's current source. While the
+  // catalog is still loading (``sources`` empty) this is undefined and
+  // the dimension pickers fall back to the static ``DIMENSION_OPTIONS``.
+  const selected = sources.find((s) => s.key === widget.config.dataset);
+  const dimOptions = selected
+    ? dimensionOptionsFor(selected)
+    : DIMENSION_OPTIONS;
+
+  function onSourceChange(key: string) {
+    const entry = sources.find((s) => s.key === key);
+    if (!entry) return; // unknown / not-yet-loaded source — no-op
+    setDataset(key as Dataset, entry);
+  }
 
   return (
     <>
       <Section label="Data source">
         <select
-          disabled
           value={widget.config.dataset}
+          onChange={(e) => onSourceChange(e.target.value)}
           aria-label="Data source"
-          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-muted"
+          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
         >
-          <option value="transactions">Transactions</option>
+          {sources.length > 0 ? (
+            sources.map((s) => (
+              <option key={s.key} value={s.key}>
+                {s.label}
+              </option>
+            ))
+          ) : (
+            // Graceful fallback while the catalog loads: show the
+            // widget's current source so the control never renders empty.
+            <option value={widget.config.dataset}>
+              {widget.config.dataset === "accounts"
+                ? "Accounts"
+                : "Transactions"}
+            </option>
+          )}
         </select>
       </Section>
 
@@ -80,7 +113,7 @@ export default function DataTab({
             aria-label="Primary dimension"
             className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
           >
-            {DIMENSION_OPTIONS.map((opt) => (
+            {dimOptions.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
               </option>
@@ -118,7 +151,7 @@ export default function DataTab({
             className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
           >
             <option value="">None</option>
-            {DIMENSION_OPTIONS.map((opt) => (
+            {dimOptions.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
               </option>

--- a/frontend/components/reports/config/MeasuresEditor.tsx
+++ b/frontend/components/reports/config/MeasuresEditor.tsx
@@ -27,12 +27,23 @@ import type {
 export default function MeasuresEditor({
   widget,
   onChange,
+  fieldOptions,
 }: {
   widget: Widget & { config: LineConfig | AreaConfig | StackedBarConfig | TableConfig };
   onChange: (m: SeriesConfig[]) => void;
+  /**
+   * Field options narrowed to the selected data source's published
+   * measures. When omitted (catalog not yet loaded), falls back to the
+   * static ``FIELD_OPTIONS`` so the transactions path and existing tests
+   * are unchanged. Also seeds the field of a newly-added series so an
+   * accounts widget never adds a transactions-only ``amount`` row.
+   */
+  fieldOptions?: Array<{ value: string; label: string }>;
 }) {
   const measures = widget.config.measures;
   const cap = widget.type === "table" ? MAX_TABLE_COLUMNS : MAX_SERIES;
+  const fields = fieldOptions ?? FIELD_OPTIONS;
+  const defaultField = (fields[0]?.value ?? "amount") as MeasureField;
 
   function update(idx: number, next: SeriesConfig) {
     const copy = [...measures];
@@ -44,7 +55,7 @@ export default function MeasuresEditor({
     if (measures.length >= cap) return;
     onChange([
       ...measures,
-      { measure: { agg: "sum", field: "amount" } },
+      { measure: { agg: "sum", field: defaultField } },
     ]);
   }
 
@@ -125,7 +136,7 @@ export default function MeasuresEditor({
               aria-label={`Series ${idx + 1} field`}
               className="flex-1 rounded-md border border-border bg-bg px-2 py-1 text-xs text-text-primary"
             >
-              {FIELD_OPTIONS.map((opt) => (
+              {fields.map((opt) => (
                 <option key={opt.value} value={opt.value}>
                   {opt.label}
                 </option>

--- a/frontend/components/reports/config/SingleMeasureEditor.tsx
+++ b/frontend/components/reports/config/SingleMeasureEditor.tsx
@@ -16,10 +16,19 @@ import type { Aggregation, Measure, MeasureField } from "@/lib/reports/types";
 export default function SingleMeasureEditor({
   measure,
   onChange,
+  fieldOptions,
 }: {
   measure: Measure;
   onChange: (m: Measure) => void;
+  /**
+   * Field options narrowed to the selected data source's published
+   * measures. When omitted (catalog not yet loaded), falls back to the
+   * static ``FIELD_OPTIONS`` so the transactions path and existing tests
+   * are unchanged.
+   */
+  fieldOptions?: Array<{ value: string; label: string }>;
 }) {
+  const fields = fieldOptions ?? FIELD_OPTIONS;
   return (
     <>
       <Section label="Aggregation" help={AGG_HELP_KEY[measure.agg]}>
@@ -47,7 +56,7 @@ export default function SingleMeasureEditor({
           aria-label="Field"
           className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
         >
-          {FIELD_OPTIONS.map((opt) => (
+          {fields.map((opt) => (
             <option key={opt.value} value={opt.value}>
               {opt.label}
             </option>

--- a/frontend/components/reports/config/controlConstants.ts
+++ b/frontend/components/reports/config/controlConstants.ts
@@ -66,6 +66,31 @@ export function dimensionOptionsFor(
   return entry.dimensions.map((d) => ({ value: d.key, label: d.label }));
 }
 
+/**
+ * Maps a source catalog entry's measures to FIELD picker options
+ * (``{value: field, label}``), de-duplicated to the distinct fields the
+ * source actually publishes (e.g. transactions → amount + id; accounts →
+ * balance + id), preserving catalog order. The Data tab drives the
+ * measure field selects off the SELECTED source's catalog rather than the
+ * static ``FIELD_OPTIONS`` fallback, so an accounts widget never offers a
+ * transactions-only field like ``amount`` (and then 422s at query time).
+ */
+export function measureFieldOptionsFor(
+  entry: SourceCatalogEntry,
+): Array<{ value: string; label: string }> {
+  const seen = new Set<string>();
+  const out: Array<{ value: string; label: string }> = [];
+  for (const m of entry.measures) {
+    if (seen.has(m.field)) continue;
+    seen.add(m.field);
+    out.push({
+      value: m.field,
+      label: MEASURE_FIELD_LABELS[m.field as MeasureField] ?? m.field,
+    });
+  }
+  return out;
+}
+
 export const MAX_SERIES = 5;
 export const MAX_TABLE_COLUMNS = 5;
 

--- a/frontend/components/reports/config/controlConstants.ts
+++ b/frontend/components/reports/config/controlConstants.ts
@@ -13,6 +13,7 @@ import type {
   Dimension,
   LineConfig,
   MeasureField,
+  SourceCatalogEntry,
   StackedBarConfig,
   TableConfig,
   Widget,
@@ -51,6 +52,19 @@ export const DIMENSION_OPTIONS: Array<{ value: Dimension; label: string }> = [
   { value: "week", label: "Week" },
   { value: "day", label: "Day" },
 ];
+
+/**
+ * Maps a source catalog entry's dimensions to picker options
+ * (``{value: key, label}``). Used by the Data tab to drive the
+ * primary/secondary dimension selects off the SELECTED source rather
+ * than the static ``DIMENSION_OPTIONS`` fallback, so an accounts widget
+ * never offers transactions-only dimensions (and vice versa).
+ */
+export function dimensionOptionsFor(
+  entry: SourceCatalogEntry,
+): Array<{ value: string; label: string }> {
+  return entry.dimensions.map((d) => ({ value: d.key, label: d.label }));
+}
 
 export const MAX_SERIES = 5;
 export const MAX_TABLE_COLUMNS = 5;

--- a/frontend/components/reports/config/useWidgetMutations.ts
+++ b/frontend/components/reports/config/useWidgetMutations.ts
@@ -18,12 +18,14 @@ import {
 import type {
   AreaConfig,
   BarConfig,
+  Dataset,
   Dimension,
   KPIConfig,
   LineConfig,
   Measure,
   PieConfig,
   SeriesConfig,
+  SourceCatalogEntry,
   SparklineConfig,
   StackedBarConfig,
   TableConfig,
@@ -108,6 +110,47 @@ export function buildWidgetMutations(
     onUpdate(next);
   }
 
+  /**
+   * Switches the widget's data source and prunes any now-invalid
+   * dimension. ``entry`` is the SELECTED source's catalog; dimensions
+   * not present in it would 422 at query time against the backend
+   * ``validate()``, so they are dropped. The primary dimension is reset
+   * to the new source's first dimension key when the current primary
+   * isn't carried by the new source (KPI widgets carry no dimensions and
+   * only get their ``dataset`` swapped).
+   */
+  function setDataset(dataset: Dataset, entry: SourceCatalogEntry) {
+    if (widget.type === "kpi") {
+      const next: Widget = {
+        ...widget,
+        config: { ...(widget.config as KPIConfig), dataset },
+      };
+      onUpdate(next);
+      return;
+    }
+    const cfg = widget.config as
+      | BarConfig
+      | LineConfig
+      | AreaConfig
+      | PieConfig
+      | SparklineConfig
+      | StackedBarConfig
+      | TableConfig;
+    const valid = new Set(entry.dimensions.map((d) => d.key));
+    const fallback = entry.dimensions[0]?.key as Dimension | undefined;
+    // Keep dimensions the new source carries, in order; drop the rest.
+    let dims = (cfg.dimensions ?? []).filter((d) => valid.has(d));
+    // The primary slot must always be filled with a valid dimension.
+    if (dims.length === 0 && fallback) {
+      dims = [fallback];
+    }
+    const next: Widget = {
+      ...widget,
+      config: { ...cfg, dataset, dimensions: dims },
+    } as Widget;
+    onUpdate(next);
+  }
+
   function setComparePrior(value: boolean) {
     if (widget.type !== "kpi") return;
     const next: Widget = {
@@ -148,6 +191,7 @@ export function buildWidgetMutations(
     setSeries,
     setPrimaryDimension,
     setSecondaryDimension,
+    setDataset,
     setComparePrior,
     setTopN,
     setStacked,

--- a/frontend/components/reports/config/useWidgetMutations.ts
+++ b/frontend/components/reports/config/useWidgetMutations.ts
@@ -15,6 +15,7 @@ import {
   isMultiSeries,
   isSingleAggLocked,
 } from "@/components/reports/config/controlConstants";
+import { pruneFiltersToSource } from "@/lib/reports/resolve";
 import type {
   AreaConfig,
   BarConfig,
@@ -124,10 +125,18 @@ export function buildWidgetMutations(
    * - Dimensions: keep the ones the new source carries (in order); drop
    *   the rest, refilling the primary slot with the source's first
    *   dimension key. KPI widgets carry no dimensions.
+   * - Per-widget filters: prune ``config.filters`` to only the filter
+   *   fields the new source publishes (``pruneFiltersToSource``). A
+   *   leftover ``category_ids`` / ``txn_type`` / date filter from a
+   *   transactions widget would otherwise 422 against the accounts
+   *   source's ``validate()`` at the next query.
    */
   function setDataset(dataset: Dataset, entry: SourceCatalogEntry) {
     const measureFields = new Set(entry.measures.map((m) => m.field));
     const firstMeasure = entry.measures[0];
+    // Filter fields the NEW source publishes. ``config.filters`` is
+    // pruned to these so no stale per-widget filter survives a switch.
+    const publishedFilterFields = entry.filters.map((f) => f.field);
     // First valid measure for this source (default after a field-invalid
     // switch). ``entry.measures`` is always non-empty for a real source;
     // guard for the degenerate empty-catalog case so we never write an
@@ -145,9 +154,10 @@ export function buildWidgetMutations(
         resetMeasure && !measureFields.has(cfg.measure.field)
           ? resetMeasure
           : cfg.measure;
+      const filters = pruneFiltersToSource(cfg.filters, publishedFilterFields);
       const next: Widget = {
         ...widget,
-        config: { ...cfg, dataset, measure },
+        config: { ...cfg, dataset, measure, filters },
       };
       onUpdate(next);
       return;
@@ -181,9 +191,10 @@ export function buildWidgetMutations(
         allValid || !resetMeasure
           ? mcfg.measures
           : [{ measure: resetMeasure }];
+      const filters = pruneFiltersToSource(mcfg.filters, publishedFilterFields);
       const next: Widget = {
         ...widget,
-        config: { ...mcfg, dataset, dimensions: dims, measures },
+        config: { ...mcfg, dataset, dimensions: dims, measures, filters },
       } as Widget;
       onUpdate(next);
       return;
@@ -194,9 +205,10 @@ export function buildWidgetMutations(
       resetMeasure && !measureFields.has(scfg.measure.field)
         ? resetMeasure
         : scfg.measure;
+    const filters = pruneFiltersToSource(scfg.filters, publishedFilterFields);
     const next: Widget = {
       ...widget,
-      config: { ...scfg, dataset, dimensions: dims, measure },
+      config: { ...scfg, dataset, dimensions: dims, measure, filters },
     } as Widget;
     onUpdate(next);
   }

--- a/frontend/components/reports/config/useWidgetMutations.ts
+++ b/frontend/components/reports/config/useWidgetMutations.ts
@@ -111,19 +111,43 @@ export function buildWidgetMutations(
   }
 
   /**
-   * Switches the widget's data source and prunes any now-invalid
-   * dimension. ``entry`` is the SELECTED source's catalog; dimensions
-   * not present in it would 422 at query time against the backend
-   * ``validate()``, so they are dropped. The primary dimension is reset
-   * to the new source's first dimension key when the current primary
-   * isn't carried by the new source (KPI widgets carry no dimensions and
-   * only get their ``dataset`` swapped).
+   * Switches the widget's data source, resetting both measure(s) and
+   * dimensions that the new source doesn't carry. ``entry`` is the
+   * SELECTED source's catalog; a measure field or dimension not published
+   * by it would 422 at query time against the backend ``validate()``.
+   *
+   * - Measure: if the current measure's field isn't one the new source
+   *   publishes, reset to the source's FIRST measure (its agg + field), so
+   *   e.g. transactions→accounts defaults to ``sum_balance``
+   *   ({agg:"sum", field:"balance"}). Multi-series widgets collapse to a
+   *   single series carrying that first measure.
+   * - Dimensions: keep the ones the new source carries (in order); drop
+   *   the rest, refilling the primary slot with the source's first
+   *   dimension key. KPI widgets carry no dimensions.
    */
   function setDataset(dataset: Dataset, entry: SourceCatalogEntry) {
+    const measureFields = new Set(entry.measures.map((m) => m.field));
+    const firstMeasure = entry.measures[0];
+    // First valid measure for this source (default after a field-invalid
+    // switch). ``entry.measures`` is always non-empty for a real source;
+    // guard for the degenerate empty-catalog case so we never write an
+    // undefined measure.
+    const resetMeasure: Measure | undefined = firstMeasure
+      ? {
+          agg: firstMeasure.agg as Measure["agg"],
+          field: firstMeasure.field as Measure["field"],
+        }
+      : undefined;
+
     if (widget.type === "kpi") {
+      const cfg = widget.config as KPIConfig;
+      const measure =
+        resetMeasure && !measureFields.has(cfg.measure.field)
+          ? resetMeasure
+          : cfg.measure;
       const next: Widget = {
         ...widget,
-        config: { ...(widget.config as KPIConfig), dataset },
+        config: { ...cfg, dataset, measure },
       };
       onUpdate(next);
       return;
@@ -144,9 +168,35 @@ export function buildWidgetMutations(
     if (dims.length === 0 && fallback) {
       dims = [fallback];
     }
+
+    if (isMultiSeries(widget)) {
+      const mcfg = cfg as LineConfig | AreaConfig | StackedBarConfig | TableConfig;
+      // Reset measures when ANY series references a field the new source
+      // doesn't publish. Collapse to a single series carrying the source's
+      // first measure (simplest fully-valid reset).
+      const allValid = mcfg.measures.every((s) =>
+        measureFields.has(s.measure.field),
+      );
+      const measures: SeriesConfig[] =
+        allValid || !resetMeasure
+          ? mcfg.measures
+          : [{ measure: resetMeasure }];
+      const next: Widget = {
+        ...widget,
+        config: { ...mcfg, dataset, dimensions: dims, measures },
+      } as Widget;
+      onUpdate(next);
+      return;
+    }
+
+    const scfg = cfg as BarConfig | PieConfig | SparklineConfig;
+    const measure =
+      resetMeasure && !measureFields.has(scfg.measure.field)
+        ? resetMeasure
+        : scfg.measure;
     const next: Widget = {
       ...widget,
-      config: { ...cfg, dataset, dimensions: dims },
+      config: { ...scfg, dataset, dimensions: dims, measure },
     } as Widget;
     onUpdate(next);
   }

--- a/frontend/lib/reports/describe-filters.ts
+++ b/frontend/lib/reports/describe-filters.ts
@@ -42,6 +42,11 @@ export function describeWidgetFilters(
   canvasFilters: CanvasFilters | undefined,
   lookups: Lookups,
   now?: Date,
+  // When false (a date-less source such as ``accounts``), no date chip
+  // is emitted — the resolver drops the date filter at query time, so a
+  // chip would show but do nothing. Defaults to true (transactions and
+  // the pre-catalog-load window) to preserve current behavior.
+  sourceSupportsDate = true,
 ): FilterChip[] {
   const chips: FilterChip[] = [];
 
@@ -55,7 +60,11 @@ export function describeWidgetFilters(
     widgetFilters.date_range,
     canvasFilters?.date_range,
   );
-  if (effectiveDate && (effectiveDate.start || effectiveDate.end)) {
+  if (
+    sourceSupportsDate &&
+    effectiveDate &&
+    (effectiveDate.start || effectiveDate.end)
+  ) {
     chips.push({
       key: "date",
       label: dateLabel(effectiveDate, now ?? new Date()),

--- a/frontend/lib/reports/resolve.ts
+++ b/frontend/lib/reports/resolve.ts
@@ -15,7 +15,9 @@
  */
 import type {
   CanvasFilters,
+  Dataset,
   Filter,
+  SourceCatalogEntry,
   WidgetFilters,
 } from "./types";
 
@@ -84,18 +86,48 @@ function valuesEqual(widgetVal: unknown, canvasVal: unknown): boolean {
 }
 
 /**
+ * True when the data source ``dataset`` publishes a ``date`` filter
+ * field in its catalog entry — i.e. the source has a date column the
+ * canvas date range can scope. ``transactions`` does; ``accounts`` does
+ * not.
+ *
+ * Defaults to ``true`` when the source can't be resolved (empty catalog
+ * during the pre-load window, or a dataset missing from the catalog) so
+ * we never silently drop the transactions date filter while the catalog
+ * is still loading. The backend tolerates a stray date filter on a
+ * date-less source (it drops it server-side), so "default to supports"
+ * is the safe bias.
+ */
+export function sourceSupportsDateFilter(
+  sources: SourceCatalogEntry[] | undefined,
+  dataset: Dataset,
+): boolean {
+  if (!sources || sources.length === 0) return true;
+  const entry = sources.find((s) => s.key === dataset);
+  if (!entry) return true;
+  return entry.filters.some((f) => f.field === "date");
+}
+
+/**
  * Resolves a widget's effective filters into a list of AST filter
  * primitives. ``widget`` overrides on a per-field basis; otherwise
  * the canvas value cascades through.
+ *
+ * ``sourceSupportsDate`` gates the shared canvas date filter: when
+ * ``false`` (a date-less source such as ``accounts``), the date range
+ * is omitted entirely so we never send a filter the source can't
+ * honor. Defaults to ``true`` to preserve current behavior when the
+ * source catalog isn't available yet.
  */
 export function resolveFilters(
   canvas: CanvasFilters | undefined,
   widget: WidgetFilters | undefined,
+  sourceSupportsDate = true,
 ): Filter[] {
   const out: Filter[] = [];
   const canvasDr = canvas?.date_range;
   const widgetDr = widget?.date_range;
-  const dr = pickDateRange(widgetDr, canvasDr);
+  const dr = sourceSupportsDate ? pickDateRange(widgetDr, canvasDr) : undefined;
   if (dr && dr.start && dr.end) {
     out.push({
       field: "date",

--- a/frontend/lib/reports/resolve.ts
+++ b/frontend/lib/reports/resolve.ts
@@ -187,6 +187,59 @@ export function resolveFilters(
 }
 
 /**
+ * Maps each ``WidgetFilters`` key to the backend filter ``field`` it
+ * compiles to (see ``resolveFilters`` above for the actual emission).
+ * The single source of truth for the WidgetFilters↔source-field
+ * mapping, reused by ``pruneFiltersToSource`` so the prune logic can
+ * never drift from what the resolver emits.
+ *
+ * ``tag_match`` is a knob on the ``tag_name`` filter (not its own
+ * field), so it shares ``tag_name``'s mapping and is pruned in lockstep
+ * with ``tag_names``.
+ */
+const FILTER_KEY_TO_SOURCE_FIELD: Record<keyof WidgetFilters, string> = {
+  date_range: "date",
+  account_ids: "account_id",
+  category_ids: "category_id",
+  txn_type: "txn_type",
+  amount_range: "amount",
+  tag_names: "tag_name",
+  tag_match: "tag_name",
+};
+
+/**
+ * Prunes a widget's per-widget ``WidgetFilters`` down to only the
+ * filters the given source publishes. Any key whose backend filter
+ * field isn't in ``publishedFields`` is dropped, so switching a widget's
+ * source (e.g. transactions → accounts) can't strand a filter the new
+ * source's ``validate()`` would 422 (a leftover ``category_ids`` /
+ * ``txn_type`` / ``amount_range`` on an accounts widget).
+ *
+ * ``publishedFields`` is the new source's published filter fields —
+ * ``entry.filters.map((f) => f.field)``. Returns a NEW object (never
+ * mutates the input); returns ``undefined`` when the pruned result is
+ * empty so we don't persist an empty ``{}`` filters blob.
+ */
+export function pruneFiltersToSource(
+  filters: WidgetFilters | undefined,
+  publishedFields: string[],
+): WidgetFilters | undefined {
+  if (!filters) return undefined;
+  const allowed = new Set(publishedFields);
+  const out: WidgetFilters = {};
+  let kept = 0;
+  for (const key of Object.keys(filters) as Array<keyof WidgetFilters>) {
+    const field = FILTER_KEY_TO_SOURCE_FIELD[key];
+    if (!field || !allowed.has(field)) continue;
+    // ``tag_match`` rides along only when ``tag_names`` survives — its
+    // field is ``tag_name``, already gated by the same membership check.
+    Object.assign(out, { [key]: filters[key] });
+    kept += 1;
+  }
+  return kept > 0 ? out : undefined;
+}
+
+/**
  * The single source of truth for the date inherit/override decision:
  * the widget date wins when it has a start or end, otherwise the
  * shared canvas date cascades. Exported so the chip-describe helper

--- a/frontend/lib/reports/series.ts
+++ b/frontend/lib/reports/series.ts
@@ -60,6 +60,7 @@ export const MEASURE_FIELD_LABELS: Record<MeasureField, string> = {
   id: "Row count",
   category_id: "Category",
   account_id: "Account",
+  balance: "Balance",
 };
 
 /** Display label for a measure field, falling back to the raw key. */

--- a/frontend/lib/reports/series.ts
+++ b/frontend/lib/reports/series.ts
@@ -37,6 +37,9 @@ export const DIMENSION_HEADERS: Record<Dimension, string> = {
   month: "Month",
   week: "Week",
   day: "Day",
+  account_type: "Account type",
+  currency: "Currency",
+  account_active: "Active",
 };
 
 /** Header label for a dimension key, falling back to the raw key. */

--- a/frontend/lib/reports/types.ts
+++ b/frontend/lib/reports/types.ts
@@ -24,7 +24,7 @@ export type WidgetType =
 // values to the editor's ``addWidget`` factory.
 export type WidgetTypeV1 = WidgetType;
 
-export type Dataset = "transactions";
+export type Dataset = "transactions" | "accounts";
 
 export type Aggregation = "sum" | "count" | "avg" | "distinct";
 
@@ -39,7 +39,10 @@ export type Dimension =
   | "status"
   | "month"
   | "week"
-  | "day";
+  | "day"
+  | "account_type"
+  | "currency"
+  | "account_active";
 
 export type FilterField =
   | "date"
@@ -319,4 +322,40 @@ export interface ReportUpdatePayload {
   visibility?: ReportVisibility;
   layout_json?: LayoutJson | Record<string, never>;
   canvas_filters_json?: CanvasFilters | Record<string, never>;
+}
+
+// ─── source catalog (GET /api/v1/reports/sources) ───────────────
+//
+// The self-describing data-source registry. Each entry declares the
+// dimensions, measures, and filters a source supports; the widget
+// editor drives its pickers off the selected source's catalog so a
+// widget can never offer (and then 422 on) an out-of-source field.
+
+export interface SourceCatalogFilter {
+  field: string;
+  label: string;
+  ops: string[];
+  kind: string;
+}
+
+export interface SourceCatalogDimension {
+  key: string;
+  label: string;
+  kind: string;
+}
+
+export interface SourceCatalogMeasure {
+  key: string;
+  label: string;
+  agg: string;
+  field: string;
+  format: string;
+}
+
+export interface SourceCatalogEntry {
+  key: string;
+  label: string;
+  dimensions: SourceCatalogDimension[];
+  measures: SourceCatalogMeasure[];
+  filters: SourceCatalogFilter[];
 }

--- a/frontend/lib/reports/types.ts
+++ b/frontend/lib/reports/types.ts
@@ -28,7 +28,12 @@ export type Dataset = "transactions" | "accounts";
 
 export type Aggregation = "sum" | "count" | "avg" | "distinct";
 
-export type MeasureField = "amount" | "id" | "category_id" | "account_id";
+export type MeasureField =
+  | "amount"
+  | "id"
+  | "category_id"
+  | "account_id"
+  | "balance";
 
 export type Dimension =
   | "category"

--- a/frontend/lib/reports/use-report-sources.ts
+++ b/frontend/lib/reports/use-report-sources.ts
@@ -1,0 +1,36 @@
+"use client";
+
+/**
+ * `useReportSources` — fetches the self-describing data-source catalog
+ * from `GET /api/v1/reports/sources` (the registry the backend Phase 5
+ * work exposed). Each entry declares the dimensions, measures, and
+ * filters a source supports; the widget editor's Data tab drives its
+ * pickers off the selected source's catalog so a widget can never offer
+ * (and then 422 on) an out-of-source field.
+ *
+ * Mirrors the `AccountFilter` fetch idiom: `apiFetch` through SWR with
+ * `revalidateOnFocus: false`. `sources` defaults to `[]` so callers can
+ * render gracefully while loading.
+ */
+import useSWR from "swr";
+
+import { apiFetch } from "@/lib/api";
+import type { SourceCatalogEntry } from "@/lib/reports/types";
+
+const SOURCES_SWR_KEY = "/api/v1/reports/sources";
+
+async function fetchSources(): Promise<SourceCatalogEntry[]> {
+  return apiFetch<SourceCatalogEntry[]>("/api/v1/reports/sources");
+}
+
+export function useReportSources(): {
+  sources: SourceCatalogEntry[];
+  isLoading: boolean;
+} {
+  const { data, isLoading } = useSWR<SourceCatalogEntry[]>(
+    SOURCES_SWR_KEY,
+    fetchSources,
+    { revalidateOnFocus: false },
+  );
+  return { sources: data ?? [], isLoading };
+}

--- a/frontend/lib/reports/useReportQuery.ts
+++ b/frontend/lib/reports/useReportQuery.ts
@@ -11,7 +11,8 @@ import useSWR from "swr";
 import { useMemo } from "react";
 
 import { runQuery } from "./api";
-import { resolveFilters } from "./resolve";
+import { resolveFilters, sourceSupportsDateFilter } from "./resolve";
+import { useReportSources } from "./use-report-sources";
 import type {
   CanvasFilters,
   Measure,
@@ -39,9 +40,11 @@ export function useReportQuery(
   widget: Widget,
   canvasFilters: CanvasFilters | undefined,
 ): UseReportQueryResult {
+  const { sources } = useReportSources();
+  const supportsDate = sourceSupportsDateFilter(sources, widget.config.dataset);
   const query = useMemo<ReportsQuery>(() => {
-    return buildQueryAst(widget, canvasFilters);
-  }, [widget, canvasFilters]);
+    return buildQueryAst(widget, canvasFilters, supportsDate);
+  }, [widget, canvasFilters, supportsDate]);
 
   const swrKey = ["report-query", widget.id, JSON.stringify(query)];
   const { data, error, isLoading } = useSWR<ReportsQueryResponse>(
@@ -64,10 +67,15 @@ export function useReportQuery(
 export function buildQueryAst(
   widget: Widget,
   canvasFilters: CanvasFilters | undefined,
+  sourceSupportsDate = true,
 ): ReportsQuery {
   const widgetFilters: WidgetFilters | undefined =
     "filters" in widget.config ? widget.config.filters : undefined;
-  const filters = resolveFilters(canvasFilters, widgetFilters);
+  const filters = resolveFilters(
+    canvasFilters,
+    widgetFilters,
+    sourceSupportsDate,
+  );
 
   if (widget.type === "kpi") {
     return {
@@ -145,10 +153,15 @@ export function buildSeriesQueryAst(
   widget: Widget,
   measure: Measure,
   canvasFilters: CanvasFilters | undefined,
+  sourceSupportsDate = true,
 ): ReportsQuery {
   const widgetFilters: WidgetFilters | undefined =
     "filters" in widget.config ? widget.config.filters : undefined;
-  const filters = resolveFilters(canvasFilters, widgetFilters);
+  const filters = resolveFilters(
+    canvasFilters,
+    widgetFilters,
+    sourceSupportsDate,
+  );
   const dimensions =
     "dimensions" in widget.config ? widget.config.dimensions : [];
   const sort = "sort" in widget.config ? widget.config.sort : undefined;
@@ -183,9 +196,14 @@ export function useSeriesQueries(
   isLoading: boolean;
   error: Error | undefined;
 } {
+  const { sources } = useReportSources();
+  const supportsDate = sourceSupportsDateFilter(sources, widget.config.dataset);
   const queries = useMemo(
-    () => measures.map((m) => buildSeriesQueryAst(widget, m, canvasFilters)),
-    [widget, canvasFilters, measures],
+    () =>
+      measures.map((m) =>
+        buildSeriesQueryAst(widget, m, canvasFilters, supportsDate),
+      ),
+    [widget, canvasFilters, measures, supportsDate],
   );
   const swrKey = ["report-series-query", widget.id, JSON.stringify(queries)];
   const { data, error, isLoading } = useSWR<ReportsQueryResponse[]>(

--- a/frontend/tests/app/report-title-edit.test.tsx
+++ b/frontend/tests/app/report-title-edit.test.tsx
@@ -1,0 +1,262 @@
+import {
+  renderWithSWR,
+  fireEvent,
+  screen,
+  waitFor,
+} from "../utils/render-with-swr";
+
+// Stub the canvas (react-grid-layout) — jsdom can't measure container
+// width so the responsive grid silently collapses. The stub keeps the
+// render-tree shape so downstream interactions still work.
+vi.mock("@/components/reports/Canvas", () => ({
+  default: ({ layout, renderWidget }: {
+    layout: { widgets: { id: string }[] };
+    renderWidget: (w: { id: string }) => React.ReactNode;
+  }) => (
+    <div data-testid="reports-canvas">
+      {layout.widgets.map((w) => (
+        <div key={w.id} data-widget-id={w.id}>
+          {renderWidget(w as never)}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/reports/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/reports/api")>(
+    "@/lib/reports/api",
+  );
+  return {
+    ...actual,
+    getReport: vi.fn(),
+    saveLayout: vi.fn(),
+    runQuery: vi.fn(),
+    deleteReport: vi.fn(),
+    listVersions: vi.fn(),
+    restoreVersion: vi.fn(),
+    updateReport: vi.fn(),
+    duplicateReport: vi.fn(),
+  };
+});
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/auth/AuthProvider")
+  >("@/components/auth/AuthProvider");
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+  };
+});
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+const stableRouter = { push: pushMock, replace: replaceMock };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/reports/10",
+}));
+
+import ReportEditorPage from "@/app/reports/[id]/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import * as reportsApi from "@/lib/reports/api";
+
+const BASE_USER = {
+  id: 1,
+  username: "alice",
+  email: "alice@example.com",
+  first_name: "Alice",
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+function mockUser(featureReportsV2 = true) {
+  vi.mocked(useAuth).mockReturnValue({
+    user: BASE_USER as never,
+    loading: false,
+    needsSetup: false,
+    featureReportsV2,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+}
+
+function makeParams(id = "10") {
+  return { id };
+}
+
+const EMPTY_REPORT = {
+  id: 10,
+  owner_user_id: 1,
+  org_id: 1,
+  visibility: "private" as const,
+  name: "My report",
+  description: null,
+  layout_json: { version: 1 as const, widgets: [] },
+  canvas_filters_json: {},
+  schema_version: 1,
+  created_at: "2026-05-22T10:00:00",
+  updated_at: "2026-05-22T10:00:00",
+};
+
+const REPORT_WITH_WIDGET = {
+  ...EMPTY_REPORT,
+  layout_json: {
+    version: 1 as const,
+    widgets: [
+      {
+        id: "w_kpi",
+        type: "kpi" as const,
+        title: "Total",
+        grid: { x: 0, y: 0, w: 3, h: 2 },
+        config: {
+          dataset: "transactions" as const,
+          measure: { agg: "sum" as const, field: "amount" as const },
+          format: "currency" as const,
+        },
+      },
+    ],
+  },
+};
+
+describe("ReportEditorPage — inline title edit", () => {
+  const getReportMock = vi.mocked(reportsApi.getReport);
+  const runQueryMock = vi.mocked(reportsApi.runQuery);
+  const updateReportMock = vi.mocked(reportsApi.updateReport);
+
+  beforeEach(() => {
+    getReportMock.mockReset();
+    runQueryMock.mockReset();
+    updateReportMock.mockReset();
+    runQueryMock.mockResolvedValue({
+      rows: [],
+      meta: { row_count: 0, truncated: false, query_ms: 1 },
+    });
+    pushMock.mockReset();
+    replaceMock.mockReset();
+    // @ts-expect-error -- clear any matchMedia stub a prior test installed
+    delete window.matchMedia;
+  });
+
+  it("renders an editable title input in edit mode and PATCHes the new name on commit", async () => {
+    mockUser(true);
+    // Empty report → owner opens in edit mode automatically.
+    getReportMock.mockResolvedValue(EMPTY_REPORT as never);
+    updateReportMock.mockResolvedValue({
+      ...EMPTY_REPORT,
+      name: "Renamed report",
+      updated_at: "2026-05-22T11:00:00",
+    } as never);
+
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor");
+    const input = screen.getByLabelText("Report title") as HTMLInputElement;
+    expect(input.value).toBe("My report");
+
+    fireEvent.change(input, { target: { value: "Renamed report" } });
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(updateReportMock).toHaveBeenCalledWith(10, {
+        name: "Renamed report",
+      }),
+    );
+    // The header reflects the persisted name.
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText("Report title") as HTMLInputElement).value,
+      ).toBe("Renamed report"),
+    );
+  });
+
+  it("commits the rename on Enter as well as blur", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue(EMPTY_REPORT as never);
+    updateReportMock.mockResolvedValue({
+      ...EMPTY_REPORT,
+      name: "Via enter",
+    } as never);
+
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor");
+    const input = screen.getByLabelText("Report title");
+    fireEvent.change(input, { target: { value: "Via enter" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(updateReportMock).toHaveBeenCalledWith(10, { name: "Via enter" }),
+    );
+  });
+
+  it("does not PATCH when the name is unchanged", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue(EMPTY_REPORT as never);
+
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor");
+    const input = screen.getByLabelText("Report title");
+    fireEvent.blur(input);
+
+    expect(updateReportMock).not.toHaveBeenCalled();
+  });
+
+  it("reverts to the current name and does not PATCH when committed empty", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue(EMPTY_REPORT as never);
+
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor");
+    const input = screen.getByLabelText("Report title") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.blur(input);
+
+    expect(updateReportMock).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText("Report title") as HTMLInputElement).value,
+      ).toBe("My report"),
+    );
+  });
+
+  it("renders the title as static text (no input) in view mode", async () => {
+    mockUser(true);
+    // Report with a widget → owner opens in VIEW mode.
+    getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);
+
+    renderWithSWR(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("kpi-widget");
+    // View mode: no editable title input.
+    expect(screen.queryByLabelText("Report title")).toBeNull();
+    // The name still shows as static text.
+    expect(screen.getByText("My report")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/reports/config/controlConstants.test.ts
+++ b/frontend/tests/components/reports/config/controlConstants.test.ts
@@ -10,8 +10,9 @@ import {
   MAX_TABLE_COLUMNS,
   isMultiSeries,
   isSingleAggLocked,
+  measureFieldOptionsFor,
 } from "@/components/reports/config/controlConstants";
-import type { Widget } from "@/lib/reports/types";
+import type { SourceCatalogEntry, Widget } from "@/lib/reports/types";
 
 describe("widget-config control constants", () => {
   it("exposes the four aggregation values sum/count/avg/distinct", () => {
@@ -58,6 +59,41 @@ describe("widget-config control constants", () => {
     for (const type of single) {
       expect(isMultiSeries({ ...base, type } as unknown as Widget)).toBe(false);
     }
+  });
+
+  it("measureFieldOptionsFor returns distinct fields in catalog order with labels", () => {
+    const accounts: SourceCatalogEntry = {
+      key: "accounts",
+      label: "Accounts",
+      dimensions: [],
+      measures: [
+        { key: "sum_balance", label: "Sum of balance", agg: "sum", field: "balance", format: "currency" },
+        { key: "avg_balance", label: "Average balance", agg: "avg", field: "balance", format: "currency" },
+        { key: "count_accounts", label: "Account count", agg: "count", field: "id", format: "number" },
+      ],
+      filters: [],
+    };
+    // balance appears twice in the catalog (sum + avg) → one option;
+    // labels come from MEASURE_FIELD_LABELS ("Balance"/"Row count").
+    expect(measureFieldOptionsFor(accounts)).toEqual([
+      { value: "balance", label: "Balance" },
+      { value: "id", label: "Row count" },
+    ]);
+  });
+
+  it("measureFieldOptionsFor falls back to the raw field for unknown keys", () => {
+    const entry: SourceCatalogEntry = {
+      key: "mystery",
+      label: "Mystery",
+      dimensions: [],
+      measures: [
+        { key: "k", label: "K", agg: "sum", field: "unknown_field", format: "number" },
+      ],
+      filters: [],
+    };
+    expect(measureFieldOptionsFor(entry)).toEqual([
+      { value: "unknown_field", label: "unknown_field" },
+    ]);
   });
 
   it("isSingleAggLocked is true only for pie/sparkline", () => {

--- a/frontend/tests/components/reports/data-tab-source-picker.test.tsx
+++ b/frontend/tests/components/reports/data-tab-source-picker.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * DataTab source picker — the catalog-driven `Data source` select.
+ *
+ * The picker is now live: it lists every source from
+ * `useReportSources()` and, on switch, resets any dimension that the
+ * new source's catalog doesn't carry (otherwise the widget would 422
+ * at query time against the backend `validate()`). These tests mock the
+ * SWR hook to a two-source catalog and assert both behaviors.
+ */
+import { renderWithSWR, fireEvent, screen } from "../../utils/render-with-swr";
+
+import DataTab from "@/components/reports/config/DataTab";
+import type { BarWidget, SourceCatalogEntry, Widget } from "@/lib/reports/types";
+import { useReportSources } from "@/lib/reports/use-report-sources";
+
+vi.mock("@/lib/reports/use-report-sources", () => ({
+  useReportSources: vi.fn(),
+}));
+
+const CATALOG: SourceCatalogEntry[] = [
+  {
+    key: "transactions",
+    label: "Transactions",
+    dimensions: [
+      { key: "category", label: "Category", kind: "categorical" },
+      { key: "account", label: "Account", kind: "categorical" },
+      { key: "month", label: "Month", kind: "temporal" },
+    ],
+    measures: [
+      { key: "sum_amount", label: "Sum of amount", agg: "sum", field: "amount", format: "currency" },
+    ],
+    filters: [],
+  },
+  {
+    key: "accounts",
+    label: "Accounts",
+    dimensions: [
+      { key: "account_type", label: "Account type", kind: "categorical" },
+      { key: "currency", label: "Currency", kind: "categorical" },
+    ],
+    measures: [
+      { key: "sum_balance", label: "Sum of balance", agg: "sum", field: "balance", format: "currency" },
+    ],
+    filters: [],
+  },
+];
+
+beforeEach(() => {
+  vi.mocked(useReportSources).mockReturnValue({
+    sources: CATALOG,
+    isLoading: false,
+  });
+});
+
+function makeBar(): BarWidget {
+  return {
+    id: "w_bar",
+    type: "bar",
+    title: "Bar",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+    },
+  };
+}
+
+it("enables the Data source select and lists every catalog source", () => {
+  renderWithSWR(<DataTab widget={makeBar()} onUpdate={vi.fn()} />);
+
+  const select = screen.getByLabelText("Data source") as HTMLSelectElement;
+  expect(select).not.toBeDisabled();
+  expect(
+    screen.getByRole("option", { name: "Accounts" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("option", { name: "Transactions" }),
+  ).toBeInTheDocument();
+});
+
+it("switches dataset and drops a now-invalid dimension on source change", () => {
+  const onUpdate = vi.fn();
+  renderWithSWR(<DataTab widget={makeBar()} onUpdate={onUpdate} />);
+
+  fireEvent.change(screen.getByLabelText("Data source"), {
+    target: { value: "accounts" },
+  });
+
+  expect(onUpdate).toHaveBeenCalledTimes(1);
+  const next = onUpdate.mock.calls[0][0] as Widget;
+  expect(next.config.dataset).toBe("accounts");
+  // "category" is not in the accounts catalog — it must be gone, replaced
+  // by the accounts source's first dimension key.
+  const dims = (next.config as BarWidget["config"]).dimensions;
+  expect(dims).not.toContain("category");
+  expect(dims[0]).toBe("account_type");
+});

--- a/frontend/tests/components/reports/data-tab-source-picker.test.tsx
+++ b/frontend/tests/components/reports/data-tab-source-picker.test.tsx
@@ -13,6 +13,7 @@ import DataTab from "@/components/reports/config/DataTab";
 import type {
   BarWidget,
   KPIWidget,
+  LineWidget,
   SourceCatalogEntry,
   Widget,
 } from "@/lib/reports/types";
@@ -36,7 +37,15 @@ const CATALOG: SourceCatalogEntry[] = [
       { key: "avg_amount", label: "Average amount", agg: "avg", field: "amount", format: "currency" },
       { key: "count_rows", label: "Transaction count", agg: "count", field: "id", format: "number" },
     ],
-    filters: [],
+    filters: [
+      { field: "date", label: "Date", ops: ["between"], kind: "time" },
+      { field: "amount", label: "Amount", ops: ["between"], kind: "amount" },
+      { field: "category_id", label: "Category", ops: ["in"], kind: "category" },
+      { field: "account_id", label: "Account", ops: ["in"], kind: "account" },
+      { field: "txn_type", label: "Type", ops: ["eq"], kind: "type" },
+      { field: "status", label: "Status", ops: ["eq"], kind: "status" },
+      { field: "tag_name", label: "Tag", ops: ["in"], kind: "tag" },
+    ],
   },
   {
     key: "accounts",
@@ -50,7 +59,16 @@ const CATALOG: SourceCatalogEntry[] = [
       { key: "avg_balance", label: "Average balance", agg: "avg", field: "balance", format: "currency" },
       { key: "count_accounts", label: "Account count", agg: "count", field: "id", format: "number" },
     ],
-    filters: [],
+    // Accounts publishes account_id but NOT category_id / txn_type /
+    // amount / date / tag_name — a transactions widget's leftover
+    // filters on those fields must be pruned on switch.
+    filters: [
+      { field: "account_id", label: "Account", ops: ["in"], kind: "account" },
+      { field: "account_type", label: "Account type", ops: ["in"], kind: "account_type" },
+      { field: "currency", label: "Currency", ops: ["in"], kind: "currency" },
+      { field: "account_active", label: "Status", ops: ["eq"], kind: "boolean" },
+      { field: "balance", label: "Balance", ops: ["between"], kind: "number" },
+    ],
   },
 ];
 
@@ -99,6 +117,24 @@ function makeAccountsBar(): BarWidget {
       dataset: "accounts",
       measure: { agg: "sum", field: "balance" },
       dimensions: ["account_type"],
+    },
+  };
+}
+
+/** A multi-series (line) transactions widget with two amount series. */
+function makeLine(): LineWidget {
+  return {
+    id: "w_line",
+    type: "line",
+    title: "Line",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [
+        { measure: { agg: "sum", field: "amount" } },
+        { measure: { agg: "avg", field: "amount" } },
+      ],
+      dimensions: ["month"],
     },
   };
 }
@@ -195,28 +231,108 @@ it("switch back accounts→transactions resets dims + measure to valid defaults"
   expect(next.config.measure).toEqual({ agg: "sum", field: "amount" });
 });
 
+it("multi-series widget: switching to accounts collapses measures to one valid accounts series", () => {
+  const onUpdate = vi.fn();
+  renderWithSWR(<DataTab widget={makeLine()} onUpdate={onUpdate} />);
+
+  fireEvent.change(screen.getByLabelText("Data source"), {
+    target: { value: "accounts" },
+  });
+
+  expect(onUpdate).toHaveBeenCalledTimes(1);
+  const next = onUpdate.mock.calls[0][0] as LineWidget;
+  expect(next.config.dataset).toBe("accounts");
+  // Both source series referenced ``amount`` (a transactions-only field)
+  // → collapse to a single valid accounts series (sum_balance).
+  expect(next.config.measures).toHaveLength(1);
+  const accountsFields = new Set(["balance", "id"]);
+  for (const s of next.config.measures) {
+    expect(accountsFields.has(s.measure.field)).toBe(true);
+  }
+  expect(next.config.measures[0].measure).toEqual({
+    agg: "sum",
+    field: "balance",
+  });
+  // ``month`` isn't an accounts dimension → dropped, refilled with the
+  // accounts source's first dimension key.
+  expect(next.config.dimensions).not.toContain("month");
+  expect(next.config.dimensions[0]).toBe("account_type");
+});
+
+it("prunes stale per-widget filters the new source doesn't publish on switch", () => {
+  const onUpdate = vi.fn();
+  const widget: BarWidget = {
+    ...makeBar(),
+    config: {
+      ...makeBar().config,
+      filters: {
+        // Survives: accounts publishes ``account_id``.
+        account_ids: [1, 2],
+        // All pruned: accounts publishes none of these fields.
+        category_ids: [9],
+        txn_type: "expense",
+        amount_range: { min: 10 },
+        tag_names: ["foo"],
+        tag_match: "any",
+        date_range: { start: "2026-01-01", end: "2026-01-31" },
+      },
+    },
+  };
+  renderWithSWR(<DataTab widget={widget} onUpdate={onUpdate} />);
+
+  fireEvent.change(screen.getByLabelText("Data source"), {
+    target: { value: "accounts" },
+  });
+
+  const next = onUpdate.mock.calls[0][0] as BarWidget;
+  expect(next.config.dataset).toBe("accounts");
+  // Only ``account_ids`` (→ account_id, published by accounts) survives.
+  expect(next.config.filters).toEqual({ account_ids: [1, 2] });
+});
+
+it("drops the whole filters blob when no widget filter survives the switch", () => {
+  const onUpdate = vi.fn();
+  const widget: BarWidget = {
+    ...makeBar(),
+    config: {
+      ...makeBar().config,
+      filters: { category_ids: [9], txn_type: "expense" },
+    },
+  };
+  renderWithSWR(<DataTab widget={widget} onUpdate={onUpdate} />);
+
+  fireEvent.change(screen.getByLabelText("Data source"), {
+    target: { value: "accounts" },
+  });
+
+  const next = onUpdate.mock.calls[0][0] as BarWidget;
+  // category_ids + txn_type both unpublished by accounts → no filters.
+  expect(next.config.filters).toBeUndefined();
+});
+
 it("persisted accounts widget rendered before /sources resolves has no value/options mismatch", () => {
   // Catalog still loading: sources empty. The accounts widget's stored
   // dimension (``account_type``) and field (``balance``) must still have a
-  // matching <option> so no React "value not in options" warning fires.
+  // matching <option> so the rendered selects' values are valid options.
   vi.mocked(useReportSources).mockReturnValue({
     sources: [],
     isLoading: true,
   });
-  const warn = vi.spyOn(console, "error").mockImplementation(() => {});
 
   renderWithSWR(<DataTab widget={makeAccountsBar()} onUpdate={vi.fn()} />);
 
+  // Assert positively that every controlled select's value is one of its
+  // own option values — a real "value not in options" mismatch would
+  // leave the select with an empty/absent value here.
   const dimSelect = screen.getByLabelText("Primary dimension") as HTMLSelectElement;
   expect(dimSelect.value).toBe("account_type");
   expect(
-    Array.from(dimSelect.options).some((o) => o.value === "account_type"),
-  ).toBe(true);
-  // No controlled-select value/options mismatch warning.
-  expect(warn).not.toHaveBeenCalledWith(
-    expect.stringContaining("value"),
-    expect.anything(),
-    expect.anything(),
-  );
-  warn.mockRestore();
+    Array.from(dimSelect.options).map((o) => o.value),
+  ).toContain(dimSelect.value);
+
+  const fieldSelect = screen.getByLabelText("Field") as HTMLSelectElement;
+  expect(fieldSelect.value).toBe("balance");
+  expect(
+    Array.from(fieldSelect.options).map((o) => o.value),
+  ).toContain(fieldSelect.value);
 });

--- a/frontend/tests/components/reports/data-tab-source-picker.test.tsx
+++ b/frontend/tests/components/reports/data-tab-source-picker.test.tsx
@@ -10,7 +10,12 @@
 import { renderWithSWR, fireEvent, screen } from "../../utils/render-with-swr";
 
 import DataTab from "@/components/reports/config/DataTab";
-import type { BarWidget, SourceCatalogEntry, Widget } from "@/lib/reports/types";
+import type {
+  BarWidget,
+  KPIWidget,
+  SourceCatalogEntry,
+  Widget,
+} from "@/lib/reports/types";
 import { useReportSources } from "@/lib/reports/use-report-sources";
 
 vi.mock("@/lib/reports/use-report-sources", () => ({
@@ -28,6 +33,8 @@ const CATALOG: SourceCatalogEntry[] = [
     ],
     measures: [
       { key: "sum_amount", label: "Sum of amount", agg: "sum", field: "amount", format: "currency" },
+      { key: "avg_amount", label: "Average amount", agg: "avg", field: "amount", format: "currency" },
+      { key: "count_rows", label: "Transaction count", agg: "count", field: "id", format: "number" },
     ],
     filters: [],
   },
@@ -40,6 +47,8 @@ const CATALOG: SourceCatalogEntry[] = [
     ],
     measures: [
       { key: "sum_balance", label: "Sum of balance", agg: "sum", field: "balance", format: "currency" },
+      { key: "avg_balance", label: "Average balance", agg: "avg", field: "balance", format: "currency" },
+      { key: "count_accounts", label: "Account count", agg: "count", field: "id", format: "number" },
     ],
     filters: [],
   },
@@ -62,6 +71,34 @@ function makeBar(): BarWidget {
       dataset: "transactions",
       measure: { agg: "sum", field: "amount" },
       dimensions: ["category"],
+    },
+  };
+}
+
+function makeKpi(): KPIWidget {
+  return {
+    id: "w_kpi",
+    type: "kpi",
+    title: "KPI",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+    },
+  };
+}
+
+/** A persisted accounts-source bar widget (the saved-and-reopened case). */
+function makeAccountsBar(): BarWidget {
+  return {
+    id: "w_acct_bar",
+    type: "bar",
+    title: "Accounts bar",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "accounts",
+      measure: { agg: "sum", field: "balance" },
+      dimensions: ["account_type"],
     },
   };
 }
@@ -95,4 +132,91 @@ it("switches dataset and drops a now-invalid dimension on source change", () => 
   const dims = (next.config as BarWidget["config"]).dimensions;
   expect(dims).not.toContain("category");
   expect(dims[0]).toBe("account_type");
+});
+
+it("narrows measure FIELD options to the accounts source (balance, not amount)", () => {
+  // Render a widget already on the accounts source so the field select is
+  // driven by the accounts catalog.
+  renderWithSWR(<DataTab widget={makeAccountsBar()} onUpdate={vi.fn()} />);
+
+  const fieldSelect = screen.getByLabelText("Field") as HTMLSelectElement;
+  const optionValues = Array.from(fieldSelect.options).map((o) => o.value);
+  expect(optionValues).toContain("balance");
+  expect(optionValues).not.toContain("amount");
+  // The distinct fields the accounts source publishes: balance + id.
+  expect(optionValues).toEqual(["balance", "id"]);
+});
+
+it("resets the measure to a valid accounts measure on switch to accounts", () => {
+  const onUpdate = vi.fn();
+  renderWithSWR(<DataTab widget={makeBar()} onUpdate={onUpdate} />);
+
+  fireEvent.change(screen.getByLabelText("Data source"), {
+    target: { value: "accounts" },
+  });
+
+  const next = onUpdate.mock.calls[0][0] as BarWidget;
+  // The measure must NOT be left on the transactions field ``amount`` —
+  // that 422s at query time. It resets to the accounts source's first
+  // measure (sum_balance).
+  expect(next.config.measure.field).not.toBe("amount");
+  expect(next.config.measure).toEqual({ agg: "sum", field: "balance" });
+});
+
+it("KPI widget: switching source doesn't crash and resets its measure", () => {
+  const onUpdate = vi.fn();
+  renderWithSWR(<DataTab widget={makeKpi()} onUpdate={onUpdate} />);
+
+  fireEvent.change(screen.getByLabelText("Data source"), {
+    target: { value: "accounts" },
+  });
+
+  expect(onUpdate).toHaveBeenCalledTimes(1);
+  const next = onUpdate.mock.calls[0][0] as KPIWidget;
+  expect(next.config.dataset).toBe("accounts");
+  expect(next.config.measure).toEqual({ agg: "sum", field: "balance" });
+});
+
+it("switch back accounts→transactions resets dims + measure to valid defaults", () => {
+  const onUpdate = vi.fn();
+  renderWithSWR(<DataTab widget={makeAccountsBar()} onUpdate={onUpdate} />);
+
+  fireEvent.change(screen.getByLabelText("Data source"), {
+    target: { value: "transactions" },
+  });
+
+  const next = onUpdate.mock.calls[0][0] as BarWidget;
+  expect(next.config.dataset).toBe("transactions");
+  // ``account_type`` isn't a transactions dimension → dropped, refilled
+  // with the transactions source's first dimension.
+  expect(next.config.dimensions).not.toContain("account_type");
+  expect(next.config.dimensions[0]).toBe("category");
+  // ``balance`` isn't a transactions field → measure reset to sum_amount.
+  expect(next.config.measure).toEqual({ agg: "sum", field: "amount" });
+});
+
+it("persisted accounts widget rendered before /sources resolves has no value/options mismatch", () => {
+  // Catalog still loading: sources empty. The accounts widget's stored
+  // dimension (``account_type``) and field (``balance``) must still have a
+  // matching <option> so no React "value not in options" warning fires.
+  vi.mocked(useReportSources).mockReturnValue({
+    sources: [],
+    isLoading: true,
+  });
+  const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  renderWithSWR(<DataTab widget={makeAccountsBar()} onUpdate={vi.fn()} />);
+
+  const dimSelect = screen.getByLabelText("Primary dimension") as HTMLSelectElement;
+  expect(dimSelect.value).toBe("account_type");
+  expect(
+    Array.from(dimSelect.options).some((o) => o.value === "account_type"),
+  ).toBe(true);
+  // No controlled-select value/options mismatch warning.
+  expect(warn).not.toHaveBeenCalledWith(
+    expect.stringContaining("value"),
+    expect.anything(),
+    expect.anything(),
+  );
+  warn.mockRestore();
 });

--- a/frontend/tests/lib/reports/describe-filters.test.ts
+++ b/frontend/tests/lib/reports/describe-filters.test.ts
@@ -124,6 +124,34 @@ describe("describeWidgetFilters", () => {
     expect(chips.find((c) => c.key === "date")).toBeUndefined();
   });
 
+  it("omits the date chip for a date-less source even with an effective date", () => {
+    const presets = buildPresetRanges(NOW);
+    // Same inputs as the inherited-date case, but the source doesn't
+    // support a date filter (accounts) → no date chip at all.
+    const chips = describeWidgetFilters(
+      bar({}),
+      { date_range: presets.this_month },
+      NO_LOOKUPS,
+      NOW,
+      false,
+    );
+    expect(chips.find((c) => c.key === "date")).toBeUndefined();
+  });
+
+  it("keeps non-date chips when the source is date-less", () => {
+    // A date-less source still surfaces account/category/txn_type chips —
+    // only the date chip is suppressed.
+    const chips = describeWidgetFilters(
+      bar({ txn_type: "expense" }),
+      { date_range: buildPresetRanges(NOW).this_month },
+      NO_LOOKUPS,
+      NOW,
+      false,
+    );
+    expect(chips.find((c) => c.key === "date")).toBeUndefined();
+    expect(chips.find((c) => c.key === "txn_type")).toBeDefined();
+  });
+
   it("resolves account ids to names with +N truncation", () => {
     const chips = describeWidgetFilters(
       bar({ account_ids: [1, 2, 3] }),

--- a/frontend/tests/lib/reports/resolve-dataset.test.tsx
+++ b/frontend/tests/lib/reports/resolve-dataset.test.tsx
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import { buildQueryAst } from "@/lib/reports/useReportQuery";
+import { sourceSupportsDateFilter } from "@/lib/reports/resolve";
+import type {
+  BarWidget,
+  CanvasFilters,
+  SourceCatalogEntry,
+} from "@/lib/reports/types";
+
+/**
+ * Task 7 (Reports v3 Phase 5): the resolver must stamp the widget's
+ * ``dataset`` onto the AST and OMIT the shared canvas date filter for
+ * sources that don't publish a ``date`` filter field.
+ *
+ * The new ``accounts`` source has no ``date`` column, so cascading the
+ * canvas date range onto it is meaningless. The backend already drops a
+ * stray date filter on accounts, but the frontend shouldn't send one.
+ *
+ * A source supports a date filter iff its catalog ``filters`` list
+ * includes one with ``field === "date"`` — ``transactions`` does,
+ * ``accounts`` does not.
+ */
+
+const CANVAS_DATE: CanvasFilters = {
+  date_range: { start: "2026-01-01", end: "2026-01-31" },
+};
+
+const ACCOUNTS_SOURCE: SourceCatalogEntry = {
+  key: "accounts",
+  label: "Accounts",
+  dimensions: [
+    { key: "account_type", label: "Account type", kind: "category" },
+  ],
+  measures: [
+    {
+      key: "balance",
+      label: "Balance",
+      agg: "sum",
+      field: "balance",
+      format: "currency",
+    },
+  ],
+  // No ``date`` filter — accounts has no date column.
+  filters: [],
+};
+
+const TRANSACTIONS_SOURCE: SourceCatalogEntry = {
+  key: "transactions",
+  label: "Transactions",
+  dimensions: [{ key: "category", label: "Category", kind: "category" }],
+  measures: [
+    {
+      key: "amount_sum",
+      label: "Amount",
+      agg: "sum",
+      field: "amount",
+      format: "currency",
+    },
+  ],
+  filters: [
+    { field: "date", label: "Date", ops: ["between", "gte", "lte"], kind: "date" },
+  ],
+};
+
+const SOURCES: SourceCatalogEntry[] = [ACCOUNTS_SOURCE, TRANSACTIONS_SOURCE];
+
+function accountsBarWidget(): BarWidget {
+  return {
+    id: "w-accounts",
+    type: "bar",
+    title: "Balance by account type",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "accounts",
+      measure: { agg: "sum", field: "balance" },
+      dimensions: ["account_type"],
+    },
+  };
+}
+
+function transactionsBarWidget(): BarWidget {
+  return {
+    id: "w-transactions",
+    type: "bar",
+    title: "Spend by category",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+    },
+  };
+}
+
+describe("sourceSupportsDateFilter", () => {
+  it("is false for a source whose filters omit a date field", () => {
+    expect(sourceSupportsDateFilter(SOURCES, "accounts")).toBe(false);
+  });
+
+  it("is true for a source whose filters include a date field", () => {
+    expect(sourceSupportsDateFilter(SOURCES, "transactions")).toBe(true);
+  });
+
+  it("defaults to true when the catalog is empty (pre-load)", () => {
+    expect(sourceSupportsDateFilter([], "transactions")).toBe(true);
+    expect(sourceSupportsDateFilter([], "accounts")).toBe(true);
+  });
+
+  it("defaults to true when the source is not in the catalog", () => {
+    expect(sourceSupportsDateFilter([TRANSACTIONS_SOURCE], "accounts")).toBe(
+      true,
+    );
+  });
+});
+
+describe("buildQueryAst — dataset stamping + date-less source", () => {
+  it("stamps dataset='accounts' and OMITS the canvas date filter", () => {
+    const ast = buildQueryAst(
+      accountsBarWidget(),
+      CANVAS_DATE,
+      sourceSupportsDateFilter(SOURCES, "accounts"),
+    );
+    expect(ast.dataset).toBe("accounts");
+    expect(ast.filters.some((f) => f.field === "date")).toBe(false);
+  });
+
+  it("stamps dataset='transactions' and KEEPS the canvas date filter", () => {
+    const ast = buildQueryAst(
+      transactionsBarWidget(),
+      CANVAS_DATE,
+      sourceSupportsDateFilter(SOURCES, "transactions"),
+    );
+    expect(ast.dataset).toBe("transactions");
+    expect(ast.filters).toContainEqual({
+      field: "date",
+      op: "between",
+      value: ["2026-01-01", "2026-01-31"],
+    });
+  });
+
+  it("keeps the date filter by default when the catalog flag is omitted (pre-load safety)", () => {
+    const ast = buildQueryAst(transactionsBarWidget(), CANVAS_DATE);
+    expect(ast.filters).toContainEqual({
+      field: "date",
+      op: "between",
+      value: ["2026-01-01", "2026-01-31"],
+    });
+  });
+});

--- a/specs/2026-06-13-reports-v3-phase5-accounts-source-design.md
+++ b/specs/2026-06-13-reports-v3-phase5-accounts-source-design.md
@@ -1,0 +1,138 @@
+# Reports v3 — Phase 5: AccountsSource
+
+**Date:** 2026-06-13
+**Status:** design, architect-reviewed (pre-plan)
+**Scope:** add a second `ReportSource` (`accounts`) on the PR #441 registry. AccountsSource **only** this round; RecurringSource is a deliberate fast follow-on PR, not in scope here.
+
+## Goal
+
+Make the Reports v3 source registry genuinely pluggable by adding the first non-transactions source. Users can build widgets that report on their **accounts snapshot** — total/average balance and account counts, grouped by account, account type, currency, or active status. This proves the registry's extensibility (a source ships as one new file + a closed-enum widening, no new infra) and is the prerequisite shape for the harder NetWorth source (Phase 6, separate, decision-gated).
+
+`accounts` is a **snapshot table** (one row per account). `accounts.balance` is a stored `Numeric` column, so balance reporting is a single-table read plus one join to `account_types` — **no transaction reconstruction** (that is NetWorth/Phase 6 territory).
+
+## Non-goals
+
+- RecurringSource (follow-on PR, same plumbing).
+- NetWorthSource / asset-liability classification / balance reconstruction (Phase 6).
+- Multi-currency correctness beyond exposing `currency` as a grouping lever (see §7). Locale-aware formatting / per-feature cross-currency safety remain the future i18n/multi-currency project.
+- Time-series over accounts (no `created_at` bucketing — accounts are a snapshot).
+- `opening_balance` measures (trivial to add later; left out to keep the surface tight).
+
+## Reportable surface
+
+### Dimensions (group by)
+| Key | Label | `kind` | Source column |
+|---|---|---|---|
+| `account` | Account | `account` | `accounts.name` (existing dimension key) |
+| `account_type` | Account type | `account_type` | `account_types.name` (via FK join) |
+| `currency` | Currency | `currency` (new kind) | `accounts.currency` |
+| `account_active` | Status | `boolean` (new kind) | `accounts.is_active` → `"Active"`/`"Inactive"` |
+
+### Measures
+| Key | Label | Agg | Field | Format |
+|---|---|---|---|---|
+| `sum_balance` | Total balance | sum | `balance` | currency |
+| `avg_balance` | Average balance | avg | `balance` | currency |
+| `count_accounts` | Account count | count | `id` | number |
+
+### Filters (published in the `/sources` catalog — see §3, S1)
+| Field | Ops | `kind` |
+|---|---|---|
+| `account` (`account_id`) | `in` | `account` |
+| `account_type` | `eq`, `in` | `account_type` |
+| `currency` | `eq`, `in` | `currency` |
+| `account_active` | `eq` | `boolean` |
+| `balance` | `between`, `gte`, `lte` | (numeric) |
+
+**No `date` filter** — accounts have no date column. See §6 for how the canvas shared-date bar interacts.
+
+## Architecture
+
+### 1. Closed-enum widening — consolidate first, then widen
+`Dataset`, `Dimension`, `MeasureField`, and `Aggregation` are currently **duplicated** in `backend/app/schemas/reports_query.py` (the live-query AST) and `backend/app/schemas/report_layout.py` (the saved-layout JSON validator). They are value-identical today but encode two contracts; widening four enums in lockstep across two files is a silent-drift hazard exactly when we exercise it.
+
+**Step 1 (behavior-preserving):** extract the shared atoms — `Dataset`, `Dimension`, `MeasureField`, `Aggregation` — into a new `backend/app/schemas/reports_enums.py`; both `reports_query.py` and `report_layout.py` import from it. Layout-only enums (`WidgetType`, `WidgetFormat`) stay where they are. This is a mechanical no-op refactor and should be its own first task/commit so it reviews cleanly.
+
+**Step 2 (the widening), on the now-single enum:**
+- `Dataset += ACCOUNTS = "accounts"`
+- `Dimension += ACCOUNT_TYPE = "account_type"`, `CURRENCY = "currency"`, `ACCOUNT_ACTIVE = "account_active"`
+- `MeasureField += BALANCE = "balance"`
+- `FilterField += ACCOUNT_TYPE`, `CURRENCY`, `ACCOUNT_ACTIVE`, `BALANCE` (`FilterField` is AST-only, lives in `reports_query.py`)
+
+Enums stay closed → the AST still cannot describe SQL; anything off-whitelist is a 422 at Pydantic parse. **Belt-and-suspenders regardless of consolidation:** a test asserting `set(reports_query.Dataset) == set(report_layout.Dataset)` (and same for `Dimension`, `MeasureField`) so any future drift is a red test, not a blank widget.
+
+**No Alembic migration.** `Dataset`/`Dimension`/`MeasureField` values live inside the `layout_json` / `canvas_filters_json` **JSON** columns, not native DB enums; the query AST is request-body-only and never persisted as a typed column. Widening Python enums touches no DDL. The only DB objects (`accounts`, `account_types`) already exist.
+
+### 2. Validation split — Pydantic = sane, source = in-my-catalog
+The current `Measure._validate_agg_field` (`reports_query.py:146`) hardcodes "sum/avg require `field=='amount'`". Widening `MeasureField` with `balance` breaks this. Replace with a **source-agnostic numeric set**:
+
+```python
+NUMERIC_MEASURE_FIELDS = {MeasureField.AMOUNT, MeasureField.BALANCE}  # module-level, importable by tests
+```
+
+sum/avg require `field in NUMERIC_MEASURE_FIELDS`; count/distinct accept any whitelisted field. This does **not** weaken the whitelist — `field` is still a closed enum typed by Pydantic. The validator was always a *semantic sanity gate*, not the whitelist.
+
+**Per-source validity** moves to the source layer (keeps `schemas/` free of any import on `app.reports.sources`, which would be circular — sources already import the schemas):
+- Add `def validate(self, query: ReportsQuery) -> None: ...` to the `ReportSource` Protocol in `base.py`. Make it a **required Protocol method** (not optional / not `getattr`-defaulted) so a future source can't silently ship with no gate. (`@runtime_checkable` checks method presence only, not signature — back it with the registry-exhaustiveness test.)
+- Each source validates the AST against the catalog it already publishes: every `query.dimensions` key ∈ its `dimensions()`, `query.measure.field` valid for its `measures()`, every filter field ∈ its `filters()` (S1). On violation, raise `ValueError`.
+- `TransactionsSource.validate()` therefore rejects `sum(balance)` and `currency`-dimension etc. with a `ValueError` → 422, even though Pydantic now considers `sum(balance)` numerically sane.
+
+**Router wiring (the 422-vs-500 fix).** Today `run_query` → `_run_source_query` has no try/except; a raw `ValueError` would surface as **500** (confirmed: `main.py` has handlers for Pydantic `ValidationError`, `NotFoundError`, `ConflictError`, `RateLimitExceeded` — none catch a plain `ValueError`). `_run_source_query` must call `source.validate(ast)` before `build_rows` and map `ValueError` → `HTTPException(status_code=422, detail=...)`.
+
+### 3. `/sources` catalog must publish filterable fields (architect S1)
+Today the catalog publishes only dimensions + measures (`base.py` `SourceDimension`/`SourceMeasure`). The frontend filter editor and the date-applicability rule (§6) both need each source to declare **which filter fields it accepts, with which ops**. Without it the frontend hardcodes per-source filter knowledge — the exact drift the registry exists to kill.
+
+- Add a `SourceFilter` value object to `base.py`: `field: str`, `label: str`, `ops: list[str]`, `kind: str`.
+- Add `def filters(self) -> list[SourceFilter]: ...` to the Protocol.
+- Surface it through `/sources`: new `SourceFilterOut` in the response model; `list_sources` serializes `s.filters()` alongside dims/measures.
+- This catalog becomes the single source of truth read by BOTH `source.validate()` and the frontend editor.
+
+### 4. AccountsSource.build_rows
+New file `backend/app/reports/sources/accounts.py`, self-registering like `transactions.py`. A small compiler over `accounts` + `account_types` (single join on `account_type_id`, which is NOT NULL):
+- **Org-scoping is on `accounts.org_id` only** (the hard rule). Join `account_types` purely on the FK; do **not** also constrain `account_types.org_id` (avoids inner-joining away valid accounts; the FK already guarantees same-org). A test must assert an account in org A never appears in org B's results.
+- **Boolean → label normalization in Python after fetch**: MySQL returns `1`/`0`, SQLite `0`/`1`; map to stable `"Active"`/`"Inactive"` row keys in Python, never rely on the driver returning a Python bool from a GROUP BY expression. Mirror how transactions `status` (settled/pending) renders today.
+- **`build_rows` compiles only its own published filter fields** and structurally ignores anything else — it must be incapable of emitting SQL for `date` (or any non-accounts field). A stray `date` filter results in "filter dropped," never a 500.
+- Returns `(rows, meta)` with `row_count` / `truncated` / `query_ms`, coerced to `QueryMeta` at the router exactly like transactions.
+
+### 5. `kind` taxonomy guard
+`SourceDimension.kind` / `SourceFilter.kind` are free strings the frontend switches rendering on; a typo is a silent blank-control bug. Add new kinds `currency` and `boolean`, and add a test asserting every published `kind` across all sources ∈ a known set (`{category, account, status, type, tag, time, account_type, currency, boolean}`). (Closing it to an enum is optional; the test is the requirement.)
+
+## 6. Shared date bar interaction (architect Q5 — two-tier)
+The canvas shared-date bar (#448) is meaningless for an accounts widget. Lock **both** halves:
+- **Primary contract — frontend omits.** `resolve.ts` does not stamp the canvas date filter onto a widget whose source does not declare `date` in its catalog `filters()`. Driven by the catalog, not a hardcoded "accounts has no date."
+- **Defense-in-depth — source tolerates.** `source.validate()` uses a **two-tier** rule:
+  - A **shared-canvas field** (`date`, and the `account_ids`/`category_ids` carried by `CanvasFilters`) that is not applicable to this source → **silently drop**, do not 422. Rationale: a layout saved on a date-filtered canvas, or a resolve/bar race, must not break the widget.
+  - A **non-shared field** in the global `FilterField` enum but not in this source's catalog (e.g. `txn_type` sent to `accounts`) → **reject** (`ValueError` → 422). That is a malformed query, not a shared-bar artifact.
+- Define the shared-canvas drop-set explicitly in one place. `build_rows` must also structurally ignore dropped fields (§4). Test: a query with a `date` filter against `accounts` returns rows (date dropped) — not 422, not 500.
+
+## 7. Multi-currency `sum_balance` — documented limitation
+`accounts.currency` is per-account and free (`String(3)`, default `EUR`). `sum(balance)` across mixed-currency accounts adds EUR+USD into a meaningless number, yet `format="currency"`. Per operator decision, the chosen mitigation is **expose `currency` as a groupable/filterable dimension** so users can group balance by currency (and avoid mixing) — the lightest option, consistent with the app-wide "grouped, no symbol" stance.
+
+This spec **documents the limitation explicitly**: balance measures are only numerically meaningful when grouped by `currency` (or filtered to a single currency). A non-blocking `meta` warning when a balance measure is requested without a `currency` dimension and the org holds >1 currency is noted as an **optional follow-up**, not in scope (the operator chose the plain dimension over a default-group hint). Proper cross-currency safety is the future multi-currency project.
+
+## 8. Frontend
+- **New SWR hook** `frontend/lib/hooks/use-report-sources.ts` (or `lib/reports/`) fetching `/api/v1/reports/sources`. First consumer of the catalog.
+- **Source picker** in `components/reports/config/DataTab.tsx`: the `Data source` `<select>` is currently a `disabled` placeholder hardcoded to `transactions` (`DataTab.tsx:44-53`) — make it live, options from the catalog.
+- **Data-driven dims/measures:** today dimensions come from the hardcoded `DIMENSION_OPTIONS` in `controlConstants.ts` and measures from `SingleMeasureEditor`/`MeasuresEditor`. Drive the available dimension + measure options from the **selected source's** catalog entry. Switching source **resets** now-invalid dims/measures to the new source's defaults (do not leave a `category` dimension on an `accounts` widget).
+- **`resolve.ts`** stamps `dataset` from the widget config and applies the §6 date-omission for date-less sources.
+- New/existing widgets default to `dataset: "transactions"`.
+
+## 9. Test coverage (architect S4)
+- Per-source `validate()` rejects cross-source measure/dim: `sum(amount)` on `accounts` → 422; `category` dimension on `accounts` → 422; `sum(balance)` on `transactions` → 422.
+- Relaxed `NUMERIC_MEASURE_FIELDS` still rejects `sum(id)` / `sum(category_id)` at the Pydantic layer (422).
+- Date-tolerance: `date` filter against `accounts` returns rows (dropped), not 422/500. A non-shared inapplicable field (`txn_type` on `accounts`) → 422.
+- Enum set-equality test (§1).
+- Registry exhaustiveness assertion (extends the existing one): `accounts` is registered, and its catalog keys (dims/measures/filters) are a subset of the closed enums.
+- Org-isolation: an account in org A never appears in org B's accounts-source results.
+- Boolean-dimension key normalization across SQLite/MySQL → stable `"Active"`/`"Inactive"`.
+- `kind` taxonomy test (§5).
+- AccountsSource correctness: `sum_balance` grouped by `account_type` / `currency`; `count_accounts`; `avg_balance`; balance `between` filter.
+- Frontend: source picker renders from catalog; switching source resets invalid dims/measures; `resolve.ts` omits date for a date-less source; round-trip an accounts widget through save/load.
+
+## Files touched
+**Backend:** `schemas/reports_enums.py` (new), `schemas/reports_query.py`, `schemas/report_layout.py`, `reports/sources/base.py`, `reports/sources/accounts.py` (new), `reports/sources/__init__.py` (register), `routers/reports.py` (`_run_source_query` validate+422, `/sources` filters serialization, `SourceFilterOut`).
+**Frontend:** `lib/hooks/use-report-sources.ts` (new), `components/reports/config/DataTab.tsx`, `components/reports/config/controlConstants.ts`, `components/reports/config/SingleMeasureEditor.tsx` / `MeasuresEditor.tsx` (source-aware options), `lib/reports/resolve.ts`, `lib/reports/types.ts`.
+**No migration.**
+
+## Build / review process
+Subagent-driven execution with a review gate per task (per [[feedback_subagent_driven]] / [[feedback_subagent_execution_guardrails]]). Backend tests in an **isolated compose project** (`-p team-<name>`), never the default `pfv` stack. Frontend verification = `eslint . --quiet` + `tsc --noEmit` + full `vitest run` (all three; eslint is a CI gate). Fleet/self-review before merge, matching the rest of the Reports v3 wave.

--- a/specs/2026-06-14-reports-v3-phase5-accounts-source-plan.md
+++ b/specs/2026-06-14-reports-v3-phase5-accounts-source-plan.md
@@ -1014,6 +1014,84 @@ git commit -m "feat(reports): resolver omits canvas date filter for date-less so
 
 ---
 
+## Task 7b: Editable report title on the existing-report page
+
+**Bundled-in request (2026-06-14):** the new-report page has an editable name input, but the saved-report page renders the title as static text — no way to rename a report after creation, even though the backend `PATCH /{report_id}` and the `updateReport(id, payload)` client already support `name`. Close the UI gap.
+
+**Files:**
+- Modify: `app/reports/[id]/page.tsx` (static title at lines ~637-639; `updateReport` import; `setReport`)
+- Test: `tests/app/report-title-edit.test.tsx` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/app/report-title-edit.test.tsx
+// Render the report editor page in edit mode for an owned report and assert
+// the title is an editable input that PATCHes name on commit. Mock the
+// reports api module so updateReport is observable; mirror the mock setup
+// already used by the page's existing tests (check tests/app/ for the
+// report-editor render harness and reuse it — do NOT hand-roll SWR/auth).
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const updateReport = vi.fn(async (_id: number, payload: any) => ({
+  id: 1, name: payload.name, layout_json: {}, canvas_filters_json: {},
+}));
+vi.mock("@/lib/reports/api", async (orig) => ({
+  ...(await orig<typeof import("@/lib/reports/api")>()),
+  updateReport,
+}));
+
+test("in edit mode the title is editable and commits via updateReport", async () => {
+  // ...render the page for an owned report (reuse the existing harness),
+  // enter edit mode...
+  const input = await screen.findByLabelText("Report title");
+  fireEvent.change(input, { target: { value: "Q2 spending" } });
+  fireEvent.blur(input);
+  await waitFor(() =>
+    expect(updateReport).toHaveBeenCalledWith(1, { name: "Q2 spending" }),
+  );
+});
+
+test("in view mode the title is static text, not an input", async () => {
+  // ...render the page in view mode (not edit)...
+  expect(screen.queryByLabelText("Report title")).not.toBeInTheDocument();
+});
+```
+
+> Inspect `tests/app/` for the existing report-`[id]`-page render harness (auth/SWR/router mocks) and reuse it verbatim. The two assertions above are the contract; the surrounding setup must match the project's existing report-editor tests.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose exec frontend npx vitest run tests/app/report-title-edit.test.tsx`
+Expected: FAIL — no `Report title` input (title is a static `<span>`).
+
+- [ ] **Step 3: Implement the inline title editor**
+
+In `app/reports/[id]/page.tsx`, import `updateReport` from `@/lib/reports/api`. Replace the static title span (lines ~637-639):
+
+```tsx
+          <span className="text-sm font-semibold text-text-primary">
+            {report.name}
+          </span>
+```
+
+with an edit-mode-aware title. In `editModeActive`, render a text `<input aria-label="Report title">` seeded from `report.name`; on blur/Enter commit, if the trimmed value is non-empty AND changed, call `updateReport(report.id, { name: trimmed })`, `setReport(updated)`; empty → revert to the current name (do not persist a blank). In view mode keep the static span. Style the input to match the existing header typography (`text-sm font-semibold`), borderless until focus, so it reads as an inline-editable title, not a form field. Keep it independent of the layout `dirty`/Save flow — renaming is its own immediate PATCH (the backend already treats a rename as a non-snapshotting metadata change, per `reports.py:324-334`).
+
+- [ ] **Step 4: Run the test**
+
+Run: `docker compose exec frontend npx vitest run tests/app/report-title-edit.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/reports/\[id\]/page.tsx tests/app/report-title-edit.test.tsx
+git commit -m "feat(reports): inline-edit report title on the saved-report page"
+```
+
+---
+
 ## Task 8: Frontend verification gate
 
 **Files:** none — full-suite gate ([[reference_frontend_full_suite_verification]], [[reference_eslint_ci_gate_misses]]).

--- a/specs/2026-06-14-reports-v3-phase5-accounts-source-plan.md
+++ b/specs/2026-06-14-reports-v3-phase5-accounts-source-plan.md
@@ -1,0 +1,1056 @@
+# Reports v3 Phase 5 — AccountsSource Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a second `ReportSource` (`accounts`) to the Reports v3 registry so users can build widgets reporting on their accounts snapshot (balance / counts by account, type, currency, active status).
+
+**Architecture:** Widen the closed query-AST enums (consolidated first into one shared module), move per-source validity from Pydantic into a required `ReportSource.validate()` method, publish filterable fields through the `/sources` catalog, and add a small org-scoped `accounts`+`account_types` compiler. Frontend wires the (currently disabled) Data-tab source picker to the catalog and drives dims/measures from it.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2.0 async, Pydantic v2 (backend); Next.js/React/TypeScript/SWR/Vitest (frontend). Backend tests run in an **isolated compose project** (`-p team-<name>`), never the default `pfv` stack.
+
+**Reference spec:** `specs/2026-06-13-reports-v3-phase5-accounts-source-design.md`
+
+**Product default (flag at review):** AccountsSource includes **all** accounts regardless of `is_active`, matching existing transactions-report precedent; `account_active` is exposed as a dimension + filter so users can exclude inactive accounts explicitly. Operator may flip the default to active-only in review.
+
+---
+
+## File structure
+
+**Backend**
+- `app/schemas/reports_enums.py` — **new.** Shared closed atoms: `Dataset`, `Aggregation`, `MeasureField`, `Dimension`. Imported by both query + layout schemas.
+- `app/schemas/reports_query.py` — import shared atoms; widen `FilterField` (AST-only); relax `Measure` validator via `NUMERIC_MEASURE_FIELDS`.
+- `app/schemas/report_layout.py` — import shared atoms instead of redefining.
+- `app/reports/sources/base.py` — add `SourceFilter` value object; add `filters()` + `validate()` to the `ReportSource` Protocol; define the shared-canvas drop-set.
+- `app/reports/sources/transactions.py` — implement `filters()` + `validate()`.
+- `app/reports/sources/accounts.py` — **new.** Catalog + org-scoped compiler; self-registers.
+- `app/reports/sources/__init__.py` — import `accounts` so it registers.
+- `app/schemas/report_sources.py` — add `SourceFilterOut`; add `filters` to `SourceCatalogEntry`.
+- `app/routers/reports.py` — `_run_source_query` calls `validate()` and maps `ValueError`→422; `/sources` serializes `filters()`.
+
+**Frontend**
+- `lib/reports/use-report-sources.ts` — **new.** SWR hook over `/api/v1/reports/sources`.
+- `lib/reports/types.ts` — add `accounts` dataset + new dimension literals; `SourceCatalog*` types.
+- `components/reports/config/DataTab.tsx` — live source picker; source-driven dimension options; reset on switch.
+- `components/reports/config/controlConstants.ts` — helper to derive dimension/measure options from a catalog entry.
+- `lib/reports/resolve.ts` — stamp `dataset`; omit canvas date filter for date-less sources.
+
+**Tests**
+- `tests/services/test_report_sources_registry.py` — extend (drift, exhaustiveness, validate).
+- `tests/services/test_accounts_source.py` — **new.** Compiler correctness + org isolation + boolean labels.
+- `tests/routers/test_report_sources_endpoint.py` — extend (filters in catalog).
+- `tests/routers/test_reports_query_validation.py` — **new.** Cross-source 422 + date tolerance.
+- `tests/schemas/test_reports_enums_consistency.py` — **new.** Enum drift guard.
+- Frontend: `tests/components/reports/data-tab-source-picker.test.tsx`, `tests/lib/reports/resolve-dataset.test.tsx` — **new.**
+
+---
+
+## Task 1: Consolidate shared enums (behavior-preserving)
+
+**Files:**
+- Create: `app/schemas/reports_enums.py`
+- Modify: `app/schemas/reports_query.py`, `app/schemas/report_layout.py`
+- Test: `tests/schemas/test_reports_enums_consistency.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/schemas/test_reports_enums_consistency.py
+"""Guard against the two-copy enum drift the shared module exists to kill."""
+from app.schemas import reports_query, report_layout
+
+
+def test_shared_enum_atoms_are_the_same_object():
+    # After consolidation both modules re-export the SAME enum class.
+    assert reports_query.Dataset is report_layout.Dataset
+    assert reports_query.Dimension is report_layout.Dimension
+    assert reports_query.MeasureField is report_layout.MeasureField
+    assert reports_query.Aggregation is report_layout.Aggregation
+
+
+def test_dataset_values_unchanged_for_now():
+    assert {d.value for d in reports_query.Dataset} == {"transactions"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose -p team-accsrc exec backend pytest tests/schemas/test_reports_enums_consistency.py -v`
+Expected: FAIL — `reports_query.Dataset is report_layout.Dataset` is False (two distinct classes today).
+
+- [ ] **Step 3: Create the shared module**
+
+```python
+# app/schemas/reports_enums.py
+"""Shared closed enum atoms for the reports query AST and the saved-layout
+JSON validator. Both surfaces draw dataset / dimension / measure-field /
+aggregation from these closed enums so a value cannot drift between "what a
+saved widget references" and "what the live compiler accepts"."""
+from __future__ import annotations
+
+import enum
+
+
+class Dataset(str, enum.Enum):
+    TRANSACTIONS = "transactions"
+
+
+class Aggregation(str, enum.Enum):
+    SUM = "sum"
+    COUNT = "count"
+    AVG = "avg"
+    DISTINCT = "distinct"
+
+
+class MeasureField(str, enum.Enum):
+    AMOUNT = "amount"
+    ID = "id"
+    CATEGORY_ID = "category_id"
+    ACCOUNT_ID = "account_id"
+
+
+class Dimension(str, enum.Enum):
+    CATEGORY = "category"
+    CATEGORY_MASTER = "category_master"
+    ACCOUNT = "account"
+    TAG = "tag"
+    TXN_TYPE = "txn_type"
+    STATUS = "status"
+    MONTH = "month"
+    WEEK = "week"
+    DAY = "day"
+```
+
+- [ ] **Step 4: Re-export from `reports_query.py`**
+
+In `app/schemas/reports_query.py`, DELETE the local `class Dataset`, `class Aggregation`, `class MeasureField`, `class Dimension` definitions (keep their docstrings as a comment if useful) and replace with an import near the top (after the existing imports):
+
+```python
+from app.schemas.reports_enums import Aggregation, Dataset, Dimension, MeasureField
+```
+
+Leave `FilterField`, `FilterOp`, `Measure`, etc. in place. Everything referencing these names continues to work.
+
+- [ ] **Step 5: Re-export from `report_layout.py`**
+
+In `app/schemas/report_layout.py`, DELETE the local `class Dataset`, `class Aggregation`, `class MeasureField`, `class Dimension` (lines ~62-89) and add near the top imports:
+
+```python
+from app.schemas.reports_enums import Aggregation, Dataset, Dimension, MeasureField
+```
+
+Keep `WidgetType`, `WidgetFormat`, `SortBy`, `SortDir` local (layout-only).
+
+- [ ] **Step 6: Run the new test + the existing reports suites**
+
+Run: `docker compose -p team-accsrc exec backend pytest tests/schemas/test_reports_enums_consistency.py tests/services/test_report_sources_registry.py tests/routers/test_report_sources_endpoint.py -v`
+Expected: PASS (consolidation is behavior-preserving; the registry tests that import `from app.schemas.reports_query import Dimension` still resolve).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/schemas/reports_enums.py app/schemas/reports_query.py app/schemas/report_layout.py tests/schemas/test_reports_enums_consistency.py
+git commit -m "refactor(reports): extract shared query-AST enums into reports_enums"
+```
+
+---
+
+## Task 2: Widen enums for accounts + relax the Measure validator
+
+**Files:**
+- Modify: `app/schemas/reports_enums.py`, `app/schemas/reports_query.py`
+- Test: `tests/schemas/test_reports_enums_consistency.py` (extend), `tests/schemas/test_measure_numeric_validation.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/schemas/test_measure_numeric_validation.py
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.reports_query import (
+    Aggregation, Measure, MeasureField, NUMERIC_MEASURE_FIELDS,
+)
+
+
+def test_sum_balance_is_numerically_sane():
+    # balance is numeric → Pydantic accepts it (per-source layer gates source validity).
+    m = Measure(agg=Aggregation.SUM, field=MeasureField.BALANCE)
+    assert m.field is MeasureField.BALANCE
+
+
+def test_sum_id_still_rejected_at_pydantic():
+    with pytest.raises(ValidationError):
+        Measure(agg=Aggregation.SUM, field=MeasureField.ID)
+
+
+def test_numeric_set_is_amount_and_balance():
+    assert NUMERIC_MEASURE_FIELDS == {MeasureField.AMOUNT, MeasureField.BALANCE}
+```
+
+Append to `tests/schemas/test_reports_enums_consistency.py`:
+
+```python
+def test_accounts_dataset_and_new_dimensions_present():
+    from app.schemas.reports_query import Dataset, Dimension, MeasureField
+    assert "accounts" in {d.value for d in Dataset}
+    assert {"account_type", "currency", "account_active"}.issubset({d.value for d in Dimension})
+    assert "balance" in {f.value for f in MeasureField}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker compose -p team-accsrc exec backend pytest tests/schemas/test_measure_numeric_validation.py tests/schemas/test_reports_enums_consistency.py -v`
+Expected: FAIL — `NUMERIC_MEASURE_FIELDS` undefined; `accounts`/`balance` not in enums.
+
+- [ ] **Step 3: Widen the shared enums**
+
+In `app/schemas/reports_enums.py`:
+
+```python
+class Dataset(str, enum.Enum):
+    TRANSACTIONS = "transactions"
+    ACCOUNTS = "accounts"
+```
+
+```python
+class MeasureField(str, enum.Enum):
+    AMOUNT = "amount"
+    ID = "id"
+    CATEGORY_ID = "category_id"
+    ACCOUNT_ID = "account_id"
+    BALANCE = "balance"
+```
+
+```python
+class Dimension(str, enum.Enum):
+    CATEGORY = "category"
+    CATEGORY_MASTER = "category_master"
+    ACCOUNT = "account"
+    TAG = "tag"
+    TXN_TYPE = "txn_type"
+    STATUS = "status"
+    MONTH = "month"
+    WEEK = "week"
+    DAY = "day"
+    ACCOUNT_TYPE = "account_type"
+    CURRENCY = "currency"
+    ACCOUNT_ACTIVE = "account_active"
+```
+
+- [ ] **Step 4: Widen `FilterField` + relax the Measure validator in `reports_query.py`**
+
+Add to `FilterField` (the AST-only enum in `reports_query.py`):
+
+```python
+    ACCOUNT_TYPE = "account_type"
+    CURRENCY = "currency"
+    ACCOUNT_ACTIVE = "account_active"
+    BALANCE = "balance"
+```
+
+Add the module-level numeric set near the other caps (after `MAX_DATE_WINDOW_DAYS`):
+
+```python
+# Fields a SUM / AVG may target. Source-agnostic numeric sanity gate — the
+# per-source validate() still rejects a field the source does not publish.
+NUMERIC_MEASURE_FIELDS = {MeasureField.AMOUNT, MeasureField.BALANCE}
+```
+
+Replace `Measure._validate_agg_field` body:
+
+```python
+    @model_validator(mode="after")
+    def _validate_agg_field(self):
+        if self.agg in (Aggregation.SUM, Aggregation.AVG):
+            if self.field not in NUMERIC_MEASURE_FIELDS:
+                raise ValueError(
+                    f"agg={self.agg.value} requires a numeric field "
+                    f"{sorted(f.value for f in NUMERIC_MEASURE_FIELDS)}; "
+                    f"got field={self.field.value!r}"
+                )
+        return self
+```
+
+- [ ] **Step 5: Extend `FilterField` scalar coercion**
+
+In `_coerce_filter_scalar` (`reports_query.py`), add handling so the new filter fields coerce safely (place before the final unreachable raise):
+
+```python
+    if field is FilterField.ACCOUNT_TYPE:
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("account_type must be an integer id") from exc
+    if field is FilterField.CURRENCY:
+        v = str(value).strip().upper()
+        if not (len(v) == 3 and v.isalpha()):
+            raise ValueError("currency must be a 3-letter code")
+        return v
+    if field is FilterField.ACCOUNT_ACTIVE:
+        if isinstance(value, bool):
+            return value
+        v = str(value).strip().lower()
+        if v in ("true", "1", "active"):
+            return True
+        if v in ("false", "0", "inactive"):
+            return False
+        raise ValueError("account_active must be a boolean")
+    if field is FilterField.BALANCE:
+        return _coerce_decimal(value)
+```
+
+(`account` filtering reuses the existing `ACCOUNT_ID` field/coercion — `account_type` here is the type id.)
+
+- [ ] **Step 6: Run the tests**
+
+Run: `docker compose -p team-accsrc exec backend pytest tests/schemas/ -v`
+Expected: PASS.
+
+Note: `test_every_dataset_enum_value_has_a_registered_source` in `tests/services/test_report_sources_registry.py` will now FAIL (accounts dataset has no source yet) — that is expected and fixed in Task 4. Do not run that file green here.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/schemas/reports_enums.py app/schemas/reports_query.py tests/schemas/
+git commit -m "feat(reports): widen query-AST enums for the accounts source"
+```
+
+---
+
+## Task 3: Source catalog filters + Protocol `validate()`/`filters()` + router 422 wiring
+
+**Files:**
+- Modify: `app/reports/sources/base.py`, `app/reports/sources/transactions.py`, `app/schemas/report_sources.py`, `app/routers/reports.py`
+- Test: `tests/routers/test_reports_query_validation.py` (new), `tests/routers/test_report_sources_endpoint.py` (extend)
+
+- [ ] **Step 1: Write the failing validation test**
+
+```python
+# tests/routers/test_reports_query_validation.py
+"""Per-source validity is enforced after Pydantic parse and surfaces as 422."""
+import pytest
+
+from app.reports import sources as registry
+from app.schemas.reports_query import (
+    Aggregation, Dataset, Dimension, Filter, FilterField, FilterOp,
+    Measure, MeasureField, ReportsQuery,
+)
+
+
+def _q(dataset, measure, dims=None, filters=None):
+    return ReportsQuery(
+        dataset=dataset, measure=measure,
+        dimensions=dims or [], filters=filters or [],
+    )
+
+
+def test_transactions_rejects_balance_measure():
+    src = registry.get_source("transactions")
+    q = _q(Dataset.TRANSACTIONS, Measure(agg=Aggregation.SUM, field=MeasureField.BALANCE))
+    with pytest.raises(ValueError):
+        src.validate(q)
+
+
+def test_transactions_rejects_currency_dimension():
+    src = registry.get_source("transactions")
+    q = _q(Dataset.TRANSACTIONS,
+           Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+           dims=[Dimension.CURRENCY])
+    with pytest.raises(ValueError):
+        src.validate(q)
+
+
+def test_transactions_accepts_its_own_surface():
+    src = registry.get_source("transactions")
+    q = _q(Dataset.TRANSACTIONS,
+           Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+           dims=[Dimension.CATEGORY])
+    src.validate(q)  # no raise
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose -p team-accsrc exec backend pytest tests/routers/test_reports_query_validation.py -v`
+Expected: FAIL — `ReportSource` has no `validate` attribute.
+
+- [ ] **Step 3: Add `SourceFilter`, Protocol methods, and the shared-canvas drop-set in `base.py`**
+
+```python
+# add to app/reports/sources/base.py
+
+# Canvas-level shared filter fields (the #448 date bar + any canvas
+# account/category scoping). A source that does not publish one of these
+# SILENTLY DROPS it (it is a shared-bar artifact, not a malformed query);
+# any OTHER unpublished field is rejected. See spec §6.
+SHARED_CANVAS_FILTER_FIELDS = frozenset({"date", "account_id", "category_id"})
+
+
+@dataclass(frozen=True)
+class SourceFilter:
+    field: str          # AST FilterField value, e.g. "currency"
+    label: str          # human label for the editor
+    ops: tuple[str, ...]  # allowed FilterOp values, e.g. ("eq", "in")
+    kind: str           # control hint: account|account_type|currency|boolean|...
+```
+
+Add to the `ReportSource` Protocol (all required):
+
+```python
+    def filters(self) -> list[SourceFilter]: ...
+
+    def validate(self, query: ReportsQuery) -> None:
+        """Raise ValueError if the AST references a dimension / measure
+        field / filter field this source does not publish. Shared-canvas
+        fields that don't apply are dropped, not rejected (spec §6)."""
+        ...
+```
+
+Add a reusable default validator helper in `base.py` (sources call it):
+
+```python
+def validate_against_catalog(source: "ReportSource", query: ReportsQuery) -> None:
+    dim_keys = {d.key for d in source.dimensions()}
+    for dim in query.dimensions:
+        if dim.value not in dim_keys:
+            raise ValueError(
+                f"source {source.key!r} does not support dimension {dim.value!r}"
+            )
+    measure_fields = {m.field for m in source.measures()}
+    if query.measure.field.value not in measure_fields:
+        raise ValueError(
+            f"source {source.key!r} does not support measure field "
+            f"{query.measure.field.value!r}"
+        )
+    filter_fields = {f.field for f in source.filters()}
+    for f in query.filters:
+        if f.field.value in filter_fields:
+            continue
+        if f.field.value in SHARED_CANVAS_FILTER_FIELDS:
+            continue  # shared-bar artifact → dropped at build time
+        raise ValueError(
+            f"source {source.key!r} does not support filter field {f.field.value!r}"
+        )
+```
+
+- [ ] **Step 4: Implement `filters()` + `validate()` on `TransactionsSource`**
+
+```python
+# app/reports/sources/transactions.py
+from app.reports.sources.base import (
+    ReportSource, SourceDimension, SourceFilter, SourceMeasure,
+    validate_against_catalog,
+)
+
+_FILTERS = [
+    SourceFilter("date", "Date", ("between", "gte", "lte"), "time"),
+    SourceFilter("amount", "Amount", ("between", "gte", "lte", "eq"), "amount"),
+    SourceFilter("category_id", "Category", ("eq", "in"), "category"),
+    SourceFilter("account_id", "Account", ("eq", "in"), "account"),
+    SourceFilter("txn_type", "Type", ("eq", "in"), "type"),
+    SourceFilter("status", "Status", ("eq",), "status"),
+    SourceFilter("tag_name", "Tag", ("eq", "in"), "tag"),
+]
+
+# inside class TransactionsSource:
+    def filters(self) -> list[SourceFilter]:
+        return list(_FILTERS)
+
+    def validate(self, query: ReportsQuery) -> None:
+        validate_against_catalog(self, query)
+```
+
+- [ ] **Step 5: Run the validation test**
+
+Run: `docker compose -p team-accsrc exec backend pytest tests/routers/test_reports_query_validation.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Surface filters through `/sources` + wire router 422**
+
+In `app/schemas/report_sources.py`:
+
+```python
+class SourceFilterOut(BaseModel):
+    field: str
+    label: str
+    ops: list[str]
+    kind: str
+
+
+class SourceCatalogEntry(BaseModel):
+    key: str
+    label: str
+    dimensions: list[SourceDimensionOut]
+    measures: list[SourceMeasureOut]
+    filters: list[SourceFilterOut]
+```
+
+In `app/routers/reports.py` `list_sources`, add the filters serialization:
+
+```python
+            filters=[SourceFilterOut(**dataclasses.asdict(f)) for f in s.filters()],
+```
+
+(Import `SourceFilterOut` alongside the existing `SourceDimensionOut` import.)
+
+In `_run_source_query`, call validate before build and map ValueError → 422:
+
+```python
+async def _run_source_query(db: AsyncSession, ast: ReportsQuery, *, org_id: int):
+    source = get_source(ast.dataset.value)
+    try:
+        source.validate(ast)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return await source.build_rows(db, org_id, ast)
+```
+
+- [ ] **Step 7: Extend the catalog-endpoint test**
+
+In `tests/routers/test_report_sources_endpoint.py`, add an assertion that each entry has a non-empty `filters` list with `field`/`label`/`ops`/`kind` keys, and that the transactions entry includes a `date` filter.
+
+- [ ] **Step 8: Run the router tests**
+
+Run: `docker compose -p team-accsrc exec backend pytest tests/routers/test_report_sources_endpoint.py tests/routers/test_reports_query_validation.py -v`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/reports/sources/base.py app/reports/sources/transactions.py app/schemas/report_sources.py app/routers/reports.py tests/routers/
+git commit -m "feat(reports): publish source filters + per-source validate() with 422 wiring"
+```
+
+---
+
+## Task 4: AccountsSource (catalog + org-scoped compiler)
+
+**Files:**
+- Create: `app/reports/sources/accounts.py`
+- Modify: `app/reports/sources/__init__.py`
+- Test: `tests/services/test_accounts_source.py` (new), `tests/services/test_report_sources_registry.py` (extend)
+
+- [ ] **Step 1: Write the failing compiler test**
+
+```python
+# tests/services/test_accounts_source.py
+import pytest
+
+from app.reports import sources as registry
+from app.schemas.reports_query import (
+    Aggregation, Dataset, Dimension, Filter, FilterField, FilterOp,
+    Measure, MeasureField, ReportsQuery,
+)
+
+
+def _q(measure, dims=None, filters=None):
+    return ReportsQuery(dataset=Dataset.ACCOUNTS, measure=measure,
+                        dimensions=dims or [], filters=filters or [])
+
+
+@pytest.mark.asyncio
+async def test_sum_balance_by_account_type(db_session, accounts_fixture):
+    """accounts_fixture seeds org with: Checking(EUR,500,active),
+    Savings(EUR,1500,active), OldCard(EUR,-200,inactive) under types
+    'Bank'(Checking,Savings) and 'Card'(OldCard)."""
+    src = registry.get_source("accounts")
+    q = _q(Measure(agg=Aggregation.SUM, field=MeasureField.BALANCE),
+           dims=[Dimension.ACCOUNT_TYPE])
+    rows, meta = await src.build_rows(db_session, accounts_fixture.org_id, q)
+    by_type = {r["account_type"]: r["value"] for r in rows}
+    assert by_type["Bank"] == 2000.0   # 500 + 1500
+    assert by_type["Card"] == -200.0
+    assert meta["row_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_account_active_dimension_labels(db_session, accounts_fixture):
+    src = registry.get_source("accounts")
+    q = _q(Measure(agg=Aggregation.COUNT, field=MeasureField.ID),
+           dims=[Dimension.ACCOUNT_ACTIVE])
+    rows, _ = await src.build_rows(db_session, accounts_fixture.org_id, q)
+    by_status = {r["account_active"]: r["value"] for r in rows}
+    assert by_status == {"Active": 2, "Inactive": 1}
+
+
+@pytest.mark.asyncio
+async def test_org_isolation(db_session, accounts_fixture, other_org_account):
+    src = registry.get_source("accounts")
+    q = _q(Measure(agg=Aggregation.COUNT, field=MeasureField.ID))
+    rows, _ = await src.build_rows(db_session, accounts_fixture.org_id, q)
+    # other_org_account belongs to a different org and must not be counted.
+    assert rows[0]["value"] == 3
+
+
+@pytest.mark.asyncio
+async def test_date_filter_is_dropped_not_errored(db_session, accounts_fixture):
+    src = registry.get_source("accounts")
+    q = _q(Measure(agg=Aggregation.COUNT, field=MeasureField.ID),
+           filters=[Filter(field=FilterField.DATE, op=FilterOp.BETWEEN,
+                           value=["2020-01-01", "2020-12-31"])])
+    src.validate(q)  # tolerated (shared-canvas field)
+    rows, _ = await src.build_rows(db_session, accounts_fixture.org_id, q)
+    assert rows[0]["value"] == 3  # date predicate ignored
+
+
+@pytest.mark.asyncio
+async def test_currency_filter_and_dimension(db_session, accounts_fixture):
+    src = registry.get_source("accounts")
+    q = _q(Measure(agg=Aggregation.SUM, field=MeasureField.BALANCE),
+           dims=[Dimension.CURRENCY],
+           filters=[Filter(field=FilterField.CURRENCY, op=FilterOp.EQ, value="EUR")])
+    rows, _ = await src.build_rows(db_session, accounts_fixture.org_id, q)
+    assert {r["currency"] for r in rows} == {"EUR"}
+
+
+def test_accounts_rejects_transactions_field():
+    src = registry.get_source("accounts")
+    q = _q(Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT))
+    with pytest.raises(ValueError):
+        src.validate(q)
+```
+
+> **Fixtures:** add `accounts_fixture` and `other_org_account` to `tests/conftest.py` (or the nearest reports conftest), mirroring existing account-seeding fixtures. `accounts_fixture` returns an object exposing `.org_id` and seeds the three accounts + two `account_types` described above. `other_org_account` seeds one account under a second org. Check `tests/conftest.py` for the existing org/account factory pattern and reuse it; do NOT hand-roll session/engine setup.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose -p team-accsrc exec backend pytest tests/services/test_accounts_source.py -v`
+Expected: FAIL — `get_source("accounts")` raises KeyError (not registered).
+
+- [ ] **Step 3: Implement `accounts.py`**
+
+```python
+# app/reports/sources/accounts.py
+"""Accounts source — a snapshot over accounts + account_types.
+
+One row per account; no time dimension. balance / opening_balance are
+stored columns, so this is a single join with no transaction reconstruction
+(NetWorth/Phase 6 is the reconstruction case). Every query is scoped to
+accounts.org_id; account_types is joined on the FK only.
+"""
+from __future__ import annotations
+
+import time
+
+from sqlalchemy import case, distinct, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account, AccountType
+from app.reports.sources import register
+from app.reports.sources.base import (
+    ReportSource, SourceDimension, SourceFilter, SourceMeasure,
+    validate_against_catalog,
+)
+from app.schemas.reports_query import (
+    Aggregation, Dimension, FilterField, FilterOp, MeasureField, ReportsQuery,
+)
+
+_DIMENSIONS = [
+    SourceDimension("account", "Account", "account"),
+    SourceDimension("account_type", "Account type", "account_type"),
+    SourceDimension("currency", "Currency", "currency"),
+    SourceDimension("account_active", "Status", "boolean"),
+]
+
+_MEASURES = [
+    SourceMeasure("sum_balance", "Total balance", "sum", "balance", "currency"),
+    SourceMeasure("avg_balance", "Average balance", "avg", "balance", "currency"),
+    SourceMeasure("count_accounts", "Account count", "count", "id", "number"),
+]
+
+_FILTERS = [
+    SourceFilter("account_id", "Account", ("in",), "account"),
+    SourceFilter("account_type", "Account type", ("eq", "in"), "account_type"),
+    SourceFilter("currency", "Currency", ("eq", "in"), "currency"),
+    SourceFilter("account_active", "Status", ("eq",), "boolean"),
+    SourceFilter("balance", "Balance", ("between", "gte", "lte"), "number"),
+]
+
+# Active/inactive rendered as stable string keys in Python (drivers return
+# 1/0 from a GROUP BY boolean expression — never rely on a Python bool).
+_ACTIVE_LABEL = case((Account.is_active.is_(True), "Active"), else_="Inactive")
+
+_DIM_EXPR = {
+    Dimension.ACCOUNT: (Account.name, "account"),
+    Dimension.ACCOUNT_TYPE: (AccountType.name, "account_type"),
+    Dimension.CURRENCY: (Account.currency, "currency"),
+    Dimension.ACCOUNT_ACTIVE: (_ACTIVE_LABEL, "account_active"),
+}
+
+_MEASURE_COL = {
+    MeasureField.BALANCE: Account.balance,
+    MeasureField.ID: Account.id,
+}
+
+
+def _measure_expr(measure):
+    col = _MEASURE_COL[measure.field]
+    if measure.agg is Aggregation.SUM:
+        return func.coalesce(func.sum(col), 0).label("value")
+    if measure.agg is Aggregation.AVG:
+        return func.coalesce(func.avg(col), 0).label("value")
+    if measure.agg is Aggregation.DISTINCT:
+        return func.count(distinct(col)).label("value")
+    return func.count(col).label("value")  # COUNT
+
+
+def _apply_filter(stmt, f):
+    # date / category_id / unknown shared-canvas fields are silently dropped.
+    if f.field is FilterField.ACCOUNT_ID:
+        return stmt.where(Account.id.in_(f.value)) if f.op is FilterOp.IN \
+            else stmt.where(Account.id == f.value)
+    if f.field is FilterField.ACCOUNT_TYPE:
+        return stmt.where(Account.account_type_id.in_(f.value)) if f.op is FilterOp.IN \
+            else stmt.where(Account.account_type_id == f.value)
+    if f.field is FilterField.CURRENCY:
+        return stmt.where(Account.currency.in_(f.value)) if f.op is FilterOp.IN \
+            else stmt.where(Account.currency == f.value)
+    if f.field is FilterField.ACCOUNT_ACTIVE:
+        return stmt.where(Account.is_active.is_(bool(f.value)))
+    if f.field is FilterField.BALANCE:
+        if f.op is FilterOp.BETWEEN:
+            return stmt.where(Account.balance.between(f.value[0], f.value[1]))
+        if f.op is FilterOp.GTE:
+            return stmt.where(Account.balance >= f.value)
+        if f.op is FilterOp.LTE:
+            return stmt.where(Account.balance <= f.value)
+    return stmt  # dropped
+
+
+class AccountsSource:
+    key = "accounts"
+    label = "Accounts"
+
+    def dimensions(self): return list(_DIMENSIONS)
+    def measures(self): return list(_MEASURES)
+    def filters(self): return list(_FILTERS)
+
+    def validate(self, query: ReportsQuery) -> None:
+        validate_against_catalog(self, query)
+
+    async def build_rows(self, db: AsyncSession, org_id: int, query: ReportsQuery):
+        dim_exprs = [_DIM_EXPR[d] for d in query.dimensions]
+        cols = [expr.label(key) for expr, key in dim_exprs]
+        stmt = (
+            select(*cols, _measure_expr(query.measure))
+            .select_from(Account)
+            .join(AccountType, AccountType.id == Account.account_type_id)
+            .where(Account.org_id == org_id)
+        )
+        for f in query.filters:
+            stmt = _apply_filter(stmt, f)
+        if dim_exprs:
+            stmt = stmt.group_by(*[expr for expr, _ in dim_exprs])
+        stmt = stmt.limit(query.limit)
+
+        started = time.perf_counter()
+        result = await db.execute(stmt)
+        rows = result.mappings().all()
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+
+        out = []
+        for r in rows:
+            d = {key: r.get(key) for _, key in dim_exprs}
+            val = r.get("value")
+            d["value"] = float(val) if hasattr(val, "as_tuple") else val
+            out.append(d)
+        meta = {"row_count": len(out), "truncated": len(out) >= query.limit,
+                "query_ms": elapsed_ms}
+        return out, meta
+
+
+register(AccountsSource())
+```
+
+- [ ] **Step 4: Register the module**
+
+In `app/reports/sources/__init__.py`, add next to the transactions import at the bottom:
+
+```python
+from app.reports.sources import accounts as _accounts  # noqa: E402,F401
+```
+
+- [ ] **Step 5: Run the accounts tests**
+
+Run: `docker compose -p team-accsrc exec backend pytest tests/services/test_accounts_source.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Extend the registry tests + run them green**
+
+In `tests/services/test_report_sources_registry.py`, add:
+
+```python
+def test_accounts_source_catalog():
+    src = source_registry.get_source("accounts")
+    assert src.key == "accounts"
+    assert {d.key for d in src.dimensions()} == {
+        "account", "account_type", "currency", "account_active"}
+    assert {m.key for m in src.measures()} == {
+        "sum_balance", "avg_balance", "count_accounts"}
+    assert {f.field for f in src.filters()} == {
+        "account_id", "account_type", "currency", "account_active", "balance"}
+
+
+def test_all_catalog_keys_are_known_kinds():
+    known = {"category", "account", "status", "type", "tag", "time",
+             "account_type", "currency", "boolean", "amount", "number"}
+    for s in source_registry.all_sources():
+        for d in s.dimensions():
+            assert d.kind in known, f"{s.key}:{d.key} bad kind {d.kind}"
+        for f in s.filters():
+            assert f.kind in known, f"{s.key}:{f.field} bad kind {f.kind}"
+
+
+def test_every_source_catalog_keys_subset_of_closed_enums():
+    from app.schemas.reports_query import Dimension, MeasureField, FilterField
+    dims = {d.value for d in Dimension}
+    fields = {f.value for f in MeasureField}
+    filt = {f.value for f in FilterField}
+    for s in source_registry.all_sources():
+        assert {d.key for d in s.dimensions()}.issubset(dims)
+        assert {m.field for m in s.measures()}.issubset(fields)
+        assert {f.field for f in s.filters()}.issubset(filt)
+```
+
+Run: `docker compose -p team-accsrc exec backend pytest tests/services/test_report_sources_registry.py -v`
+Expected: PASS — including `test_every_dataset_enum_value_has_a_registered_source` (accounts now registered).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/reports/sources/accounts.py app/reports/sources/__init__.py tests/services/
+git commit -m "feat(reports): add AccountsSource (balance/count over accounts snapshot)"
+```
+
+---
+
+## Task 5: Backend suite sweep
+
+**Files:** none new — verification gate.
+
+- [ ] **Step 1: Run the full reports backend surface**
+
+Run: `docker compose -p team-accsrc exec backend pytest tests/schemas/ tests/services/test_report_sources_registry.py tests/services/test_accounts_source.py tests/routers/test_report_sources_endpoint.py tests/routers/test_reports_query_validation.py -v`
+Expected: all PASS.
+
+- [ ] **Step 2: Run the existing reports query suite (regression)**
+
+Run: `docker compose -p team-accsrc exec backend pytest tests/ -k "report" -v`
+Expected: all PASS — transactions path byte-for-byte unchanged.
+
+- [ ] **Step 3: Commit (only if any fixup was needed)**
+
+```bash
+git commit -am "test(reports): backend suite green for accounts source" || true
+```
+
+---
+
+## Task 6: Frontend — source picker driven by the catalog
+
+**Files:**
+- Create: `lib/reports/use-report-sources.ts`
+- Modify: `lib/reports/types.ts`, `components/reports/config/DataTab.tsx`, `components/reports/config/controlConstants.ts`
+- Test: `tests/components/reports/data-tab-source-picker.test.tsx`
+
+- [ ] **Step 1: Add types**
+
+In `lib/reports/types.ts`: extend the `Dataset` union to `"transactions" | "accounts"`; add the new dimension literals (`"account_type" | "currency" | "account_active"`) to the `Dimension` union; add catalog types:
+
+```typescript
+export interface SourceCatalogFilter { field: string; label: string; ops: string[]; kind: string; }
+export interface SourceCatalogDimension { key: string; label: string; kind: string; }
+export interface SourceCatalogMeasure { key: string; label: string; agg: string; field: string; format: string; }
+export interface SourceCatalogEntry {
+  key: string; label: string;
+  dimensions: SourceCatalogDimension[];
+  measures: SourceCatalogMeasure[];
+  filters: SourceCatalogFilter[];
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```tsx
+// tests/components/reports/data-tab-source-picker.test.tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import DataTab from "@/components/reports/config/DataTab";
+// Use the project's catalog-mock helper. The hook must be mockable; mock
+// useReportSources to return a two-source catalog (transactions + accounts).
+
+vi.mock("@/lib/reports/use-report-sources", () => ({
+  useReportSources: () => ({
+    sources: [
+      { key: "transactions", label: "Transactions",
+        dimensions: [{ key: "category", label: "Category", kind: "category" }],
+        measures: [], filters: [] },
+      { key: "accounts", label: "Accounts",
+        dimensions: [{ key: "account_type", label: "Account type", kind: "account_type" }],
+        measures: [], filters: [] },
+    ],
+    isLoading: false,
+  }),
+}));
+
+test("source picker is enabled and lists catalog sources", () => {
+  const widget = { type: "bar", config: { dataset: "transactions", measure: { agg: "sum", field: "amount" } } } as any;
+  render(<DataTab widget={widget} onUpdate={() => {}} />);
+  const picker = screen.getByLabelText("Data source") as HTMLSelectElement;
+  expect(picker.disabled).toBe(false);
+  expect(screen.getByRole("option", { name: "Accounts" })).toBeInTheDocument();
+});
+
+test("switching source resets dimension to the new source's first option", () => {
+  const updates: any[] = [];
+  const widget = { type: "bar", config: { dataset: "transactions", measure: { agg: "sum", field: "amount" }, dimensions: ["category"] } } as any;
+  render(<DataTab widget={widget} onUpdate={(w) => updates.push(w)} />);
+  fireEvent.change(screen.getByLabelText("Data source"), { target: { value: "accounts" } });
+  const last = updates[updates.length - 1];
+  expect(last.config.dataset).toBe("accounts");
+  expect(last.config.dimensions ?? []).not.toContain("category"); // invalid dim dropped
+});
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `docker compose exec frontend npx vitest run tests/components/reports/data-tab-source-picker.test.tsx`
+Expected: FAIL — picker is `disabled`; no `useReportSources`.
+
+- [ ] **Step 4: Implement the SWR hook**
+
+```typescript
+// lib/reports/use-report-sources.ts
+import useSWR from "swr";
+import { apiFetch } from "@/lib/api";
+import type { SourceCatalogEntry } from "@/lib/reports/types";
+
+const SOURCES_KEY = "/api/v1/reports/sources";
+
+export function useReportSources() {
+  const { data, isLoading } = useSWR<SourceCatalogEntry[]>(
+    SOURCES_KEY,
+    (url: string) => apiFetch(url).then((r) => r.json()),
+    { revalidateOnFocus: false },
+  );
+  return { sources: data ?? [], isLoading };
+}
+```
+
+> Match the project's real fetch idiom — check `components/reports/filters/AccountFilter.tsx` for how it calls the API (apiFetch vs a typed wrapper) and mirror it exactly.
+
+- [ ] **Step 5: Wire the picker + reset-on-switch in `DataTab.tsx`**
+
+Replace the disabled `<select>` (DataTab.tsx:44-53) with a live one populated from `useReportSources()`. On change, call `onUpdate` with the new dataset AND drop any `dimensions` / measure not present in the new source's catalog (reset primary dimension to the new source's first dimension key). Drive the primary/secondary dimension `<option>`s from the selected source's catalog dimensions instead of the static `DIMENSION_OPTIONS`. Add a `dimensionOptionsFor(entry)` helper in `controlConstants.ts` that maps catalog dimensions → `{value,label}`.
+
+- [ ] **Step 6: Run the test**
+
+Run: `docker compose exec frontend npx vitest run tests/components/reports/data-tab-source-picker.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/reports/use-report-sources.ts lib/reports/types.ts components/reports/config/DataTab.tsx components/reports/config/controlConstants.ts tests/components/reports/data-tab-source-picker.test.tsx
+git commit -m "feat(reports): catalog-driven source picker in the widget Data tab"
+```
+
+---
+
+## Task 7: Frontend — resolve.ts stamps dataset + omits date for date-less sources
+
+**Files:**
+- Modify: `lib/reports/resolve.ts`
+- Test: `tests/lib/reports/resolve-dataset.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/lib/reports/resolve-dataset.test.tsx
+import { resolveWidgetQuery } from "@/lib/reports/resolve"; // match the real export name
+
+test("date canvas filter is omitted for a source without a date filter", () => {
+  const accountsWidget = { type: "bar", config: { dataset: "accounts", measure: { agg: "sum", field: "balance" }, dimensions: ["account_type"] } } as any;
+  const canvas = { date_range: { start: "2026-01-01", end: "2026-12-31" } } as any;
+  // Pass the catalog so resolve knows accounts has no `date` filter.
+  const ast = resolveWidgetQuery(accountsWidget, canvas, /* sourcesCatalog */ [
+    { key: "accounts", label: "Accounts", dimensions: [], measures: [],
+      filters: [{ field: "currency", label: "Currency", ops: ["eq"], kind: "currency" }] },
+  ]);
+  expect(ast.dataset).toBe("accounts");
+  expect((ast.filters ?? []).some((f: any) => f.field === "date")).toBe(false);
+});
+
+test("date canvas filter is kept for transactions", () => {
+  const txWidget = { type: "bar", config: { dataset: "transactions", measure: { agg: "sum", field: "amount" }, dimensions: ["category"] } } as any;
+  const canvas = { date_range: { start: "2026-01-01", end: "2026-12-31" } } as any;
+  const ast = resolveWidgetQuery(txWidget, canvas, [
+    { key: "transactions", label: "Transactions", dimensions: [], measures: [],
+      filters: [{ field: "date", label: "Date", ops: ["between"], kind: "time" }] },
+  ]);
+  expect((ast.filters ?? []).some((f: any) => f.field === "date")).toBe(true);
+});
+```
+
+> Inspect `lib/reports/resolve.ts` first: confirm the real export name and current signature. If `resolve` does not currently receive the sources catalog, thread it through from the call sites (the report pages already have it once `useReportSources` lands). Keep the change minimal — a date filter is only emitted when the resolved source publishes a `date` filter field.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose exec frontend npx vitest run tests/lib/reports/resolve-dataset.test.tsx`
+Expected: FAIL — date filter still stamped on the accounts widget (or signature mismatch).
+
+- [ ] **Step 3: Implement**
+
+In `resolve.ts`, when building the filter list, only append the canvas date filter if the resolved source's catalog entry has a filter with `field === "date"`. Stamp `dataset` from `widget.config.dataset`.
+
+- [ ] **Step 4: Run the test**
+
+Run: `docker compose exec frontend npx vitest run tests/lib/reports/resolve-dataset.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/reports/resolve.ts tests/lib/reports/resolve-dataset.test.tsx
+git commit -m "feat(reports): resolver omits canvas date filter for date-less sources"
+```
+
+---
+
+## Task 8: Frontend verification gate
+
+**Files:** none — full-suite gate ([[reference_frontend_full_suite_verification]], [[reference_eslint_ci_gate_misses]]).
+
+- [ ] **Step 1: ESLint (CI gate — tsc+vitest green is NOT enough)**
+
+Run: `docker compose exec frontend npx eslint . --quiet`
+Expected: clean.
+
+- [ ] **Step 2: Type-check**
+
+Run: `docker compose exec frontend npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Full vitest run (NOT just touched files)**
+
+Run: `docker compose exec frontend npx vitest run`
+Expected: all pass (known flake: `settings-ai-providers-page > "PUTs the default routing payload on save"` — passes in isolation; not a regression).
+
+- [ ] **Step 4: Commit any fixups**
+
+```bash
+git commit -am "chore(reports): lint/type fixups for accounts source" || true
+```
+
+---
+
+## Final: review + PR
+
+- [ ] Self/fleet review per the Reports v3 wave standard (multi-dimension adversarial review → per-finding verification → fold confirmed). Surface the `is_active` default (include-all vs active-only) to the operator explicitly.
+- [ ] Open PR titled `feat(reports): accounts data source for report widgets` (conventional-commits — the title is the release/deploy gate). Concise body, no test-plan section, no AI attribution.
+
+---
+
+## Self-review checklist (completed by plan author)
+
+- **Spec coverage:** §1 enum-widening → Tasks 1–2; §2 validation split → Tasks 2–3; §3 catalog filters → Task 3; §4 AccountsSource → Task 4; §5 kind guard → Task 4 Step 6; §6 date two-tier → Tasks 3 (drop-set), 4 (build drop), 7 (frontend omit); §7 multi-currency → currency dim in Task 4 + documented; §8 frontend → Tasks 6–7; §9 tests → Tasks 1–7 (TDD). ✓
+- **Type consistency:** `validate_against_catalog`, `SourceFilter(field,label,ops,kind)`, `SHARED_CANVAS_FILTER_FIELDS`, `NUMERIC_MEASURE_FIELDS`, `useReportSources`, `resolveWidgetQuery` used consistently across tasks. ✓ (`resolveWidgetQuery` export name to be confirmed against `resolve.ts` in Task 7 Step 1.)
+- **No migration:** confirmed — enum values live in JSON columns. ✓
+- **Open verification points flagged inline:** real fetch idiom (Task 6), resolve.ts signature/export (Task 7), conftest account-factory reuse (Task 4).


### PR DESCRIPTION
## Reports v3 Phase 5

Adds the first **non-transactions report source** on the PR #441 registry, proving it's genuinely pluggable, plus the bundled-in **editable report title** affordance.

### AccountsSource (backend)
- New `accounts` source: report on the accounts snapshot — **Total/Average balance** and **Account count**, grouped by account, account type, currency, or active status. Single `accounts`+`account_types` join, org-scoped on `accounts.org_id`; no transaction reconstruction.
- **Shared closed enums consolidated** into `schemas/reports_enums.py` (was duplicated across the query AST and layout validator), then widened for accounts (`Dataset`, `Dimension`, `MeasureField`, `FilterField`). No migration — these live in JSON columns, not native DB enums.
- **Per-source validation**: `ReportSource` now requires `validate()` + `filters()`. `validate_against_catalog` rejects any dimension/measure/filter a source doesn't publish (→ **422**, wired in the router so it's not a 500), while **silently dropping** inapplicable shared-canvas fields (the date bar) so an accounts widget on a date-filtered canvas doesn't break.
- `/sources` now publishes each source's **filterable fields**, making the editor fully catalog-driven.

### Frontend
- **Catalog-driven source picker** in the widget Data tab (first consumer of `/sources`): pick a source → its dimensions **and measures** drive the controls; switching source resets now-invalid dims/measures to valid defaults (no more 422-prone widgets).
- Resolver **omits the canvas date filter** for date-less sources (defaults to keeping it pre-catalog-load, so transactions dashboards never momentarily lose date scoping).
- **Inline report-title editing** on the saved-report page (was static text; backend `PATCH` already supported it). Commits on blur/Enter; handles the Enter→blur double-commit and mid-typing clobber races.

### Multi-currency note
`sum_balance` across mixed currencies is meaningless; `currency` is exposed as a grouping/filter dimension as the (operator-chosen) mitigation. Proper cross-currency safety remains the future i18n/multi-currency project.

Specs: `specs/2026-06-13-reports-v3-phase5-accounts-source-design.md` + `-plan.md`. Built subagent-driven with a two-stage review gate per task.