### PR TITLE
feat(reports): recurring data source for report widgets

### DIFF
--- a/backend/app/reports/sources/__init__.py
+++ b/backend/app/reports/sources/__init__.py
@@ -27,3 +27,4 @@ def all_sources() -> list[ReportSource]:
 # avoid a circular import (transactions.py imports from .base + __init__).
 from app.reports.sources import transactions as _transactions  # noqa: E402,F401
 from app.reports.sources import accounts as _accounts  # noqa: E402,F401
+from app.reports.sources import recurring as _recurring  # noqa: E402,F401

--- a/backend/app/reports/sources/recurring.py
+++ b/backend/app/reports/sources/recurring.py
@@ -196,6 +196,20 @@ class RecurringSource:
 
     def validate(self, query: ReportsQuery) -> None:
         validate_against_catalog(self, query)
+        # RecurringTransaction.type is Enum(income, expense) — recurring has
+        # NO transfer. The shared txn_type scalar coercion accepts transfer
+        # (correct for transactions), so a transfer filter passes schema +
+        # catalog here and would compile to type=='transfer' (silent empty
+        # result on MySQL). Reject it authoritatively for this source only;
+        # transactions legitimately allows transfer.
+        for f in query.filters:
+            if f.field is FilterField.TXN_TYPE:
+                values = f.value if isinstance(f.value, (list, tuple)) else [f.value]
+                if any(v not in ("income", "expense") for v in values):
+                    raise ValueError(
+                        "recurring: txn_type 'transfer' is not valid for "
+                        "recurring templates"
+                    )
 
     async def build_rows(
         self, db: AsyncSession, org_id: int, query: ReportsQuery

--- a/backend/app/reports/sources/recurring.py
+++ b/backend/app/reports/sources/recurring.py
@@ -1,0 +1,289 @@
+"""Recurring source — amount / count over recurring templates.
+
+Recurring templates are a snapshot table: one row per template, with
+``amount`` stored as a column. So this source compiles to a single
+``RecurringTransaction JOIN Account JOIN Category`` SELECT — no
+transaction reconstruction. ``org_id`` is injected here (HARD
+requirement) and scoped on ``recurring_transactions.org_id`` only;
+Account and Category are reachable solely through their FKs, so they
+need no separate org filter.
+
+The compiler is structurally incapable of emitting SQL for any field
+outside its own catalog (date / status / … are silently ignored),
+which is what makes the shared-canvas date-bar drop a stray date filter
+instead of erroring — the Phase-5 contract.
+
+Note: ``RecurringTransaction.frequency`` is a true ``Frequency`` enum
+column (mapped to ``Enum(Frequency)``), so the driver may hand back a
+``Frequency`` member rather than its string value. ``RecurringTransaction.type``
+is a plain-string ``Enum`` and returns a str. Either way, the row
+coercion below normalizes any ``enum.Enum`` dimension value to ``.value``
+so grouped JSON keys are always plain strings ("monthly", "expense").
+"""
+from __future__ import annotations
+
+import enum as _enum
+import time
+from typing import Any
+
+from sqlalchemy import case, distinct, func, literal_column, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account
+from app.models.category import Category
+from app.models.recurring import RecurringTransaction
+from app.reports.sources import register
+from app.reports.sources.base import (
+    ReportSource, SourceDimension, SourceFilter, SourceMeasure,
+    validate_against_catalog,
+)
+from app.schemas.reports_query import (
+    MAX_LIMIT,
+    Aggregation,
+    Dimension,
+    FilterField,
+    FilterOp,
+    MeasureField,
+    ReportsQuery,
+)
+
+_DIMENSIONS = [
+    SourceDimension("category", "Category", "category"),
+    SourceDimension("account", "Account", "account"),
+    SourceDimension("currency", "Currency", "currency"),
+    SourceDimension("txn_type", "Type", "type"),
+    SourceDimension("frequency", "Frequency", "type"),
+    SourceDimension("recurring_active", "Status", "boolean"),
+]
+
+_MEASURES = [
+    SourceMeasure("sum_amount", "Total amount", "sum", "amount", "currency"),
+    SourceMeasure("avg_amount", "Average amount", "avg", "amount", "currency"),
+    SourceMeasure("count_recurring", "Recurring count", "count", "id", "number"),
+]
+
+_FILTERS = [
+    SourceFilter("account_id", "Account", ("in",), "account"),
+    SourceFilter("category_id", "Category", ("eq", "in"), "category"),
+    SourceFilter("currency", "Currency", ("eq", "in"), "currency"),
+    SourceFilter("txn_type", "Type", ("eq", "in"), "type"),
+    SourceFilter("frequency", "Frequency", ("eq", "in"), "type"),
+    SourceFilter("recurring_active", "Status", ("eq",), "boolean"),
+    SourceFilter("amount", "Amount", ("between", "gte", "lte"), "number"),
+]
+
+# Dimension → (response key, SQL expression). recurring_active normalizes
+# the boolean to stable "Active"/"Inactive" strings in the SELECT via a
+# CASE so we never depend on the driver returning a Python bool.
+_DIM_EXPR = {
+    Dimension.CATEGORY: ("category", Category.name),
+    Dimension.ACCOUNT: ("account", Account.name),
+    Dimension.CURRENCY: ("currency", Account.currency),
+    Dimension.TXN_TYPE: ("txn_type", RecurringTransaction.type),
+    Dimension.FREQUENCY: ("frequency", RecurringTransaction.frequency),
+    Dimension.RECURRING_ACTIVE: (
+        "recurring_active",
+        case((RecurringTransaction.is_active.is_(True), "Active"), else_="Inactive"),
+    ),
+}
+
+# Only the source's OWN filter fields are compiled. Anything else
+# (date, status, account_type, …) is silently ignored.
+_OWN_FILTER_FIELDS = {
+    FilterField.ACCOUNT_ID,
+    FilterField.CATEGORY_ID,
+    FilterField.CURRENCY,
+    FilterField.TXN_TYPE,
+    FilterField.FREQUENCY,
+    FilterField.RECURRING_ACTIVE,
+    FilterField.AMOUNT,
+}
+
+
+def _measure_expr(measure):
+    col_map = {
+        MeasureField.AMOUNT: RecurringTransaction.amount,
+        MeasureField.ID: RecurringTransaction.id,
+    }
+    col = col_map[measure.field]
+    agg = measure.agg
+    if agg is Aggregation.SUM:
+        return func.coalesce(func.sum(col), 0).label("value")
+    if agg is Aggregation.AVG:
+        return func.coalesce(func.avg(col), 0).label("value")
+    if agg is Aggregation.DISTINCT:
+        return func.count(distinct(col)).label("value")
+    if agg is Aggregation.COUNT:
+        return func.count(col).label("value")
+    raise ValueError(f"unsupported aggregation {agg!r}")
+
+
+def _apply_filter(stmt, f):
+    """Compile one of this source's OWN filters into a WHERE clause.
+
+    Each branch is op-explicit and raises on an op the source does not
+    support, so a future caller that skips ``validate()`` gets a loud
+    error rather than a silently-dropped or mis-applied predicate
+    (defense-in-depth; ``validate_against_catalog`` already op-checks).
+
+    A field this source does not own (e.g. a dropped shared-canvas
+    ``date``) still falls through to a bare ``return stmt`` — that is the
+    Phase-5 shared-canvas drop contract, kept distinct from an op
+    mismatch on an OWNED field.
+    """
+    field, op, value = f.field, f.op, f.value
+    if field is FilterField.ACCOUNT_ID:
+        if op is FilterOp.IN:
+            return stmt.where(RecurringTransaction.account_id.in_(value))
+        if op is FilterOp.EQ:
+            return stmt.where(RecurringTransaction.account_id == value)
+        raise ValueError(f"recurring: unsupported op {op.value!r} for account_id")
+    if field is FilterField.CATEGORY_ID:
+        if op is FilterOp.IN:
+            return stmt.where(RecurringTransaction.category_id.in_(value))
+        if op is FilterOp.EQ:
+            return stmt.where(RecurringTransaction.category_id == value)
+        raise ValueError(f"recurring: unsupported op {op.value!r} for category_id")
+    if field is FilterField.CURRENCY:
+        if op is FilterOp.IN:
+            return stmt.where(Account.currency.in_(value))
+        if op is FilterOp.EQ:
+            return stmt.where(Account.currency == value)
+        raise ValueError(f"recurring: unsupported op {op.value!r} for currency")
+    if field is FilterField.TXN_TYPE:
+        if op is FilterOp.IN:
+            return stmt.where(RecurringTransaction.type.in_(value))
+        if op is FilterOp.EQ:
+            return stmt.where(RecurringTransaction.type == value)
+        raise ValueError(f"recurring: unsupported op {op.value!r} for txn_type")
+    if field is FilterField.FREQUENCY:
+        if op is FilterOp.IN:
+            return stmt.where(RecurringTransaction.frequency.in_(value))
+        if op is FilterOp.EQ:
+            return stmt.where(RecurringTransaction.frequency == value)
+        raise ValueError(f"recurring: unsupported op {op.value!r} for frequency")
+    if field is FilterField.RECURRING_ACTIVE:
+        if op is FilterOp.EQ and isinstance(value, bool):
+            return stmt.where(RecurringTransaction.is_active.is_(value))
+        raise ValueError(
+            f"recurring: recurring_active requires op 'eq' with a bool; "
+            f"got op {op.value!r} value {value!r}"
+        )
+    if field is FilterField.AMOUNT:
+        if op is FilterOp.BETWEEN:
+            lo, hi = value
+            return stmt.where(RecurringTransaction.amount.between(lo, hi))
+        if op is FilterOp.GTE:
+            return stmt.where(RecurringTransaction.amount >= value)
+        if op is FilterOp.LTE:
+            return stmt.where(RecurringTransaction.amount <= value)
+        raise ValueError(f"recurring: unsupported op {op.value!r} for amount")
+    return stmt  # field this source doesn't own → drop (shared-canvas contract)
+
+
+class RecurringSource:
+    key = "recurring"
+    label = "Recurring"
+
+    def dimensions(self) -> list[SourceDimension]:
+        return list(_DIMENSIONS)
+
+    def measures(self) -> list[SourceMeasure]:
+        return list(_MEASURES)
+
+    def filters(self) -> list[SourceFilter]:
+        return list(_FILTERS)
+
+    def validate(self, query: ReportsQuery) -> None:
+        validate_against_catalog(self, query)
+
+    async def build_rows(
+        self, db: AsyncSession, org_id: int, query: ReportsQuery
+    ) -> tuple[list[dict], dict]:
+        dim_exprs: list[tuple[str, Any]] = []
+        for dim in query.dimensions:
+            key, expr = _DIM_EXPR[dim]
+            dim_exprs.append((key, expr.label(key)))
+
+        measure_expr = _measure_expr(query.measure)
+
+        stmt = (
+            select(*[expr for _, expr in dim_exprs], measure_expr)
+            .select_from(RecurringTransaction)
+            .join(Account, Account.id == RecurringTransaction.account_id)
+            .join(Category, Category.id == RecurringTransaction.category_id)
+            .where(RecurringTransaction.org_id == org_id)  # org-scope on recurring ONLY
+        )
+
+        for f in query.filters:
+            if f.field in _OWN_FILTER_FIELDS:
+                stmt = _apply_filter(stmt, f)
+            # else: stray shared-canvas field (date, …) — silently dropped
+
+        if dim_exprs:
+            raw_group_cols = [_DIM_EXPR[dim][1] for dim in query.dimensions]
+            stmt = stmt.group_by(*raw_group_cols)
+
+        # ORDER BY — mirror reports_query_service so grouped + limited
+        # results are deterministic, not arbitrarily ordered/truncated.
+        sort = query.sort
+        if sort is not None:
+            if sort.by.value == "value":
+                order_col = literal_column("value")
+            else:  # by == "dimension"
+                if not dim_exprs:
+                    raise ValueError(
+                        "sort.by='dimension' requires at least one dimension"
+                    )
+                order_col = literal_column(dim_exprs[0][0])
+            order_col = order_col.asc() if sort.dir.value == "asc" else order_col.desc()
+            stmt = stmt.order_by(order_col)
+        elif dim_exprs:
+            # Stable default order by value desc (matches transactions).
+            stmt = stmt.order_by(literal_column("value").desc())
+
+        # Deterministic tiebreaker so truncation on ties is stable across
+        # runs. Only meaningful when grouping (multiple rows): a no-dimension
+        # query is a single aggregate row where RecurringTransaction.id is
+        # neither selected nor grouped, so an ORDER BY on it would be invalid SQL.
+        if dim_exprs:
+            stmt = stmt.order_by(func.min(RecurringTransaction.id).asc())
+
+        stmt = stmt.limit(min(query.limit, MAX_LIMIT))
+
+        started = time.perf_counter()
+        result = await db.execute(stmt)
+        rows = result.mappings().all()
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+
+        out_rows = []
+        for r in rows:
+            d = {}
+            for key, _ in dim_exprs:
+                v = r.get(key)
+                # frequency (and defensively txn_type) may come back as an
+                # enum.Enum member; normalize to its plain string value so
+                # JSON keys are stable strings ("monthly"), never a repr.
+                if isinstance(v, _enum.Enum):
+                    v = v.value
+                d[key] = v
+            val = r.get("value")
+            if hasattr(val, "as_tuple"):  # Decimal-like
+                try:
+                    d["value"] = float(val)
+                except Exception:  # pragma: no cover - defensive
+                    d["value"] = str(val)
+            else:
+                d["value"] = val
+            out_rows.append(d)
+
+        meta = {
+            "row_count": len(out_rows),
+            "truncated": len(out_rows) >= query.limit,
+            "query_ms": elapsed_ms,
+        }
+        return out_rows, meta
+
+
+_INSTANCE: ReportSource = RecurringSource()
+register(_INSTANCE)

--- a/backend/app/schemas/reports_enums.py
+++ b/backend/app/schemas/reports_enums.py
@@ -14,6 +14,7 @@ class Dataset(str, enum.Enum):
 
     TRANSACTIONS = "transactions"
     ACCOUNTS = "accounts"
+    RECURRING = "recurring"
 
 
 class Aggregation(str, enum.Enum):
@@ -41,6 +42,8 @@ class Dimension(str, enum.Enum):
     ACCOUNT_TYPE = "account_type"
     CURRENCY = "currency"
     ACCOUNT_ACTIVE = "account_active"
+    FREQUENCY = "frequency"
+    RECURRING_ACTIVE = "recurring_active"
     TAG = "tag"
     TXN_TYPE = "txn_type"
     STATUS = "status"

--- a/backend/app/schemas/reports_query.py
+++ b/backend/app/schemas/reports_query.py
@@ -70,6 +70,8 @@ class FilterField(str, enum.Enum):
     CURRENCY = "currency"
     ACCOUNT_ACTIVE = "account_active"
     BALANCE = "balance"
+    FREQUENCY = "frequency"
+    RECURRING_ACTIVE = "recurring_active"
     # Tag filter uses normalized tag name (lowercased), matching the
     # transactions list semantics at
     # ``backend/app/routers/transactions.py:90`` and
@@ -326,5 +328,22 @@ def _coerce_filter_scalar(field: FilterField, value):
         raise ValueError("account_active must be a boolean")
     if field is FilterField.BALANCE:
         return _coerce_decimal(value)
+    if field is FilterField.FREQUENCY:
+        v = str(value).strip().lower()
+        valid = {"weekly", "biweekly", "monthly", "quarterly", "yearly"}
+        if v not in valid:
+            raise ValueError(
+                f"frequency must be one of {sorted(valid)}; got {v!r}"
+            )
+        return v
+    if field is FilterField.RECURRING_ACTIVE:
+        if isinstance(value, bool):
+            return value
+        v = str(value).strip().lower()
+        if v in ("true", "1", "active"):
+            return True
+        if v in ("false", "0", "inactive"):
+            return False
+        raise ValueError("recurring_active must be a boolean")
     # Should be unreachable given the FilterField enum is closed.
     raise ValueError(f"unsupported filter field {field!r}")

--- a/backend/tests/schemas/test_reports_enums_consistency.py
+++ b/backend/tests/schemas/test_reports_enums_consistency.py
@@ -11,7 +11,9 @@ def test_shared_enum_atoms_are_the_same_object():
 
 
 def test_dataset_values():
-    assert {d.value for d in reports_query.Dataset} == {"transactions", "accounts"}
+    assert {d.value for d in reports_query.Dataset} == {
+        "transactions", "accounts", "recurring",
+    }
 
 
 def test_accounts_dataset_and_new_dimensions_present():

--- a/backend/tests/services/test_recurring_source.py
+++ b/backend/tests/services/test_recurring_source.py
@@ -245,6 +245,9 @@ async def test_txn_type_dimension_keys_are_plain_strings(db_session, seeded):
     rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
     for r in rows:
         assert type(r["txn_type"]) is str
+    # Verify the actual key values, not just their type: the seed has
+    # expense + income templates (recurring never has transfer).
+    assert {r["txn_type"] for r in rows} == {"income", "expense"}
 
 
 # ─── avg + IN filters ───────────────────────────────────────────────
@@ -364,12 +367,13 @@ async def test_amount_between_filter(db_session, seeded):
 # ─── op-reject (→422) ───────────────────────────────────────────────
 
 
-def test_validate_rejects_frequency_between_op():
-    """frequency only supports eq/in. A `between` op must be rejected."""
+def test_validate_rejects_frequency_unsupported_scalar_op():
+    """frequency only supports eq/in. A schema-valid scalar op the catalog
+    does not list (gte) must be rejected."""
     src = _source()
-    # between is only schema-valid on date/amount/balance, so build a
-    # frequency `in` filter then assert the validator rejects an unsupported
-    # op by using `gte` (schema-allowed scalar) which frequency does not list.
+    # `between` is only schema-valid on date/amount/balance, so we can't use
+    # it here; use `gte` (a schema-allowed scalar op) which the frequency
+    # catalog (eq/in) does not list, and assert the validator rejects it.
     ast = _query(
         filters=[Filter(field=FilterField.FREQUENCY, op=FilterOp.GTE, value="monthly")],
     )
@@ -387,6 +391,45 @@ def test_validate_rejects_recurring_active_in_op():
     )
     with pytest.raises(ValueError):
         src.validate(ast)
+
+
+# ─── Fix 1: txn_type='transfer' is invalid for recurring ────────────
+
+
+def test_validate_rejects_txn_type_transfer_eq():
+    """RecurringTransaction.type is Enum(income, expense) — recurring has NO
+    transfer. The shared scalar coercion accepts transfer (correct for
+    transactions), so validate() must reject it here or it silently compiles
+    to type=='transfer' (empty result on MySQL)."""
+    src = _source()
+    ast = _query(
+        filters=[Filter(field=FilterField.TXN_TYPE, op=FilterOp.EQ, value="transfer")],
+    )
+    with pytest.raises(ValueError):
+        src.validate(ast)
+
+
+def test_validate_rejects_txn_type_transfer_in_list():
+    """An `in` list containing transfer must also be rejected, even when it
+    also lists a valid value (income)."""
+    src = _source()
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.TXN_TYPE, op=FilterOp.IN,
+                   value=["income", "transfer"]),
+        ],
+    )
+    with pytest.raises(ValueError):
+        src.validate(ast)
+
+
+def test_validate_accepts_txn_type_income_eq():
+    """Sanity: a valid recurring txn_type (income) must NOT raise."""
+    src = _source()
+    ast = _query(
+        filters=[Filter(field=FilterField.TXN_TYPE, op=FilterOp.EQ, value="income")],
+    )
+    src.validate(ast)  # must not raise
 
 
 # ─── cross-source reject ────────────────────────────────────────────
@@ -445,6 +488,9 @@ async def test_date_filter_tolerated_and_dropped(db_session, seeded):
 
 @pytest.mark.asyncio
 async def test_sort_by_value_asc(db_session, seeded):
+    """Grouped query (dim=category) sorted ascending by value returns rows
+    ordered low → high SUM(amount). Category sums over the seed:
+    Health = Gym 30; Housing = Rent 1200 + OldSub 10 = 1210; Income = 3000."""
     src = _source()
     ast = _query(
         measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
@@ -454,3 +500,69 @@ async def test_sort_by_value_asc(db_session, seeded):
     rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
     values = [r["value"] for r in rows]
     assert values == sorted(values)
+    # Boundary + value anchors (lowest / highest sum category).
+    assert rows[0]["category"] == "Health"
+    assert rows[-1]["category"] == "Income"
+    # Concrete ordered values list (SUM(amount) is coerced to float).
+    assert values == [30.0, 1210.0, 3000.0]
+
+
+@pytest.mark.asyncio
+async def test_sort_truncation_is_deterministic(db_session, seeded):
+    """Engineer a real aggregate tie AT the truncation boundary: two NEW
+    categories whose SUM(amount) is equal (each 5) and lower than every
+    seeded category, so a limit-1 ASC sort must pick between the two tied
+    rows. The func.min(id) tiebreaker guarantees the SAME single dimension
+    value across runs; deleting that ORDER BY line makes this fail (MySQL is
+    free to return either tied row)."""
+    from decimal import Decimal as _Decimal
+    from datetime import date as _date
+
+    # Engineer the tie so the category NAME order opposes the row id /
+    # insertion order: "Zeta" (inserted first → smaller min(id)) vs "Alpha"
+    # (inserted second → larger min(id)). With the func.min(id) tiebreaker
+    # the survivor is deterministic (smaller id, "Zeta"); without it the
+    # engine is free to fall back to grouping/name order ("Alpha") — so
+    # deleting the tiebreaker line flips the truncated value and fails.
+    zeta = Category(org_id=seeded["org1_id"], name="Zeta", type="expense")
+    alpha = Category(org_id=seeded["org1_id"], name="Alpha", type="expense")
+    db_session.add(zeta)
+    await db_session.flush()
+    db_session.add(alpha)
+    await db_session.flush()
+
+    accts, _ = await _ids(db_session, seeded["org1_id"])
+    checking = accts["Checking"]
+    db_session.add_all([
+        RecurringTransaction(
+            org_id=seeded["org1_id"], account_id=checking, category_id=zeta.id,
+            description="Zeta", amount=_Decimal("5"), type="expense",
+            frequency="monthly", next_due_date=_date(2026, 1, 1), is_active=True,
+        ),
+        RecurringTransaction(
+            org_id=seeded["org1_id"], account_id=checking, category_id=alpha.id,
+            description="Alpha", amount=_Decimal("5"), type="expense",
+            frequency="monthly", next_due_date=_date(2026, 1, 1), is_active=True,
+        ),
+    ])
+    await db_session.flush()
+
+    def _ast():
+        return _query(
+            measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+            dimensions=[Dimension.CATEGORY],
+            sort=SortSpec(by=SortBy.VALUE, dir=SortDir.ASC),
+            limit=1,
+        )
+
+    src = _source()
+    rows_a, _ = await src.build_rows(db_session, seeded["org1_id"], _ast())
+    rows_b, _ = await src.build_rows(db_session, seeded["org1_id"], _ast())
+    assert len(rows_a) == 1
+    assert rows_a[0]["value"] == 5.0  # the tied minimum is what gets truncated to
+    # Stable across runs ...
+    assert rows_a[0]["category"] == rows_b[0]["category"]
+    # ... and anchored to the func.min(id) winner ("Zeta", inserted first =
+    # smaller id), NOT the name-order fallback ("Alpha"). Removing the
+    # tiebreaker ORDER BY flips this to "Alpha" and fails the test.
+    assert rows_a[0]["category"] == "Zeta"

--- a/backend/tests/services/test_recurring_source.py
+++ b/backend/tests/services/test_recurring_source.py
@@ -1,0 +1,456 @@
+"""RecurringSource — amount/count over recurring templates.
+
+Self-contained in-memory aiosqlite fixture (mirrors
+test_accounts_source.py): engine + PRAGMA foreign_keys=ON + StaticPool.
+Does NOT rely on conftest fixtures.
+"""
+import pytest
+import pytest_asyncio
+from decimal import Decimal
+
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models.base import Base
+from app.models import Account, AccountType, Category, Organization
+from app.models.recurring import RecurringTransaction
+from app.reports import sources as registry
+from app.schemas.reports_query import (
+    Aggregation,
+    Dataset,
+    Dimension,
+    Filter,
+    FilterField,
+    FilterOp,
+    Measure,
+    MeasureField,
+    ReportsQuery,
+    SortBy,
+    SortDir,
+    SortSpec,
+)
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded(db_session):
+    """Org 1: one EUR account + categories + 4 recurring templates:
+      Rent  (expense, monthly,  1200, active)
+      Salary(income,  monthly,  3000, active)
+      Gym   (expense, weekly,     30, active)
+      OldSub(expense, monthly,    10, INACTIVE)
+    Org 2: one recurring row for org-isolation.
+    """
+    from datetime import date
+
+    org1 = Organization(name="Org1", billing_cycle_day=1)
+    org2 = Organization(name="Org2", billing_cycle_day=1)
+    db_session.add_all([org1, org2])
+    await db_session.flush()
+
+    at1 = AccountType(org_id=org1.id, name="Bank", slug="bank", is_system=False)
+    at2 = AccountType(org_id=org2.id, name="Other", slug="other", is_system=False)
+    db_session.add_all([at1, at2])
+    await db_session.flush()
+
+    acct1 = Account(
+        org_id=org1.id, name="Checking", account_type_id=at1.id,
+        balance=Decimal("0"), currency="EUR", is_active=True,
+    )
+    acct2 = Account(
+        org_id=org2.id, name="OtherAcct", account_type_id=at2.id,
+        balance=Decimal("0"), currency="EUR", is_active=True,
+    )
+    db_session.add_all([acct1, acct2])
+    await db_session.flush()
+
+    cat_housing = Category(org_id=org1.id, name="Housing", type="expense")
+    cat_income = Category(org_id=org1.id, name="Income", type="income")
+    cat_health = Category(org_id=org1.id, name="Health", type="expense")
+    cat_other = Category(org_id=org2.id, name="OtherCat", type="expense")
+    db_session.add_all([cat_housing, cat_income, cat_health, cat_other])
+    await db_session.flush()
+
+    rows = [
+        RecurringTransaction(
+            org_id=org1.id, account_id=acct1.id, category_id=cat_housing.id,
+            description="Rent", amount=Decimal("1200"), type="expense",
+            frequency="monthly", next_due_date=date(2026, 1, 1), is_active=True,
+        ),
+        RecurringTransaction(
+            org_id=org1.id, account_id=acct1.id, category_id=cat_income.id,
+            description="Salary", amount=Decimal("3000"), type="income",
+            frequency="monthly", next_due_date=date(2026, 1, 1), is_active=True,
+        ),
+        RecurringTransaction(
+            org_id=org1.id, account_id=acct1.id, category_id=cat_health.id,
+            description="Gym", amount=Decimal("30"), type="expense",
+            frequency="weekly", next_due_date=date(2026, 1, 1), is_active=True,
+        ),
+        RecurringTransaction(
+            org_id=org1.id, account_id=acct1.id, category_id=cat_housing.id,
+            description="OldSub", amount=Decimal("10"), type="expense",
+            frequency="monthly", next_due_date=date(2026, 1, 1), is_active=False,
+        ),
+        RecurringTransaction(
+            org_id=org2.id, account_id=acct2.id, category_id=cat_other.id,
+            description="OtherOrg", amount=Decimal("99"), type="expense",
+            frequency="yearly", next_due_date=date(2026, 1, 1), is_active=True,
+        ),
+    ]
+    db_session.add_all(rows)
+    await db_session.flush()
+
+    return {"org1_id": org1.id, "org2_id": org2.id}
+
+
+def _source():
+    return registry.get_source("recurring")
+
+
+def _query(**kwargs):
+    base = dict(
+        dataset=Dataset.RECURRING,
+        measure=Measure(agg=Aggregation.COUNT, field=MeasureField.ID),
+    )
+    base.update(kwargs)
+    return ReportsQuery(**base)
+
+
+async def _ids(db_session, org_id):
+    """Return {name -> account.id} and {name -> category.id} for the org."""
+    from sqlalchemy import select as _select
+
+    acct_rows = (
+        await db_session.execute(
+            _select(Account.name, Account.id).where(Account.org_id == org_id)
+        )
+    ).all()
+    cat_rows = (
+        await db_session.execute(
+            _select(Category.name, Category.id).where(Category.org_id == org_id)
+        )
+    ).all()
+    return {n: i for n, i in acct_rows}, {n: i for n, i in cat_rows}
+
+
+# ─── catalog exactness ──────────────────────────────────────────────
+
+
+def test_catalog_exactness():
+    src = _source()
+    assert src.key == "recurring"
+    assert src.label == "Recurring"
+    assert {d.key for d in src.dimensions()} == {
+        "category", "account", "currency", "txn_type", "frequency",
+        "recurring_active",
+    }
+    assert {m.key for m in src.measures()} == {
+        "sum_amount", "avg_amount", "count_recurring",
+    }
+    assert {f.field for f in src.filters()} == {
+        "account_id", "category_id", "currency", "txn_type", "frequency",
+        "recurring_active", "amount",
+    }
+
+
+# ─── grouped aggregates ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sum_amount_by_txn_type(db_session, seeded):
+    src = _source()
+    ast = _query(
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+        dimensions=[Dimension.TXN_TYPE],
+    )
+    rows, meta = await src.build_rows(db_session, seeded["org1_id"], ast)
+    by_type = {r["txn_type"]: r["value"] for r in rows}
+    # expense: 1200 + 30 + 10 = 1240; income: 3000
+    assert by_type == {"expense": 1240.0, "income": 3000.0}
+    assert meta["row_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_sum_amount_by_frequency(db_session, seeded):
+    src = _source()
+    ast = _query(
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+        dimensions=[Dimension.FREQUENCY],
+    )
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    by_freq = {r["frequency"]: r["value"] for r in rows}
+    # monthly: Rent 1200 + Salary 3000 + OldSub 10 = 4210; weekly: Gym 30
+    assert by_freq == {"monthly": 4210.0, "weekly": 30.0}
+
+
+@pytest.mark.asyncio
+async def test_count_by_recurring_active(db_session, seeded):
+    src = _source()
+    ast = _query(dimensions=[Dimension.RECURRING_ACTIVE])
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    by_active = {r["recurring_active"]: r["value"] for r in rows}
+    assert by_active == {"Active": 3, "Inactive": 1}
+
+
+@pytest.mark.asyncio
+async def test_count_no_dims_org_isolation(db_session, seeded):
+    src = _source()
+    ast = _query()
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert len(rows) == 1
+    assert rows[0]["value"] == 4  # org2's recurring row excluded
+
+
+@pytest.mark.asyncio
+async def test_frequency_dimension_keys_are_plain_strings(db_session, seeded):
+    """Grouped row keys for the frequency dimension must be plain JSON
+    strings ("monthly"), never a Python Frequency enum repr."""
+    src = _source()
+    ast = _query(dimensions=[Dimension.FREQUENCY])
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    keys = {r["frequency"] for r in rows}
+    assert keys == {"monthly", "weekly"}
+    for r in rows:
+        assert type(r["frequency"]) is str
+
+
+@pytest.mark.asyncio
+async def test_txn_type_dimension_keys_are_plain_strings(db_session, seeded):
+    src = _source()
+    ast = _query(dimensions=[Dimension.TXN_TYPE])
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    for r in rows:
+        assert type(r["txn_type"]) is str
+
+
+# ─── avg + IN filters ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_avg_amount_over_monthly_expense(db_session, seeded):
+    """avg over the two monthly expense rows (Rent 1200 + OldSub 10) = 605."""
+    src = _source()
+    ast = _query(
+        measure=Measure(agg=Aggregation.AVG, field=MeasureField.AMOUNT),
+        filters=[
+            Filter(field=FilterField.TXN_TYPE, op=FilterOp.EQ, value="expense"),
+            Filter(field=FilterField.FREQUENCY, op=FilterOp.EQ, value="monthly"),
+        ],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert len(rows) == 1
+    assert rows[0]["value"] == 605.0
+
+
+@pytest.mark.asyncio
+async def test_account_id_in_filter(db_session, seeded):
+    src = _source()
+    accts, _ = await _ids(db_session, seeded["org1_id"])
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.ACCOUNT_ID, op=FilterOp.IN,
+                   value=[accts["Checking"]]),
+        ],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert rows[0]["value"] == 4
+
+
+@pytest.mark.asyncio
+async def test_category_id_in_filter(db_session, seeded):
+    src = _source()
+    _, cats = await _ids(db_session, seeded["org1_id"])
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.CATEGORY_ID, op=FilterOp.IN,
+                   value=[cats["Housing"]]),
+        ],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert rows[0]["value"] == 2  # Rent + OldSub are Housing
+
+
+@pytest.mark.asyncio
+async def test_currency_in_filter(db_session, seeded):
+    src = _source()
+    ast = _query(
+        filters=[Filter(field=FilterField.CURRENCY, op=FilterOp.IN, value=["EUR"])],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert rows[0]["value"] == 4  # all org1 recurring rows joined to EUR account
+
+
+@pytest.mark.asyncio
+async def test_txn_type_in_filter(db_session, seeded):
+    src = _source()
+    ast = _query(
+        filters=[Filter(field=FilterField.TXN_TYPE, op=FilterOp.IN, value=["income"])],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert rows[0]["value"] == 1  # only Salary
+
+
+@pytest.mark.asyncio
+async def test_frequency_in_filter(db_session, seeded):
+    src = _source()
+    ast = _query(
+        filters=[Filter(field=FilterField.FREQUENCY, op=FilterOp.IN,
+                        value=["weekly"])],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert rows[0]["value"] == 1  # only Gym
+
+
+@pytest.mark.asyncio
+async def test_recurring_active_eq_false_filter(db_session, seeded):
+    """recurring_active eq false returns only the inactive template (OldSub)."""
+    src = _source()
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.RECURRING_ACTIVE, op=FilterOp.EQ, value=False),
+        ],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert len(rows) == 1
+    assert rows[0]["value"] == 1
+
+
+@pytest.mark.asyncio
+async def test_amount_between_filter(db_session, seeded):
+    """amount BETWEEN [0, 100] counts only Gym (30) + OldSub (10)."""
+    src = _source()
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.AMOUNT, op=FilterOp.BETWEEN, value=[0, 100]),
+        ],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert len(rows) == 1
+    assert rows[0]["value"] == 2
+
+
+# ─── op-reject (→422) ───────────────────────────────────────────────
+
+
+def test_validate_rejects_frequency_between_op():
+    """frequency only supports eq/in. A `between` op must be rejected."""
+    src = _source()
+    # between is only schema-valid on date/amount/balance, so build a
+    # frequency `in` filter then assert the validator rejects an unsupported
+    # op by using `gte` (schema-allowed scalar) which frequency does not list.
+    ast = _query(
+        filters=[Filter(field=FilterField.FREQUENCY, op=FilterOp.GTE, value="monthly")],
+    )
+    with pytest.raises(ValueError):
+        src.validate(ast)
+
+
+def test_validate_rejects_recurring_active_in_op():
+    """recurring_active only supports eq. An `in` op must be rejected."""
+    src = _source()
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.RECURRING_ACTIVE, op=FilterOp.IN, value=[False]),
+        ],
+    )
+    with pytest.raises(ValueError):
+        src.validate(ast)
+
+
+# ─── cross-source reject ────────────────────────────────────────────
+
+
+def test_transactions_source_rejects_frequency_dimension():
+    """The frequency dimension is recurring-only; the transactions source
+    must reject it."""
+    txn = registry.get_source("transactions")
+    ast = ReportsQuery(
+        dataset=Dataset.TRANSACTIONS,
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+        dimensions=[Dimension.FREQUENCY],
+    )
+    with pytest.raises(ValueError):
+        txn.validate(ast)
+
+
+def test_recurring_rejects_balance_measure_field():
+    """sum(amount) is fine on recurring, but `balance` (an accounts field)
+    is not a recurring measure field and must be rejected."""
+    src = _source()
+    ast = _query(measure=Measure(agg=Aggregation.SUM, field=MeasureField.BALANCE))
+    with pytest.raises(ValueError):
+        src.validate(ast)
+
+
+def test_recurring_accepts_sum_amount():
+    src = _source()
+    ast = _query(measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT))
+    src.validate(ast)  # must not raise
+
+
+# ─── date-drop tolerance (shared-canvas contract) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_date_filter_tolerated_and_dropped(db_session, seeded):
+    """A date filter against recurring must validate() without raising and
+    build_rows must return rows (date dropped)."""
+    src = _source()
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.DATE, op=FilterOp.BETWEEN,
+                   value=["2024-01-01", "2026-01-01"]),
+        ],
+    )
+    src.validate(ast)  # must not raise
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert len(rows) == 1
+    assert rows[0]["value"] == 4
+
+
+# ─── sort + tiebreaker ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sort_by_value_asc(db_session, seeded):
+    src = _source()
+    ast = _query(
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+        dimensions=[Dimension.CATEGORY],
+        sort=SortSpec(by=SortBy.VALUE, dir=SortDir.ASC),
+    )
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    values = [r["value"] for r in rows]
+    assert values == sorted(values)

--- a/backend/tests/services/test_recurring_source.py
+++ b/backend/tests/services/test_recurring_source.py
@@ -366,18 +366,20 @@ async def test_amount_between_filter(db_session, seeded):
 
 @pytest.mark.asyncio
 async def test_amount_gte_filter(db_session, seeded):
-    """amount GTE 1000 counts only Rent (1200) + Salary (3000). Pins the
-    comparison direction (>= not <=) on the gte branch."""
+    """amount GTE 30 counts Rent (1200) + Salary (3000) + Gym (30) = 3,
+    excluding OldSub (10). Threshold 30 pins the comparison direction: a
+    swapped `<= 30` would yield only {30, 10} = 2, so 3 != 2 catches a
+    gte/lte swap on the gte branch."""
     src = _source()
     ast = _query(
         filters=[
-            Filter(field=FilterField.AMOUNT, op=FilterOp.GTE, value=1000),
+            Filter(field=FilterField.AMOUNT, op=FilterOp.GTE, value=30),
         ],
     )
     src.validate(ast)
     rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
     assert len(rows) == 1
-    assert rows[0]["value"] == 2
+    assert rows[0]["value"] == 3
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_recurring_source.py
+++ b/backend/tests/services/test_recurring_source.py
@@ -364,6 +364,38 @@ async def test_amount_between_filter(db_session, seeded):
     assert rows[0]["value"] == 2
 
 
+@pytest.mark.asyncio
+async def test_amount_gte_filter(db_session, seeded):
+    """amount GTE 1000 counts only Rent (1200) + Salary (3000). Pins the
+    comparison direction (>= not <=) on the gte branch."""
+    src = _source()
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.AMOUNT, op=FilterOp.GTE, value=1000),
+        ],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert len(rows) == 1
+    assert rows[0]["value"] == 2
+
+
+@pytest.mark.asyncio
+async def test_amount_lte_filter(db_session, seeded):
+    """amount LTE 30 counts only Gym (30) + OldSub (10). Pins the comparison
+    direction (<= not >=) on the lte branch, and the boundary (30 inclusive)."""
+    src = _source()
+    ast = _query(
+        filters=[
+            Filter(field=FilterField.AMOUNT, op=FilterOp.LTE, value=30),
+        ],
+    )
+    src.validate(ast)
+    rows, _ = await src.build_rows(db_session, seeded["org1_id"], ast)
+    assert len(rows) == 1
+    assert rows[0]["value"] == 2
+
+
 # ─── op-reject (→422) ───────────────────────────────────────────────
 
 

--- a/backend/tests/services/test_report_sources_registry.py
+++ b/backend/tests/services/test_report_sources_registry.py
@@ -62,6 +62,23 @@ def test_accounts_source_catalog():
     }
 
 
+def test_recurring_source_catalog():
+    src = source_registry.get_source("recurring")
+    assert src.key == "recurring"
+    assert src.label == "Recurring"
+    assert {d.key for d in src.dimensions()} == {
+        "category", "account", "currency", "txn_type", "frequency",
+        "recurring_active",
+    }
+    assert {m.key for m in src.measures()} == {
+        "sum_amount", "avg_amount", "count_recurring",
+    }
+    assert {f.field for f in src.filters()} == {
+        "account_id", "category_id", "currency", "txn_type", "frequency",
+        "recurring_active", "amount",
+    }
+
+
 def test_all_catalog_keys_are_known_kinds():
     known_kinds = {
         "category", "account", "status", "type", "tag", "time",

--- a/frontend/components/reports/WidgetEditorPopover.tsx
+++ b/frontend/components/reports/WidgetEditorPopover.tsx
@@ -235,6 +235,7 @@ export default function WidgetEditorPopover({
                 <FilterEditor
                   filters={widget.config.filters ?? {}}
                   canvasFilters={canvasFilters}
+                  dataset={widget.config.dataset}
                   onChange={setFilters}
                 />
               )}

--- a/frontend/components/reports/config/DataTab.tsx
+++ b/frontend/components/reports/config/DataTab.tsx
@@ -31,6 +31,18 @@ import type {
 } from "@/lib/reports/types";
 
 /**
+ * Pre-load fallback labels for the data-source select, used only while
+ * the ``/sources`` catalog is still loading (so the control never renders
+ * empty). Once the catalog resolves the select lists every source by its
+ * own catalog label instead.
+ */
+const DATASET_FALLBACK_LABELS: Record<Dataset, string> = {
+  transactions: "Transactions",
+  accounts: "Accounts",
+  recurring: "Recurring",
+};
+
+/**
  * Catalog-free dimension options: the static ``DIMENSION_OPTIONS`` plus
  * any of the widget's CURRENT dimension keys that aren't already in that
  * list (e.g. accounts-only ``account_type`` on a persisted accounts widget
@@ -114,9 +126,7 @@ export default function DataTab({
             // Graceful fallback while the catalog loads: show the
             // widget's current source so the control never renders empty.
             <option value={widget.config.dataset}>
-              {widget.config.dataset === "accounts"
-                ? "Accounts"
-                : "Transactions"}
+              {DATASET_FALLBACK_LABELS[widget.config.dataset] ?? "Transactions"}
             </option>
           )}
         </select>

--- a/frontend/components/reports/config/FilterEditor.tsx
+++ b/frontend/components/reports/config/FilterEditor.tsx
@@ -21,6 +21,7 @@ import TagFilter from "@/components/reports/filters/TagFilter";
 import { isFieldOverridden } from "@/lib/reports/resolve";
 import type {
   CanvasFilters,
+  Dataset,
   TagMatch,
   WidgetFilters,
 } from "@/lib/reports/types";
@@ -39,12 +40,21 @@ function OverridePill() {
 export default function FilterEditor({
   filters,
   canvasFilters,
+  dataset,
   onChange,
 }: {
   filters: WidgetFilters;
   canvasFilters: CanvasFilters;
+  /**
+   * The widget's data source. ``transfer`` is a transactions-only
+   * concept (``recurring`` is income/expense only, ``accounts`` has no
+   * txn_type), so the Type control only offers Transfer when the
+   * source is ``transactions`` — otherwise the backend 422s the choice.
+   */
+  dataset: Dataset;
   onChange: (next: WidgetFilters) => void;
 }) {
+  const allowTransfer = dataset === "transactions";
   return (
     <div className="flex flex-col gap-4 rounded-md border border-border bg-bg p-3">
       <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
@@ -106,6 +116,7 @@ export default function FilterEditor({
       <div className="flex flex-col gap-1">
         <TxnTypeRadioRow
           value={filters.txn_type}
+          allowTransfer={allowTransfer}
           onChange={(txn_type) => onChange({ ...filters, txn_type })}
         />
       </div>
@@ -165,9 +176,11 @@ export default function FilterEditor({
 
 function TxnTypeRadioRow({
   value,
+  allowTransfer,
   onChange,
 }: {
   value: "income" | "expense" | "transfer" | undefined;
+  allowTransfer: boolean;
   onChange: (next: "income" | "expense" | "transfer" | undefined) => void;
 }) {
   const name = useId();
@@ -175,7 +188,11 @@ function TxnTypeRadioRow({
     { value: "", label: "Any" },
     { value: "income", label: "Income" },
     { value: "expense", label: "Expense" },
-    { value: "transfer", label: "Transfer" },
+    // ``transfer`` is a transactions-only concept; omit it for sources
+    // whose ``type`` can't be a transfer (recurring / accounts).
+    ...(allowTransfer
+      ? ([{ value: "transfer", label: "Transfer" }] as const)
+      : []),
   ];
   return (
     <>

--- a/frontend/components/reports/config/FilterEditor.tsx
+++ b/frontend/components/reports/config/FilterEditor.tsx
@@ -12,7 +12,7 @@
  * widget-only now (the canvas can't hold them), so they NEVER show the
  * override pill — they're plain per-widget controls.
  */
-import { useId } from "react";
+import { useEffect, useId } from "react";
 
 import AccountFilter from "@/components/reports/filters/AccountFilter";
 import CategoryPicker from "@/components/reports/filters/CategoryPicker";
@@ -194,6 +194,18 @@ function TxnTypeRadioRow({
       ? ([{ value: "transfer", label: "Transfer" }] as const)
       : []),
   ];
+  // Self-heal: when a persisted ``txn_type`` value isn't among the rendered
+  // choices (e.g. ``transfer`` survives in a saved config but the widget is
+  // now on a non-transactions source where Transfer is hidden), reset it to
+  // "Any" once so the control never shows a phantom no-selection-with-stale-
+  // value state. ``onChange(undefined)`` makes ``value`` undefined, which IS
+  // in-range, so the effect won't re-fire (no loop). The transactions case
+  // keeps ``transfer`` because it's a rendered choice there.
+  const valueInRange =
+    value === undefined || choices.some((c) => c.value === value);
+  useEffect(() => {
+    if (!valueInRange) onChange(undefined);
+  }, [valueInRange, onChange]);
   return (
     <>
       <div className="text-xs text-text-secondary">Transaction type</div>

--- a/frontend/components/reports/config/useWidgetMutations.ts
+++ b/frontend/components/reports/config/useWidgetMutations.ts
@@ -137,6 +137,30 @@ export function buildWidgetMutations(
     // Filter fields the NEW source publishes. ``config.filters`` is
     // pruned to these so no stale per-widget filter survives a switch.
     const publishedFilterFields = entry.filters.map((f) => f.field);
+
+    /**
+     * Prune the per-widget filters to the new source's published FIELDS,
+     * then normalize any stale enum VALUE that survives the field prune
+     * but is invalid for the new source. ``pruneFiltersToSource`` only
+     * drops fields; it never inspects values. The ``recurring`` source
+     * DOES publish a ``txn_type`` filter, so a stale ``txn_type:"transfer"``
+     * survives a transactions→recurring switch — but ``transfer`` is a
+     * transactions-only concept (recurring is income/expense only) and the
+     * backend ``RecurringSource.validate()`` 422s it. Strip it here so the
+     * widget never silently fails to render. ``txn_type`` is the only
+     * enum-valued filter today, so a targeted strip suffices.
+     */
+    const finalizeFilters = (
+      filters: WidgetFilters | undefined,
+    ): WidgetFilters | undefined => {
+      const pruned = pruneFiltersToSource(filters, publishedFilterFields);
+      if (!pruned) return undefined;
+      if (dataset !== "transactions" && pruned.txn_type === "transfer") {
+        const { txn_type: _drop, ...rest } = pruned;
+        return Object.keys(rest).length > 0 ? rest : undefined;
+      }
+      return pruned;
+    };
     // First valid measure for this source (default after a field-invalid
     // switch). ``entry.measures`` is always non-empty for a real source;
     // guard for the degenerate empty-catalog case so we never write an
@@ -154,7 +178,7 @@ export function buildWidgetMutations(
         resetMeasure && !measureFields.has(cfg.measure.field)
           ? resetMeasure
           : cfg.measure;
-      const filters = pruneFiltersToSource(cfg.filters, publishedFilterFields);
+      const filters = finalizeFilters(cfg.filters);
       const next: Widget = {
         ...widget,
         config: { ...cfg, dataset, measure, filters },
@@ -191,7 +215,7 @@ export function buildWidgetMutations(
         allValid || !resetMeasure
           ? mcfg.measures
           : [{ measure: resetMeasure }];
-      const filters = pruneFiltersToSource(mcfg.filters, publishedFilterFields);
+      const filters = finalizeFilters(mcfg.filters);
       const next: Widget = {
         ...widget,
         config: { ...mcfg, dataset, dimensions: dims, measures, filters },
@@ -205,7 +229,7 @@ export function buildWidgetMutations(
       resetMeasure && !measureFields.has(scfg.measure.field)
         ? resetMeasure
         : scfg.measure;
-    const filters = pruneFiltersToSource(scfg.filters, publishedFilterFields);
+    const filters = finalizeFilters(scfg.filters);
     const next: Widget = {
       ...widget,
       config: { ...scfg, dataset, dimensions: dims, measure, filters },

--- a/frontend/lib/reports/series.ts
+++ b/frontend/lib/reports/series.ts
@@ -40,6 +40,8 @@ export const DIMENSION_HEADERS: Record<Dimension, string> = {
   account_type: "Account type",
   currency: "Currency",
   account_active: "Active",
+  frequency: "Frequency",
+  recurring_active: "Status",
 };
 
 /** Header label for a dimension key, falling back to the raw key. */

--- a/frontend/lib/reports/types.ts
+++ b/frontend/lib/reports/types.ts
@@ -24,7 +24,7 @@ export type WidgetType =
 // values to the editor's ``addWidget`` factory.
 export type WidgetTypeV1 = WidgetType;
 
-export type Dataset = "transactions" | "accounts";
+export type Dataset = "transactions" | "accounts" | "recurring";
 
 export type Aggregation = "sum" | "count" | "avg" | "distinct";
 
@@ -47,7 +47,9 @@ export type Dimension =
   | "day"
   | "account_type"
   | "currency"
-  | "account_active";
+  | "account_active"
+  | "frequency"
+  | "recurring_active";
 
 export type FilterField =
   | "date"

--- a/frontend/tests/components/reports/config/FilterEditor.test.tsx
+++ b/frontend/tests/components/reports/config/FilterEditor.test.tsx
@@ -7,7 +7,7 @@ import { renderWithSWR, fireEvent, screen } from "../../../utils/render-with-swr
 
 import FilterEditor from "@/components/reports/config/FilterEditor";
 import { apiFetch } from "@/lib/api";
-import type { CanvasFilters, WidgetFilters } from "@/lib/reports/types";
+import type { CanvasFilters, Dataset, WidgetFilters } from "@/lib/reports/types";
 import type { Account, Category } from "@/lib/types";
 
 vi.mock("@/lib/api", () => ({
@@ -70,12 +70,14 @@ function render(
   filters: WidgetFilters,
   canvasFilters: CanvasFilters,
   onChange: (next: WidgetFilters) => void = () => {},
+  dataset: Dataset = "transactions",
 ) {
   return renderWithSWR(
     <FilterEditor
       filters={filters}
       canvasFilters={canvasFilters}
       onChange={onChange}
+      dataset={dataset}
     />,
   );
 }
@@ -145,6 +147,28 @@ describe("FilterEditor", () => {
     await screen.findByTestId("category-picker");
     fireEvent.click(screen.getByLabelText("Widget transaction type Any"));
     expect(calls.at(-1)?.txn_type).toBeUndefined();
+  });
+
+  it("offers the Transfer transaction type for a transactions widget", async () => {
+    render({}, {}, () => {}, "transactions");
+    await screen.findByTestId("category-picker");
+    expect(
+      screen.getByLabelText("Widget transaction type Transfer"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the Transfer transaction type for a recurring widget", async () => {
+    render({}, {}, () => {}, "recurring");
+    await screen.findByTestId("category-picker");
+    expect(
+      screen.getByLabelText("Widget transaction type Income"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Widget transaction type Expense"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Widget transaction type Transfer"),
+    ).not.toBeInTheDocument();
   });
 
   it("reports tag_names + tag_match when a tag chip is selected", async () => {

--- a/frontend/tests/components/reports/config/FilterEditor.test.tsx
+++ b/frontend/tests/components/reports/config/FilterEditor.test.tsx
@@ -171,6 +171,28 @@ describe("FilterEditor", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("self-heals a persisted txn_type=transfer on a recurring widget to 'Any'", async () => {
+    const calls: WidgetFilters[] = [];
+    // A widget persisted on transactions with txn_type=transfer, later
+    // switched to recurring (where transfer is hidden). The orphan value
+    // must self-correct on mount so the control never shows a phantom
+    // no-selection-with-stale-value state.
+    render({ txn_type: "transfer" }, {}, (next) => calls.push(next), "recurring");
+    await screen.findByTestId("category-picker");
+    // The self-heal effect MUST have fired (not vacuously empty) and cleared
+    // the orphan value.
+    expect(calls).toHaveLength(1);
+    expect(calls.at(-1)?.txn_type).toBeUndefined();
+  });
+
+  it("does NOT self-heal a valid txn_type=transfer on a transactions widget", async () => {
+    const calls: WidgetFilters[] = [];
+    render({ txn_type: "transfer" }, {}, (next) => calls.push(next), "transactions");
+    await screen.findByTestId("category-picker");
+    // transfer is a valid choice for transactions → no auto-clear fires.
+    expect(calls).toHaveLength(0);
+  });
+
   it("reports tag_names + tag_match when a tag chip is selected", async () => {
     const calls: WidgetFilters[] = [];
     render({}, {}, (next) => calls.push(next));

--- a/frontend/tests/components/reports/config/filter-editor-override-pill.test.tsx
+++ b/frontend/tests/components/reports/config/filter-editor-override-pill.test.tsx
@@ -82,6 +82,7 @@ function renderEditor(
     <FilterEditor
       filters={filters}
       canvasFilters={canvasFilters}
+      dataset="transactions"
       onChange={onChange}
     />,
   );

--- a/frontend/tests/components/reports/data-tab-source-picker.test.tsx
+++ b/frontend/tests/components/reports/data-tab-source-picker.test.tsx
@@ -70,6 +70,34 @@ const CATALOG: SourceCatalogEntry[] = [
       { field: "balance", label: "Balance", ops: ["between"], kind: "number" },
     ],
   },
+  {
+    key: "recurring",
+    label: "Recurring",
+    dimensions: [
+      { key: "category", label: "Category", kind: "categorical" },
+      { key: "account", label: "Account", kind: "categorical" },
+      { key: "currency", label: "Currency", kind: "categorical" },
+      { key: "txn_type", label: "Type", kind: "categorical" },
+      { key: "frequency", label: "Frequency", kind: "categorical" },
+      { key: "recurring_active", label: "Status", kind: "categorical" },
+    ],
+    measures: [
+      { key: "sum_amount", label: "Sum of amount", agg: "sum", field: "amount", format: "currency" },
+      { key: "avg_amount", label: "Average amount", agg: "avg", field: "amount", format: "currency" },
+      { key: "count_recurring", label: "Recurring count", agg: "count", field: "id", format: "number" },
+    ],
+    // Recurring publishes account_id / category_id / currency / txn_type /
+    // frequency / recurring_active / amount — but NOT date or tag_name.
+    filters: [
+      { field: "account_id", label: "Account", ops: ["in"], kind: "account" },
+      { field: "category_id", label: "Category", ops: ["in"], kind: "category" },
+      { field: "currency", label: "Currency", ops: ["in"], kind: "currency" },
+      { field: "txn_type", label: "Type", ops: ["eq"], kind: "type" },
+      { field: "frequency", label: "Frequency", ops: ["eq"], kind: "frequency" },
+      { field: "recurring_active", label: "Status", ops: ["eq"], kind: "boolean" },
+      { field: "amount", label: "Amount", ops: ["between"], kind: "amount" },
+    ],
+  },
 ];
 
 beforeEach(() => {
@@ -308,6 +336,82 @@ it("drops the whole filters blob when no widget filter survives the switch", () 
   const next = onUpdate.mock.calls[0][0] as BarWidget;
   // category_ids + txn_type both unpublished by accounts → no filters.
   expect(next.config.filters).toBeUndefined();
+});
+
+it("lists the Recurring source and switches dataset to recurring with valid defaults", () => {
+  const onUpdate = vi.fn();
+  renderWithSWR(<DataTab widget={makeBar()} onUpdate={onUpdate} />);
+
+  expect(
+    screen.getByRole("option", { name: "Recurring" }),
+  ).toBeInTheDocument();
+
+  fireEvent.change(screen.getByLabelText("Data source"), {
+    target: { value: "recurring" },
+  });
+
+  expect(onUpdate).toHaveBeenCalledTimes(1);
+  const next = onUpdate.mock.calls[0][0] as BarWidget;
+  expect(next.config.dataset).toBe("recurring");
+  // ``category`` is a recurring dimension → kept as the primary dim.
+  expect(next.config.dimensions[0]).toBe("category");
+  // sum_amount → field ``amount`` is a valid recurring measure, so the
+  // transactions measure ({sum, amount}) survives the switch unchanged.
+  expect(next.config.measure).toEqual({ agg: "sum", field: "amount" });
+});
+
+it("offers the recurring-only Frequency dimension after switching to recurring", () => {
+  const onUpdate = vi.fn();
+  // Render a widget already on the recurring source so the dimension select
+  // is driven by the recurring catalog.
+  const recurringBar: BarWidget = {
+    ...makeBar(),
+    config: {
+      dataset: "recurring",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+    },
+  };
+  renderWithSWR(<DataTab widget={recurringBar} onUpdate={onUpdate} />);
+
+  const dimSelect = screen.getByLabelText(
+    "Primary dimension",
+  ) as HTMLSelectElement;
+  const labels = Array.from(dimSelect.options).map((o) => o.textContent);
+  expect(labels).toContain("Frequency");
+  expect(labels).toContain("Status");
+});
+
+it("prunes tag_names + date_range but keeps category_ids on switch to recurring", () => {
+  const onUpdate = vi.fn();
+  const widget: BarWidget = {
+    ...makeBar(),
+    config: {
+      ...makeBar().config,
+      filters: {
+        // Survives: recurring publishes ``category_id`` and ``account_id``.
+        category_ids: [9],
+        account_ids: [1, 2],
+        // Pruned: recurring publishes neither ``tag_name`` nor ``date``.
+        tag_names: ["foo"],
+        tag_match: "any",
+        date_range: { start: "2026-01-01", end: "2026-01-31" },
+      },
+    },
+  };
+  renderWithSWR(<DataTab widget={widget} onUpdate={onUpdate} />);
+
+  fireEvent.change(screen.getByLabelText("Data source"), {
+    target: { value: "recurring" },
+  });
+
+  const next = onUpdate.mock.calls[0][0] as BarWidget;
+  expect(next.config.dataset).toBe("recurring");
+  // category_ids + account_ids survive; tag_names/tag_match/date_range gone.
+  expect(next.config.filters).toEqual({
+    category_ids: [9],
+    account_ids: [1, 2],
+  });
 });
 
 it("persisted accounts widget rendered before /sources resolves has no value/options mismatch", () => {

--- a/frontend/tests/components/reports/data-tab-source-picker.test.tsx
+++ b/frontend/tests/components/reports/data-tab-source-picker.test.tsx
@@ -414,6 +414,77 @@ it("prunes tag_names + date_range but keeps category_ids on switch to recurring"
   });
 });
 
+it("clears a stale txn_type=transfer on switch to recurring (transfer invalid there)", () => {
+  const onUpdate = vi.fn();
+  const widget: BarWidget = {
+    ...makeBar(),
+    config: {
+      ...makeBar().config,
+      filters: {
+        // recurring publishes ``txn_type`` so the FIELD survives the prune,
+        // but ``transfer`` is invalid for recurring (income/expense only) —
+        // the stale VALUE must be stripped or the backend validate() 422s.
+        txn_type: "transfer",
+      },
+    },
+  };
+  renderWithSWR(<DataTab widget={widget} onUpdate={onUpdate} />);
+
+  fireEvent.change(screen.getByLabelText("Data source"), {
+    target: { value: "recurring" },
+  });
+
+  const next = onUpdate.mock.calls[0][0] as BarWidget;
+  expect(next.config.dataset).toBe("recurring");
+  // ``txn_type`` was the only filter and its value was invalid → whole
+  // blob drops to undefined (matching pruneFiltersToSource's empty behavior).
+  expect(next.config.filters).toBeUndefined();
+});
+
+it("keeps a valid txn_type but clears transfer on switch to recurring", () => {
+  const onUpdate = vi.fn();
+  const widget: BarWidget = {
+    ...makeBar(),
+    config: {
+      ...makeBar().config,
+      filters: {
+        txn_type: "transfer",
+        // survives: recurring publishes ``category_id``.
+        category_ids: [9],
+      },
+    },
+  };
+  renderWithSWR(<DataTab widget={widget} onUpdate={onUpdate} />);
+
+  fireEvent.change(screen.getByLabelText("Data source"), {
+    target: { value: "recurring" },
+  });
+
+  const next = onUpdate.mock.calls[0][0] as BarWidget;
+  // category_ids survives; the invalid transfer txn_type is stripped.
+  expect(next.config.filters).toEqual({ category_ids: [9] });
+});
+
+it("keeps a valid txn_type=expense on switch to recurring", () => {
+  const onUpdate = vi.fn();
+  const widget: BarWidget = {
+    ...makeBar(),
+    config: {
+      ...makeBar().config,
+      filters: { txn_type: "expense" },
+    },
+  };
+  renderWithSWR(<DataTab widget={widget} onUpdate={onUpdate} />);
+
+  fireEvent.change(screen.getByLabelText("Data source"), {
+    target: { value: "recurring" },
+  });
+
+  const next = onUpdate.mock.calls[0][0] as BarWidget;
+  // ``expense`` is valid for recurring → preserved unchanged.
+  expect(next.config.filters).toEqual({ txn_type: "expense" });
+});
+
 it("persisted accounts widget rendered before /sources resolves has no value/options mismatch", () => {
   // Catalog still loading: sources empty. The accounts widget's stored
   // dimension (``account_type``) and field (``balance``) must still have a

--- a/frontend/tests/lib/reports/resolve-dataset.test.tsx
+++ b/frontend/tests/lib/reports/resolve-dataset.test.tsx
@@ -63,7 +63,33 @@ const TRANSACTIONS_SOURCE: SourceCatalogEntry = {
   ],
 };
 
-const SOURCES: SourceCatalogEntry[] = [ACCOUNTS_SOURCE, TRANSACTIONS_SOURCE];
+const RECURRING_SOURCE: SourceCatalogEntry = {
+  key: "recurring",
+  label: "Recurring",
+  dimensions: [
+    { key: "category", label: "Category", kind: "category" },
+    { key: "frequency", label: "Frequency", kind: "category" },
+  ],
+  measures: [
+    {
+      key: "sum_amount",
+      label: "Sum of amount",
+      agg: "sum",
+      field: "amount",
+      format: "currency",
+    },
+  ],
+  // No ``date`` filter — recurring templates have no transaction date.
+  filters: [
+    { field: "amount", label: "Amount", ops: ["between"], kind: "amount" },
+  ],
+};
+
+const SOURCES: SourceCatalogEntry[] = [
+  ACCOUNTS_SOURCE,
+  TRANSACTIONS_SOURCE,
+  RECURRING_SOURCE,
+];
 
 function accountsBarWidget(): BarWidget {
   return {
@@ -75,6 +101,20 @@ function accountsBarWidget(): BarWidget {
       dataset: "accounts",
       measure: { agg: "sum", field: "balance" },
       dimensions: ["account_type"],
+    },
+  };
+}
+
+function recurringBarWidget(): BarWidget {
+  return {
+    id: "w-recurring",
+    type: "bar",
+    title: "Recurring spend by category",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "recurring",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
     },
   };
 }
@@ -102,6 +142,10 @@ describe("sourceSupportsDateFilter", () => {
     expect(sourceSupportsDateFilter(SOURCES, "transactions")).toBe(true);
   });
 
+  it("is false for the recurring source (no date filter)", () => {
+    expect(sourceSupportsDateFilter(SOURCES, "recurring")).toBe(false);
+  });
+
   it("defaults to true when the catalog is empty (pre-load)", () => {
     expect(sourceSupportsDateFilter([], "transactions")).toBe(true);
     expect(sourceSupportsDateFilter([], "accounts")).toBe(true);
@@ -122,6 +166,16 @@ describe("buildQueryAst — dataset stamping + date-less source", () => {
       sourceSupportsDateFilter(SOURCES, "accounts"),
     );
     expect(ast.dataset).toBe("accounts");
+    expect(ast.filters.some((f) => f.field === "date")).toBe(false);
+  });
+
+  it("stamps dataset='recurring' and OMITS the canvas date filter", () => {
+    const ast = buildQueryAst(
+      recurringBarWidget(),
+      CANVAS_DATE,
+      sourceSupportsDateFilter(SOURCES, "recurring"),
+    );
+    expect(ast.dataset).toBe("recurring");
     expect(ast.filters.some((f) => f.field === "date")).toBe(false);
   });
 

--- a/specs/2026-06-14-reports-v3-phase5b-recurring-source-design.md
+++ b/specs/2026-06-14-reports-v3-phase5b-recurring-source-design.md
@@ -1,0 +1,53 @@
+# Reports v3 — Phase 5b: RecurringSource
+
+**Date:** 2026-06-14
+**Status:** design approved (inline brainstorm), building
+**Scope:** add a third `ReportSource` (`recurring`) — the symmetric follow-on to AccountsSource (Phase 5, #450) on the same registry. All shared plumbing (enum widening → per-source `validate()` with op-enforcement → catalog-driven picker → sort → date-omission) is proven; this is a near-mechanical mirror.
+
+## Goal
+Let users build report widgets over their **recurring-transaction templates** — total/average recurring amount and template counts, grouped by category, account, currency, type, frequency, or active status. Proves the registry scales to a third source and completes the "new data sources" remainder of Reports v3.
+
+`recurring_transactions` (one row per template): `amount` (Numeric, in the account's currency), `type` (income/expense — NO transfer), `frequency` (Frequency enum: weekly/biweekly/monthly/quarterly/yearly), `account_id`, `category_id`, `next_due_date`, `auto_settle`, `is_active`. **No tags** (obs 20439). Source = `recurring_transactions JOIN accounts JOIN categories`, org-scoped on `recurring_transactions.org_id`.
+
+## Reportable surface
+
+### Dimensions
+| Key | Source column | Note |
+|---|---|---|
+| `category` | `categories.name` | existing key |
+| `account` | `accounts.name` | existing key |
+| `currency` | `accounts.currency` | existing key — cross-currency grouping lever |
+| `txn_type` | `recurring_transactions.type` | existing key (income/expense) |
+| `frequency` | `recurring_transactions.frequency` | **new** (weekly…yearly) |
+| `recurring_active` | `recurring_transactions.is_active` → "Active"/"Inactive" | **new**, kind `boolean` (mirrors `account_active`) |
+
+### Measures
+| Key | Label | Agg | Field | Format |
+|---|---|---|---|---|
+| `sum_amount` | Total recurring amount | sum | `amount` | currency |
+| `avg_amount` | Average amount | avg | `amount` | currency |
+| `count_recurring` | Recurring count | count | `id` | number |
+
+No new `MeasureField` (reuses `amount`/`id`).
+
+### Filters
+`account_id` (in), `category_id` (eq/in), `currency` (eq/in), `txn_type` (eq/in), `frequency` (eq/in — new), `recurring_active` (eq — new), `amount` (between/gte/lte). **No `date`** — recurring is treated date-less for the canvas bar (the canvas date range is transaction-date scoped, not template due-date). `next_due_date` filtering is a possible follow-on, out of scope.
+
+## Product decision (operator-confirmed 2026-06-14)
+**Include all templates by default; expose `recurring_active` as a dimension + filter** so users can exclude paused ones — matching the AccountsSource precedent (consistent across sources). A "total recurring" includes paused templates unless filtered.
+
+## Architecture
+- **Enum widening** (`reports_enums.py` + `reports_query.py`): `Dataset.RECURRING="recurring"`; `Dimension.FREQUENCY="frequency"`, `Dimension.RECURRING_ACTIVE="recurring_active"`; `FilterField.FREQUENCY="frequency"`, `FilterField.RECURRING_ACTIVE="recurring_active"`. Filter coercion: `frequency` → validated against the Frequency enum values; `recurring_active` → bool (mirror `account_active`). **No migration** (JSON-column enums).
+- **`app/reports/sources/recurring.py`** — `RecurringSource`: catalog + org-scoped compiler over `recurring_transactions JOIN accounts JOIN categories`. `recurring_active` normalized via SQL `case(...)` to "Active"/"Inactive". Honors `query.sort` + `RecurringTransaction.id` tiebreaker. Filters op-enforced via the shared `validate_against_catalog`. `validate()` delegates to `validate_against_catalog`. Self-registers.
+- **Frontend** (mostly free — picker is catalog-driven): `types.ts` `Dataset += "recurring"`, `Dimension += "frequency" | "recurring_active"`; add labels for `frequency`/`recurring_active` to the dimension label maps + `DIMENSION_HEADERS` (`series.ts`) so `tsc` is satisfied. `pruneFiltersToSource` already drops tag/date when switching to recurring (no new mapping — `frequency`/`recurring_active` are not WidgetFilters keys). The per-widget filter EDITOR keeps its existing controls (a `frequency` filter control is a possible follow-on; grouping by frequency works immediately via the catalog-driven dimension picker).
+
+## De-scoped (flagged, not silently dropped)
+- **`category_master`** grouping for recurring (needs the parent-category self-join + helper extraction from `reports_query_service`) — follow-on; plain `category` covers the common case.
+- **`next_due_date`** "due-in-period" filter / time dimensions — follow-on.
+- **Per-widget `frequency` filter UI control** — the field is published in the catalog; the editor UI control is a follow-on. Grouping by frequency is available now.
+
+## Tests
+Backend: catalog exactness; org isolation; `frequency` + `recurring_active` dimension grouping (boolean → "Active"/"Inactive" stable strings); sum/avg/count measures; IN filters (account_id/category_id/currency/txn_type/frequency); `recurring_active` eq filter; amount between; op-reject (e.g. `frequency between` → 422); cross-source reject (`balance` measure / `frequency` dim on transactions → 422); date-drop tolerance; enum drift guard; registry exhaustiveness (`recurring` registered). Frontend: source picker lists Recurring + switches dims/measures; switching to recurring prunes tag/date filters; multi-series + KPI switch.
+
+## Process
+Subagent-driven, review gate per task; final fleet/targeted review before merge (mirrors a pattern already fleet-reviewed in #450). Backend tests in the isolated `-p team-recsrc` stack; frontend full `eslint . --quiet` + `tsc --noEmit` + `vitest run`.


### PR DESCRIPTION
## Reports v3 Phase 5b — RecurringSource

The symmetric follow-on to AccountsSource (#450): a third `ReportSource` (`recurring`) on the registry, completing the "new data sources" remainder of Reports v3.

### What it adds
Report widgets over **recurring-transaction templates** — total/average recurring amount and template counts, grouped/filtered by **category, account, currency, type, frequency, or active status**. Source = `recurring_transactions JOIN accounts JOIN categories`, org-scoped on `recurring_transactions.org_id`.

### Backend
- New `app/reports/sources/recurring.py` (`RecurringSource`), mirroring the proven `accounts` source: org-scoped compiler, `case`-normalized `recurring_active`, `sort` + stable tiebreaker, op-enforced filters via `validate_against_catalog`.
- Enum widening: `Dataset.RECURRING`, `Dimension.FREQUENCY` + `RECURRING_ACTIVE`, `FilterField` same + coercion (frequency validated vs the `Frequency` enum). **No migration** (JSON-column enums).
- **Recurring-specific handling:** `frequency` is a true Python enum → dimension keys normalized to plain strings; `type` is income/expense only → `RecurringSource.validate()` rejects a `txn_type=transfer` filter (422) rather than silently returning empty.

### Frontend
- Catalog-driven, so mostly free: `Dataset`/`Dimension` unions widened + labels; the source picker lists **Recurring** and drives its dims/measures automatically.
- Filter editor hides the **Transfer** type option for non-transactions sources (no more 422-producing selection).
- Resolver omits the date filter for recurring (date-less, like accounts).

### De-scoped (flagged, not silent): `category_master` grouping, a `next_due_date` filter, and a per-widget `frequency` filter UI control — all possible follow-ons; grouping by frequency works now.

Built subagent-driven (review gate per task) → **focused adversarial fleet review** (10 agents) → 5 findings, all fixed (transfer-reject + 4 test-quality). Backend 157 report tests green, frontend 1848 green, eslint+tsc clean. Spec: `specs/2026-06-14-reports-v3-phase5b-recurring-source-design.md`.