### PR TITLE
feat(ai): universal projected-overspend gate at AI dispatch

### DIFF
--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -1620,12 +1620,22 @@ async def call_llm_function(
     max_tokens: Optional[int] = None,
 ) -> FunctionCallDispatchResult:
     """Dispatch a function-calling chat through the chokepoint."""
+    # The provider bills the ``tools`` JSON schemas as PROMPT tokens, so
+    # fold them into the gate's projection by appending a serialized copy
+    # as a synthetic prompt message. This keeps the projected prompt cost
+    # honest for function-calling without altering the real adapter call
+    # below (which still passes the original ``messages`` + ``tools``).
+    gate_messages = (
+        messages + [{"role": "user", "content": json.dumps(tools)}]
+        if tools
+        else messages
+    )
     prepared = await _prepare_dispatch(
         db,
         org_id=org_id,
         feature_key=feature_key,
         capability="function_call",
-        messages=messages,
+        messages=gate_messages,
         max_tokens=max_tokens,
         retry_multiplier=1,
     )

--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -1074,9 +1074,12 @@ async def _prepare_dispatch(
 
     ``messages``/``max_tokens``/``retry_multiplier`` feed the universal
     projected-overspend gate (``_enforce_cap``) after ``model`` is
-    resolved. Embedding callers with no chat payload pass ``messages=[]``
-    and ``max_tokens=None`` (projection degrades to the model output
-    ceiling); structured-output callers pass their retry budget.
+    resolved. Embedding callers synthesize a ``messages`` payload from
+    their INPUT (the texts to embed) so the gate projects the embedding
+    INPUT cost as prompt tokens, with ``max_tokens=None`` resolving to
+    the model output ceiling (0 for embedding models, which emit no
+    completion tokens); structured-output callers pass their retry
+    budget.
 
     Raises ``NoRoutingConfigured``, ``AICapExceeded``, or
     ``AICapabilityNotSupported`` before the adapter is built. The
@@ -1497,15 +1500,21 @@ async def call_llm_embed(
     caller can override with the ``model`` kwarg if a feature surface
     pins a specific model.
     """
+    # Embeddings bill on their INPUT, so feed ``texts`` to the gate as a
+    # synthetic prompt payload. ``_projected_cost_cents`` then estimates
+    # prompt tokens from the joined input and prices it at the embedding
+    # input rate; ``max_tokens=None`` resolves the model output ceiling,
+    # which is 0 for embedding models (they emit no completion tokens),
+    # so projected == the embedding INPUT cost. Without this the gate saw
+    # an empty payload (projected 0) and embeddings got exhausted-only
+    # protection, letting a bulk batch overspend by its full cost.
+    gate_messages = [{"role": "user", "content": "\n".join(texts)}]
     prepared = await _prepare_dispatch(
         db,
         org_id=org_id,
         feature_key=feature_key,
         capability="embed",
-        # Embeddings have no chat messages/max_tokens; projection
-        # degrades to the model output ceiling (zero for embedding
-        # models, which only bill input).
-        messages=[],
+        messages=gate_messages,
         max_tokens=None,
         retry_multiplier=1,
     )

--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -83,6 +83,10 @@ from app.models.user import Role, User
 from app.services import ai_routing_service, notification_service
 from app.services.ai_credential_crypto import decrypt
 from app.services.ai_pricing import estimate_cost_cents
+from app.services.ai_token_estimate import (
+    default_max_output_tokens_for,
+    estimate_prompt_tokens_from_messages,
+)
 from app.services.ai_providers import (
     AIProviderError,
     CapabilityNotSupported,
@@ -503,6 +507,107 @@ async def remaining_hard_cap_cents(
     return resolved.hard_cap_cents - cost_so_far
 
 
+# --- Projected-overspend gate ----------------------------------------
+
+
+def _projected_cost_cents(
+    model: str,
+    messages: list[dict],
+    max_tokens: Optional[int],
+    *,
+    retry_multiplier: int = 1,
+) -> int:
+    """Conservative worst-case cost (cents) for a not-yet-made call.
+
+    Prompt tokens come from the shared char heuristic over ``messages``;
+    completion tokens are the caller's pinned ``max_tokens`` or the
+    model's worst-case output ceiling when unpinned. ``retry_multiplier``
+    scales the single-call estimate for callers that retry and aggregate
+    spend across attempts (e.g. structured output). Unknown models price
+    via ``estimate_cost_cents``'s conservative ``_default`` row, so the
+    projection is always computable.
+    """
+    prompt_tokens = estimate_prompt_tokens_from_messages(messages)
+    completion_tokens = (
+        max_tokens if max_tokens else default_max_output_tokens_for(model)
+    )
+    single = estimate_cost_cents(
+        model=model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+    )
+    return single * retry_multiplier
+
+
+def _enforce_cap(
+    *,
+    resolved: "_ResolvedCaps",
+    cost_so_far: int,
+    model: str,
+    messages: list[dict],
+    max_tokens: Optional[int],
+    retry_multiplier: int,
+    org_id: int,
+    feature_key: str,
+    capability: Optional[str] = None,
+) -> None:
+    """Universal hard-cap gate: block if already exhausted OR if this
+    call's conservative projected cost would tip the org over its hard
+    cap. Raises ``AICapExceeded`` (→ 402 ``ai_hard_cap_exceeded``).
+
+    No cap configured (``hard_cap_cents is None``) → no gate.
+
+    Fail-closed: if projection raises for any reason, ``projected`` is
+    pinned to 0 and a warning is logged. This degrades the gate to
+    exhausted-only enforcement — it never skips the gate and never 500s
+    the dispatch hot path. The explicit ``cost_so_far >= hard_cap`` arm
+    keeps an at-cap org blocked even when ``projected`` is 0.
+
+    Writes no ledger row and no audit event at this layer (matches the
+    prior inline exhausted block); ``AICapExceeded`` is audited as a
+    success-precondition by the routers.
+    """
+    if resolved.hard_cap_cents is None:
+        return
+
+    try:
+        projected = _projected_cost_cents(
+            model,
+            messages,
+            max_tokens,
+            retry_multiplier=retry_multiplier,
+        )
+    except Exception as exc:  # noqa: BLE001 - fail closed, never crash dispatch
+        projected = 0
+        logger.warning(
+            "ai.dispatch.cap.projection_failed",
+            org_id=org_id,
+            feature_key=feature_key,
+            capability=capability,
+            error_class=type(exc).__name__,
+        )
+
+    if (
+        cost_so_far >= resolved.hard_cap_cents
+        or cost_so_far + projected > resolved.hard_cap_cents
+    ):
+        logger.info(
+            "ai.dispatch.cap.exceeded",
+            org_id=org_id,
+            feature_key=feature_key,
+            capability=capability,
+            cost_so_far=cost_so_far,
+            hard_cap_cents=resolved.hard_cap_cents,
+            projected_cost_cents=projected,
+            reason=(
+                "exhausted"
+                if cost_so_far >= resolved.hard_cap_cents
+                else "projected"
+            ),
+        )
+        raise AICapExceeded()
+
+
 # --- Soft-cap warning -------------------------------------------------
 
 
@@ -740,22 +845,21 @@ async def call_llm(
         )
         raise NoRoutingConfigured()
 
-    # 2. Pre-check caps.
+    # 2. Pre-check caps (exhausted + projected-overspend gate).
     resolved, cost_so_far = await _resolve_caps_and_cost(
         db, org_id=org_id, feature_key=feature_key
     )
-    if (
-        resolved.hard_cap_cents is not None
-        and cost_so_far >= resolved.hard_cap_cents
-    ):
-        logger.info(
-            "ai.dispatch.cap.exceeded",
-            org_id=org_id,
-            feature_key=feature_key,
-            cost_so_far=cost_so_far,
-            hard_cap_cents=resolved.hard_cap_cents,
-        )
-        raise AICapExceeded()
+    _enforce_cap(
+        resolved=resolved,
+        cost_so_far=cost_so_far,
+        model=model,
+        messages=(request_payload.get("messages") or []),
+        max_tokens=request_payload.get("max_tokens"),
+        retry_multiplier=1,
+        org_id=org_id,
+        feature_key=feature_key,
+        capability=capability,
+    )
 
     # 3. Soft-cap warning (first-time-in-period).
     await _maybe_warn_soft_cap(
@@ -962,8 +1066,17 @@ async def _prepare_dispatch(
     org_id: int,
     feature_key: str,
     capability: str,
+    messages: list[dict],
+    max_tokens: Optional[int],
+    retry_multiplier: int = 1,
 ) -> _PreparedDispatch:
     """Resolve routing + credential + caps for one dispatch.
+
+    ``messages``/``max_tokens``/``retry_multiplier`` feed the universal
+    projected-overspend gate (``_enforce_cap``) after ``model`` is
+    resolved. Embedding callers with no chat payload pass ``messages=[]``
+    and ``max_tokens=None`` (projection degrades to the model output
+    ceiling); structured-output callers pass their retry budget.
 
     Raises ``NoRoutingConfigured``, ``AICapExceeded``, or
     ``AICapabilityNotSupported`` before the adapter is built. The
@@ -1027,19 +1140,17 @@ async def _prepare_dispatch(
     resolved, cost_so_far = await _resolve_caps_and_cost(
         db, org_id=org_id, feature_key=feature_key
     )
-    if (
-        resolved.hard_cap_cents is not None
-        and cost_so_far >= resolved.hard_cap_cents
-    ):
-        logger.info(
-            "ai.dispatch.cap.exceeded",
-            org_id=org_id,
-            feature_key=feature_key,
-            capability=capability,
-            cost_so_far=cost_so_far,
-            hard_cap_cents=resolved.hard_cap_cents,
-        )
-        raise AICapExceeded()
+    _enforce_cap(
+        resolved=resolved,
+        cost_so_far=cost_so_far,
+        model=model,
+        messages=messages,
+        max_tokens=max_tokens,
+        retry_multiplier=retry_multiplier,
+        org_id=org_id,
+        feature_key=feature_key,
+        capability=capability,
+    )
 
     await _maybe_warn_soft_cap(
         db,
@@ -1167,6 +1278,12 @@ async def call_llm_structured(
         org_id=org_id,
         feature_key=feature_key,
         capability="structured_output",
+        messages=messages,
+        max_tokens=max_tokens,
+        # Structured output retries up to STRUCTURED_OUTPUT_MAX_RETRIES and
+        # aggregates token spend across every attempt, so project the
+        # worst case: all attempts billed.
+        retry_multiplier=STRUCTURED_OUTPUT_MAX_RETRIES + 1,
     )
 
     retry_message = {
@@ -1385,6 +1502,12 @@ async def call_llm_embed(
         org_id=org_id,
         feature_key=feature_key,
         capability="embed",
+        # Embeddings have no chat messages/max_tokens; projection
+        # degrades to the model output ceiling (zero for embedding
+        # models, which only bill input).
+        messages=[],
+        max_tokens=None,
+        retry_multiplier=1,
     )
     embed_model = model or prepared.model
 
@@ -1493,6 +1616,9 @@ async def call_llm_function(
         org_id=org_id,
         feature_key=feature_key,
         capability="function_call",
+        messages=messages,
+        max_tokens=max_tokens,
+        retry_multiplier=1,
     )
 
     start = time.perf_counter()
@@ -1615,6 +1741,9 @@ async def call_llm_stream(
         org_id=org_id,
         feature_key=feature_key,
         capability="stream",
+        messages=messages,
+        max_tokens=max_tokens,
+        retry_multiplier=1,
     )
 
     accumulated: list[str] = []

--- a/backend/app/services/ai_forecast_refine_token_estimate.py
+++ b/backend/app/services/ai_forecast_refine_token_estimate.py
@@ -11,9 +11,13 @@ from __future__ import annotations
 import enum
 import math
 
+# ``_PROMPT_CHARS_PER_TOKEN`` is owned by ``ai_token_estimate`` and
+# re-exported here so the refine preflight and the universal dispatch
+# overspend gate share one char-per-token heuristic and cannot drift.
+from app.services.ai_token_estimate import _PROMPT_CHARS_PER_TOKEN
+
 # Char-per-token heuristics. The stack has no tokenizer; these are
 # deliberately rough and surfaced to the user as approximate ("≈").
-_PROMPT_CHARS_PER_TOKEN = 3.5
 _OUTPUT_CHARS_PER_TOKEN = 3.0
 
 # Per-row JSON size assumptions for the output shape (SeasonalAdjustment,

--- a/backend/app/services/ai_token_estimate.py
+++ b/backend/app/services/ai_token_estimate.py
@@ -1,0 +1,107 @@
+"""Shared, DB-free token estimators for the AI dispatch overspend gate.
+
+This module is the single home for the char-per-token prompt heuristic
+and the per-model worst-case output-token ceiling. Both the universal
+dispatch projected-overspend gate (``ai_dispatch._projected_cost_cents``)
+and the forecast-refine UI preflight
+(``ai_forecast_refine_token_estimate``) source the prompt heuristic from
+here so the two estimates cannot drift apart.
+
+Pure: no DB, no LLM, no IO. Never raises on malformed message shapes —
+projection runs on the hot dispatch path and must degrade, never crash.
+"""
+from __future__ import annotations
+
+import math
+
+from app.services.ai_pricing import MODEL_PRICING
+
+# Char-per-token heuristic. The stack has no tokenizer; this is
+# deliberately rough. Shared with ``ai_forecast_refine_token_estimate``
+# (which re-exports it) so the refine preflight and the dispatch gate
+# can never diverge.
+_PROMPT_CHARS_PER_TOKEN = 3.5
+
+
+# Conservative worst-case output ceilings (in tokens) used when a caller
+# does not pin ``max_tokens``. These are NOT context windows; they are a
+# few-thousand-token "how big could the completion plausibly get" guess,
+# matched to each model's pricing-table key. The projected cost is a
+# guardrail, so over-estimating output is the safe direction (operator
+# chose the "prevent overspend" posture).
+_GLOBAL_DEFAULT_MAX_OUTPUT_TOKENS = 4096
+
+_DEFAULT_MAX_OUTPUT_TOKENS_BY_MODEL: dict[str, int] = {
+    "gpt-4o": 4096,
+    "gpt-4o-mini": 4096,
+    "claude-sonnet-4-7": 8192,
+    "claude-haiku-4-5": 8192,
+    # Embedding models never produce completion tokens; keep a token
+    # floor so projection arithmetic stays defined (embedding pricing
+    # zeroes the completion column anyway).
+    "text-embedding-3-small": 0,
+    "text-embedding-3-large": 0,
+}
+
+
+def estimate_prompt_tokens_from_messages(messages: list[dict]) -> int:
+    """Estimate prompt tokens from chat ``messages`` via the char heuristic.
+
+    Defensive by design — message/content shapes from feature surfaces
+    vary and projection must never raise on the hot path:
+
+    - ``content`` is a ``str``: count its length.
+    - ``content`` is a ``list`` (multimodal parts): sum ``len(part["text"])``
+      for dict parts that carry a string ``"text"`` key; ignore image
+      parts, non-dict parts, and dict parts without a string ``text``.
+    - ``content`` missing / ``None`` / any other type: contributes 0.
+    - a message that is not a dict: contributes 0.
+
+    Total chars are divided by ``_PROMPT_CHARS_PER_TOKEN`` and rounded up.
+    """
+    total_chars = 0
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            total_chars += len(content)
+        elif isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                text = part.get("text")
+                if isinstance(text, str):
+                    total_chars += len(text)
+        # Any other content type (None, int, dict, ...) contributes 0.
+    return math.ceil(total_chars / _PROMPT_CHARS_PER_TOKEN)
+
+
+def default_max_output_tokens_for(model: str) -> int:
+    """Worst-case completion-token ceiling for ``model``.
+
+    Returns the per-model ceiling when known (keys mirror
+    ``ai_pricing.MODEL_PRICING``), otherwise the conservative global
+    fallback. Used to project completion cost when the caller does not
+    pin ``max_tokens``.
+    """
+    return _DEFAULT_MAX_OUTPUT_TOKENS_BY_MODEL.get(
+        model, _GLOBAL_DEFAULT_MAX_OUTPUT_TOKENS
+    )
+
+
+# Keep the per-model ceiling map honest against the pricing table: every
+# known pricing model (except the synthetic ``_default`` row) should have
+# an explicit output ceiling so a newly priced model is never silently
+# projected at only the global fallback. This is a cheap import-time
+# guard, not a runtime cost.
+_missing = {
+    m
+    for m in MODEL_PRICING
+    if m != "_default" and m not in _DEFAULT_MAX_OUTPUT_TOKENS_BY_MODEL
+}
+if _missing:  # pragma: no cover - defensive import-time consistency check
+    raise RuntimeError(
+        "ai_token_estimate: models priced but missing an output ceiling: "
+        f"{sorted(_missing)}"
+    )

--- a/backend/tests/services/test_ai_dispatch.py
+++ b/backend/tests/services/test_ai_dispatch.py
@@ -335,9 +335,11 @@ async def test_projected_overspend_blocks_under_cap_no_adapter_no_ledger(
     """Under the cap, but the projected worst-case cost tips it over →
     AICapExceeded, adapter never called, no ledger row for the call.
     """
-    # hard=100, spent=97. gpt-4o-mini completion = 60 cents/1M, so
-    # max_tokens=100_000 projects 6 cents → 97 + 6 = 103 > 100 → block,
-    # even though spent (97) is still strictly under the cap.
+    # hard=100, spent=97. gpt-4o-mini completion = 60 cents/1M; prompt
+    # "hi" adds ~1 token at 15 cents/1M. estimate_cost_cents sums the
+    # prompt and completion raw cost, then ceils ONCE: max_tokens=100_000
+    # → 6_000_000 + 15 raw = 7 cents (not 6) → 97 + 7 = 104 > 100 →
+    # block, even though spent (97) is still strictly under the cap.
     await _seed_cap_and_spend(
         db, org, credential, hard_cap_cents=100, spent_cents=97
     )

--- a/backend/tests/services/test_ai_dispatch.py
+++ b/backend/tests/services/test_ai_dispatch.py
@@ -288,6 +288,263 @@ async def test_hard_cap_blocks_dispatch_no_adapter_call_no_ledger_row(
     assert rows[0].est_cost_cents == 12
 
 
+# ---------- projected-overspend gate (call_llm entry point) ----------
+
+
+async def _seed_cap_and_spend(
+    db: AsyncSession,
+    org: Organization,
+    credential: OrgAICredential,
+    *,
+    hard_cap_cents: int,
+    spent_cents: int,
+) -> None:
+    """Configure a hard cap and seed prior spend for the org."""
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id,
+            soft_cap_cents=None,
+            hard_cap_cents=hard_cap_cents,
+            period="monthly",
+        )
+    )
+    if spent_cents > 0:
+        db.add(
+            AIUsageLedger(
+                org_id=org.id,
+                credential_id=credential.id,
+                feature_key="chat",
+                model="gpt-4o-mini",
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                est_cost_cents=spent_cents,
+                latency_ms=1,
+                success=True,
+                error_class=None,
+                dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
+            )
+        )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_projected_overspend_blocks_under_cap_no_adapter_no_ledger(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing
+):
+    """Under the cap, but the projected worst-case cost tips it over →
+    AICapExceeded, adapter never called, no ledger row for the call.
+    """
+    # hard=100, spent=97. gpt-4o-mini completion = 60 cents/1M, so
+    # max_tokens=100_000 projects 6 cents → 97 + 6 = 103 > 100 → block,
+    # even though spent (97) is still strictly under the cap.
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=100, spent_cents=97
+    )
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded) as exc_info:
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                request_payload={
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 100_000,
+                },
+            )
+    assert exc_info.value.code == "ai_hard_cap_exceeded"
+    adapter.chat.assert_not_awaited()
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    # Only the seeded prior-spend row; no row for the blocked call.
+    assert len(rows) == 1
+    assert rows[0].est_cost_cents == 97
+
+
+@pytest.mark.asyncio
+async def test_exhausted_block_still_fires_with_empty_messages(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing
+):
+    """At/over cap with empty messages (projected == 0): the explicit
+    exhausted arm still blocks (regression guard for fail-closed)."""
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=10, spent_cents=12
+    )
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded):
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                request_payload={"messages": []},
+            )
+    adapter.chat.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_under_cap_with_headroom_proceeds(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing
+):
+    """Plenty of headroom → the call proceeds and writes a ledger row."""
+    # hard=100_000 cents, no prior spend; projection is ~1 cent.
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=100_000, spent_cents=0
+    )
+    adapter = _make_adapter(
+        LLMResponse(
+            content="ok",
+            prompt_tokens=5,
+            completion_tokens=3,
+            model="gpt-4o-mini",
+        )
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            request_payload={
+                "messages": [{"role": "user", "content": "hi"}]
+            },
+        )
+    assert result.response.content == "ok"
+    adapter.chat.assert_awaited_once()
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].success is True
+
+
+@pytest.mark.asyncio
+async def test_no_hard_cap_no_gate(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing
+):
+    """hard_cap_cents is None → no cap configured, no gate, call runs."""
+    # No OrgAIDefaultCaps row at all → resolved.hard_cap_cents is None.
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            request_payload={
+                "messages": [{"role": "user", "content": "hi"}]
+            },
+        )
+    assert result.response.content == "hi"
+    adapter.chat.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_projection_failure_fails_closed_to_exhausted_only(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing
+):
+    """If projection raises, the gate degrades to exhausted-only: a
+    call with headroom still PROCEEDS (projected pinned to 0), and the
+    failure is logged — it must not 500 the hot path."""
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=100, spent_cents=10
+    )
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ), patch(
+        "app.services.ai_dispatch._projected_cost_cents",
+        side_effect=RuntimeError("boom"),
+    ):
+        # spent=10 < hard=100, projected forced to 0 → not blocked.
+        result = await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            request_payload={
+                "messages": [{"role": "user", "content": "hi"}]
+            },
+        )
+    assert result.response.content == "hi"
+    adapter.chat.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_projection_failure_still_blocks_when_exhausted(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing
+):
+    """Projection raising must not let an already-exhausted org through:
+    the explicit exhausted arm fires even with projected pinned to 0."""
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=10, spent_cents=15
+    )
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ), patch(
+        "app.services.ai_dispatch._projected_cost_cents",
+        side_effect=RuntimeError("boom"),
+    ):
+        with pytest.raises(AICapExceeded):
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                request_payload={
+                    "messages": [{"role": "user", "content": "hi"}]
+                },
+            )
+    adapter.chat.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_projects_via_default_pricing_and_gates(
+    db: AsyncSession, org: Organization, admin_user, credential
+):
+    """An unknown model still projects (via _default pricing) and gates.
+
+    _default pricing is 1500/6000 cents per 1M. Even a small unpinned
+    call projects well over 1 cent, so spent=99 under hard=100 blocks.
+    """
+    # Route to an unknown model.
+    db.add(
+        OrgAIDefaultRouting(
+            org_id=org.id,
+            credential_id=credential.id,
+            model="some-unknown-model-v9",
+        )
+    )
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=100, spent_cents=99
+    )
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded):
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                request_payload={
+                    "messages": [{"role": "user", "content": "hi"}]
+                },
+            )
+    adapter.chat.assert_not_awaited()
+
+
 # ---------- adapter failure ------------------------------------------
 
 

--- a/backend/tests/services/test_ai_dispatch_capabilities.py
+++ b/backend/tests/services/test_ai_dispatch_capabilities.py
@@ -39,14 +39,19 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.pool import StaticPool
 
 from app.config import settings as app_settings
+from datetime import datetime, timezone
+
 from app.models import Base
 from app.models.ai_usage_ledger import AIUsageLedger
+from app.models.org_ai_caps import OrgAIDefaultCaps
 from app.models.org_ai_credential import AiProvider, OrgAICredential
 from app.models.org_ai_routing import OrgAIDefaultRouting
 from app.models.user import Organization, Role, User
 from app.services.ai_credential_crypto import encrypt
 from app.services.ai_dispatch import (
+    STRUCTURED_OUTPUT_MAX_RETRIES,
     AICapabilityNotSupported,
+    AICapExceeded,
     AIDispatchFailed,
     call_llm_embed,
     call_llm_function,
@@ -954,3 +959,262 @@ async def test_call_llm_function_routes_to_openai_compatible_when_capability_adv
 
     adapter.function_call.assert_awaited_once()
     assert result.response.tool_calls[0]["name"] == "set_category"
+
+
+# ---------- projected-overspend gate (_prepare_dispatch entry) -------
+
+
+async def _seed_cap_and_spend(
+    db: AsyncSession,
+    org,
+    credential: OrgAICredential,
+    *,
+    hard_cap_cents: int,
+    spent_cents: int,
+) -> None:
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id,
+            soft_cap_cents=None,
+            hard_cap_cents=hard_cap_cents,
+            period="monthly",
+        )
+    )
+    if spent_cents > 0:
+        db.add(
+            AIUsageLedger(
+                org_id=org.id,
+                credential_id=credential.id,
+                feature_key="chat",
+                model="gpt-4o-mini",
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                est_cost_cents=spent_cents,
+                latency_ms=1,
+                success=True,
+                error_class=None,
+                dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
+            )
+        )
+    await db.commit()
+
+
+def _structured_adapter() -> MagicMock:
+    adapter = MagicMock()
+    adapter.chat_structured = AsyncMock(
+        return_value=LLMResponse(
+            content='{"category": "groceries"}',
+            prompt_tokens=5,
+            completion_tokens=3,
+            model="gpt-4o-mini",
+        )
+    )
+    return adapter
+
+
+_STRUCT_SCHEMA = {
+    "type": "object",
+    "required": ["category"],
+    "properties": {"category": {"type": "string"}},
+}
+
+
+@pytest.mark.asyncio
+async def test_structured_projected_overspend_blocks_no_adapter_no_ledger(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """Structured dispatch: under cap but projected (x retries) tips it
+    over → AICapExceeded, adapter never called, no ledger row."""
+    # hard=100, spent=99; a tiny unpinned gpt-4o-mini structured call
+    # projects ~1 cent single, x3 = 3 cents → 99 + 3 > 100 → block.
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=100, spent_cents=99
+    )
+    adapter = _structured_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded) as exc_info:
+            await call_llm_structured(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                messages=[{"role": "user", "content": "x"}],
+                response_schema=_STRUCT_SCHEMA,
+            )
+    assert exc_info.value.code == "ai_hard_cap_exceeded"
+    adapter.chat_structured.assert_not_awaited()
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1  # only the seeded prior-spend row
+    assert rows[0].est_cost_cents == 99
+
+
+@pytest.mark.asyncio
+async def test_structured_exhausted_block_still_fires(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """Already at/over cap → exhausted arm blocks structured dispatch."""
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=10, spent_cents=12
+    )
+    adapter = _structured_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded):
+            await call_llm_structured(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                messages=[{"role": "user", "content": "x"}],
+                response_schema=_STRUCT_SCHEMA,
+            )
+    adapter.chat_structured.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_structured_under_cap_with_headroom_proceeds(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """Plenty of headroom → structured dispatch proceeds."""
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=100_000, spent_cents=0
+    )
+    adapter = _structured_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm_structured(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "x"}],
+            response_schema=_STRUCT_SCHEMA,
+        )
+    assert result.response.parsed == {"category": "groceries"}
+    adapter.chat_structured.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_structured_no_hard_cap_no_gate(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """No caps row → no gate; structured dispatch proceeds."""
+    adapter = _structured_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm_structured(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "x"}],
+            response_schema=_STRUCT_SCHEMA,
+        )
+    assert result.response.parsed == {"category": "groceries"}
+    adapter.chat_structured.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_structured_projection_failure_fails_closed(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """Projection raising degrades to exhausted-only: with headroom the
+    structured call still proceeds (projected pinned to 0), no 500."""
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=100, spent_cents=10
+    )
+    adapter = _structured_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ), patch(
+        "app.services.ai_dispatch._projected_cost_cents",
+        side_effect=RuntimeError("boom"),
+    ):
+        result = await call_llm_structured(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "x"}],
+            response_schema=_STRUCT_SCHEMA,
+        )
+    assert result.response.parsed == {"category": "groceries"}
+    adapter.chat_structured.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_structured_retry_multiplier_blocks_when_single_would_fit(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """The retry multiplier is load-bearing: a structured call whose
+    SINGLE projection fits under the remaining headroom but whose
+    x(retries+1) projection exceeds it must be blocked.
+
+    Proof control: an otherwise-identical function_call dispatch
+    (retry_multiplier=1, same model/payload/cap) PROCEEDS, isolating
+    the multiplier as the cause of the structured block.
+    """
+    # gpt-4o-mini completion = 60 cents / 1M tokens.
+    # max_tokens=200_000 → single completion cost = 12 cents.
+    # retries+1 = STRUCTURED_OUTPUT_MAX_RETRIES + 1 = 3 → 36 cents.
+    assert STRUCTURED_OUTPUT_MAX_RETRIES + 1 == 3
+    big_max_tokens = 200_000
+    # hard=120, spent=100 → remaining=20.
+    # single 12 fits (100+12=112 <= 120); x3 = 36 → 100+36=136 > 120 block.
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=120, spent_cents=100
+    )
+
+    adapter = _structured_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded):
+            await call_llm_structured(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                messages=[{"role": "user", "content": "x"}],
+                response_schema=_STRUCT_SCHEMA,
+                max_tokens=big_max_tokens,
+            )
+    adapter.chat_structured.assert_not_awaited()
+
+    # Control: same payload via function_call (multiplier 1) → the
+    # single 12-cent projection fits, so it PROCEEDS.
+    func_adapter = MagicMock()
+    func_adapter.function_call = AsyncMock(
+        return_value=FunctionCallResponse(
+            tool_calls=[{"name": "f", "arguments": {}}],
+            content="",
+            prompt_tokens=1,
+            completion_tokens=1,
+            model="gpt-4o-mini",
+        )
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=func_adapter
+    ):
+        result = await call_llm_function(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "x"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "f",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+            max_tokens=big_max_tokens,
+        )
+    assert result.response.tool_calls[0]["name"] == "f"
+    func_adapter.function_call.assert_awaited_once()

--- a/backend/tests/services/test_ai_dispatch_capabilities.py
+++ b/backend/tests/services/test_ai_dispatch_capabilities.py
@@ -744,6 +744,117 @@ async def test_call_llm_function_happy_path(
     assert rows[0].completion_tokens == 6
 
 
+def _function_adapter() -> MagicMock:
+    adapter = MagicMock()
+    adapter.function_call = AsyncMock(
+        return_value=FunctionCallResponse(
+            tool_calls=[
+                {"name": "set_category", "arguments": {"slug": "rent"}}
+            ],
+            content="",
+            prompt_tokens=12,
+            completion_tokens=6,
+            model="gpt-4o-mini",
+        )
+    )
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_function_tool_schema_tips_projection_over_cap_no_adapter_no_ledger(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """The ``tools`` JSON schemas bill as prompt tokens, so the gate must
+    fold them into its projection. Under cap with a tiny ``messages`` but
+    a large ``tools`` payload, the projected prompt cost tips the org over
+    its hard cap -> AICapExceeded, adapter never awaited, no ledger row.
+
+    hard=100, spent=90, gpt-4o-mini (prompt 15c/1M, default 4096-token
+    completion ceiling). Tiny ``messages`` alone projects 1 cent
+    (90 + 1 = 91 < 100, so WITHOUT folding the tools the call would
+    proceed). The ~4M-char tool description projects ~1.14M prompt tokens
+    -> 18 cents, so 90 + 18 = 108 > 100 and the call blocks. Pins that
+    the tool schema now contributes to the projection.
+    """
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=100, spent_cents=90
+    )
+    big_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "set_category",
+                "description": "x" * 4_000_000,
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+    adapter = _function_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded) as exc_info:
+            await call_llm_function(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                messages=[{"role": "user", "content": "classify"}],
+                tools=big_tools,
+            )
+    assert exc_info.value.code == "ai_hard_cap_exceeded"
+    adapter.function_call.assert_not_awaited()
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1  # only the seeded prior-spend row
+    assert rows[0].est_cost_cents == 90
+
+
+@pytest.mark.asyncio
+async def test_function_small_tools_under_cap_proceeds(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """Same cap headroom (hard=100, spent=90) but a small ``tools``
+    payload keeps the projection under cap -> the function call proceeds
+    and writes a ledger row. Guards against the tool-folding over-counting
+    a normal call."""
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=100, spent_cents=90
+    )
+    adapter = _function_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm_function(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "classify"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "set_category",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        )
+    assert result.response.tool_calls[0]["name"] == "set_category"
+    adapter.function_call.assert_awaited_once()
+    # The real adapter call still receives the original (unmodified) tools.
+    sent_tools = adapter.function_call.await_args.kwargs["tools"]
+    assert sent_tools[0]["function"]["name"] == "set_category"
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 2  # seeded prior-spend row + this successful call
+
+
 # ---------- Stream: ONE ledger row at end-of-stream ----------------
 
 

--- a/backend/tests/services/test_ai_dispatch_capabilities.py
+++ b/backend/tests/services/test_ai_dispatch_capabilities.py
@@ -229,6 +229,24 @@ async def default_routing(
     return row
 
 
+@pytest_asyncio.fixture
+async def embed_routing(
+    db: AsyncSession, org: Organization, credential: OrgAICredential
+) -> OrgAIDefaultRouting:
+    """Routing whose model is an embedding model, so the overspend gate
+    prices the projected embedding INPUT at the embedding input rate and
+    a 0 completion ceiling (embedding models emit no completion tokens).
+    """
+    row = OrgAIDefaultRouting(
+        org_id=org.id,
+        credential_id=credential.id,
+        model="text-embedding-3-large",
+    )
+    db.add(row)
+    await db.commit()
+    return row
+
+
 # ---------- call_llm_embed -------------------------------------------
 
 
@@ -267,6 +285,172 @@ async def test_call_llm_embed_happy_path_writes_ledger(
     assert row.completion_tokens == 0
     assert row.model == "text-embedding-3-small"
     assert row.retries_used == 0
+
+
+# ---------- call_llm_embed overspend gate ----------------------------
+
+
+async def _seed_embed_cap_and_spend(
+    db: AsyncSession,
+    org,
+    credential: OrgAICredential,
+    *,
+    hard_cap_cents: int,
+    spent_cents: int,
+) -> None:
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id,
+            soft_cap_cents=None,
+            hard_cap_cents=hard_cap_cents,
+            period="monthly",
+        )
+    )
+    if spent_cents > 0:
+        db.add(
+            AIUsageLedger(
+                org_id=org.id,
+                credential_id=credential.id,
+                feature_key="chat",
+                model="text-embedding-3-large",
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                est_cost_cents=spent_cents,
+                latency_ms=1,
+                success=True,
+                error_class=None,
+                dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
+            )
+        )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_embed_exhausted_block_no_adapter_no_ledger(
+    db: AsyncSession, org, admin_user, credential, embed_routing
+):
+    """At/over the hard cap → AICapExceeded; the embed adapter is never
+    awaited and no ledger row is written for the blocked call."""
+    await _seed_embed_cap_and_spend(
+        db, org, credential, hard_cap_cents=10, spent_cents=12
+    )
+    adapter = MagicMock()
+    adapter.embed = AsyncMock(
+        return_value=EmbedResponse(
+            vectors=[[0.1]],
+            model="text-embedding-3-large",
+            prompt_tokens=1,
+        )
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded) as exc_info:
+            await call_llm_embed(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                texts=["x"],
+            )
+    assert exc_info.value.code == "ai_hard_cap_exceeded"
+    adapter.embed.assert_not_awaited()
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1  # only the seeded prior-spend row
+    assert rows[0].est_cost_cents == 12
+
+
+@pytest.mark.asyncio
+async def test_embed_projected_overspend_blocks_under_cap_no_adapter_no_ledger(
+    db: AsyncSession, org, admin_user, credential, embed_routing
+):
+    """Under the cap, but a large embedding INPUT projects an input
+    cost that tips the org over the hard cap → AICapExceeded, adapter
+    never awaited, no ledger row.
+
+    This is the embeddings-protection fix (Fix 1): the gate now projects
+    the embedding INPUT (``texts``) as prompt tokens, priced at the
+    routing model's input rate with a 0 completion ceiling.
+    text-embedding-3-large input = 13 cents / 1M tokens. A 10M-char
+    input over the 3.5 chars/token heuristic projects
+    ceil(10_000_000 / 3.5) = 2_857_143 prompt tokens → 38 cents, which
+    tips 70 + 38 over the 100-cent hard cap.
+
+    Before Fix 1 the gate saw an empty payload (projected 0) and this
+    call would have proceeded.
+    """
+    await _seed_embed_cap_and_spend(
+        db, org, credential, hard_cap_cents=100, spent_cents=70
+    )
+    big_text = "x" * 10_000_000
+    adapter = MagicMock()
+    adapter.embed = AsyncMock(
+        return_value=EmbedResponse(
+            vectors=[[0.1]],
+            model="text-embedding-3-large",
+            prompt_tokens=1,
+        )
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded) as exc_info:
+            await call_llm_embed(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                texts=[big_text],
+            )
+    assert exc_info.value.code == "ai_hard_cap_exceeded"
+    adapter.embed.assert_not_awaited()
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1  # only the seeded prior-spend row
+    assert rows[0].est_cost_cents == 70
+
+
+@pytest.mark.asyncio
+async def test_embed_under_cap_with_headroom_proceeds(
+    db: AsyncSession, org, admin_user, credential, embed_routing
+):
+    """Under the cap with headroom → embed proceeds and writes a row."""
+    await _seed_embed_cap_and_spend(
+        db, org, credential, hard_cap_cents=100_000, spent_cents=0
+    )
+    adapter = MagicMock()
+    adapter.embed = AsyncMock(
+        return_value=EmbedResponse(
+            vectors=[[0.1, 0.2, 0.3]],
+            model="text-embedding-3-large",
+            prompt_tokens=7,
+        )
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm_embed(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            texts=["small input"],
+        )
+    assert result.response.vectors == [[0.1, 0.2, 0.3]]
+    adapter.embed.assert_awaited_once()
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].success is True
+    assert rows[0].prompt_tokens == 7
 
 
 # ---------- call_llm_structured retry budget -------------------------
@@ -752,6 +936,64 @@ async def test_call_llm_stream_stalled_stream_times_out_and_closes_iterator(
     )
 
 
+# ---------- Stream: overspend gate fires before first chunk ----------
+
+
+@pytest.mark.asyncio
+async def test_call_llm_stream_gate_blocks_before_first_chunk(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """A streamed call against an exhausted hard cap must raise
+    ``AICapExceeded`` the moment iteration BEGINS, before any chunk is
+    yielded. The provider stream must never be iterated and no ledger
+    row may be written.
+
+    ``call_llm_stream`` is an async generator, so the gate (run inside
+    ``_prepare_dispatch``) only executes once the consumer starts
+    iterating. The test therefore drives the ``async for`` inside the
+    ``pytest.raises`` block to prove the pre-first-yield gate fires.
+    """
+    await _seed_cap_and_spend(
+        db, org, credential, hard_cap_cents=10, spent_cents=12
+    )
+
+    iterated = False
+
+    async def fake_stream(*, model, messages, max_tokens=None):
+        nonlocal iterated
+        iterated = True
+        yield StreamChunk(delta_text="should never reach here", done=False)
+
+    adapter = MagicMock()
+    adapter.stream = fake_stream
+
+    received: list = []
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded) as exc_info:
+            async for chunk in call_llm_stream(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                messages=[{"role": "user", "content": "hi"}],
+            ):
+                received.append(chunk)
+    assert exc_info.value.code == "ai_hard_cap_exceeded"
+    # No chunk ever reached the consumer.
+    assert received == []
+    # The provider stream was never iterated.
+    assert iterated is False
+    # No ledger row for the blocked call — only the seeded prior-spend row.
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].est_cost_cents == 12
+
+
 # ---------- Structured-output token aggregation ---------------------
 
 
@@ -1159,13 +1401,16 @@ async def test_structured_retry_multiplier_blocks_when_single_would_fit(
     (retry_multiplier=1, same model/payload/cap) PROCEEDS, isolating
     the multiplier as the cause of the structured block.
     """
-    # gpt-4o-mini completion = 60 cents / 1M tokens.
-    # max_tokens=200_000 → single completion cost = 12 cents.
-    # retries+1 = STRUCTURED_OUTPUT_MAX_RETRIES + 1 = 3 → 36 cents.
+    # gpt-4o-mini completion = 60 cents / 1M tokens; prompt "x" adds ~1
+    # token at 15 cents / 1M. estimate_cost_cents sums prompt+completion
+    # raw cost and ceils ONCE: max_tokens=200_000 → 12_000_000 + 15 raw
+    # = 13 cents single (not 12, because of the prompt cent).
+    # retries+1 = STRUCTURED_OUTPUT_MAX_RETRIES + 1 = 3 → 13 x 3 = 39
+    # cents (not 36).
     assert STRUCTURED_OUTPUT_MAX_RETRIES + 1 == 3
     big_max_tokens = 200_000
     # hard=120, spent=100 → remaining=20.
-    # single 12 fits (100+12=112 <= 120); x3 = 36 → 100+36=136 > 120 block.
+    # single 13 fits (100+13=113 <= 120); x3 = 39 → 100+39=139 > 120 block.
     await _seed_cap_and_spend(
         db, org, credential, hard_cap_cents=120, spent_cents=100
     )
@@ -1186,7 +1431,7 @@ async def test_structured_retry_multiplier_blocks_when_single_would_fit(
     adapter.chat_structured.assert_not_awaited()
 
     # Control: same payload via function_call (multiplier 1) → the
-    # single 12-cent projection fits, so it PROCEEDS.
+    # single 13-cent projection fits, so it PROCEEDS.
     func_adapter = MagicMock()
     func_adapter.function_call = AsyncMock(
         return_value=FunctionCallResponse(

--- a/backend/tests/services/test_ai_token_estimate.py
+++ b/backend/tests/services/test_ai_token_estimate.py
@@ -1,0 +1,109 @@
+"""Unit tests for the shared, DB-free AI token estimator.
+
+Covers the prompt-token char heuristic over chat ``messages`` (string
+content, multimodal list content, and malformed/missing content that
+must never raise), plus the per-model default output-token ceiling
+used to project worst-case completion cost.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.services.ai_pricing import MODEL_PRICING
+from app.services.ai_token_estimate import (
+    _GLOBAL_DEFAULT_MAX_OUTPUT_TOKENS,
+    _PROMPT_CHARS_PER_TOKEN,
+    default_max_output_tokens_for,
+    estimate_prompt_tokens_from_messages,
+)
+
+
+def _expected_tokens(total_chars: int) -> int:
+    return math.ceil(total_chars / _PROMPT_CHARS_PER_TOKEN)
+
+
+# ---------- estimate_prompt_tokens_from_messages ----------------------
+
+
+def test_string_content_uses_char_heuristic():
+    messages = [
+        {"role": "system", "content": "x" * 35},
+        {"role": "user", "content": "y" * 35},
+    ]
+    assert estimate_prompt_tokens_from_messages(messages) == _expected_tokens(70)
+
+
+def test_multimodal_list_content_sums_text_parts_only():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "a" * 20},
+                {"type": "image_url", "image_url": {"url": "http://x"}},
+                {"type": "text", "text": "b" * 20},
+                {"type": "text"},  # malformed text part, no "text" key
+                "loose-string-part-ignored",  # non-dict part
+            ],
+        }
+    ]
+    # Only the two well-formed text parts (40 chars) contribute.
+    assert estimate_prompt_tokens_from_messages(messages) == _expected_tokens(40)
+
+
+def test_missing_none_and_non_str_content_never_raises():
+    messages = [
+        {"role": "user"},  # no content key
+        {"role": "user", "content": None},
+        {"role": "user", "content": 12345},  # int content
+        {"role": "user", "content": {"unexpected": "dict"}},  # dict content
+        "not-a-dict-message",  # message is not a dict
+    ]
+    # None of these contribute chars; result is 0, and nothing raised.
+    assert estimate_prompt_tokens_from_messages(messages) == 0
+
+
+def test_empty_messages_returns_zero():
+    assert estimate_prompt_tokens_from_messages([]) == 0
+
+
+def test_mixed_string_and_list_content():
+    messages = [
+        {"role": "system", "content": "s" * 14},
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "t" * 14}],
+        },
+    ]
+    assert estimate_prompt_tokens_from_messages(messages) == _expected_tokens(28)
+
+
+# ---------- default_max_output_tokens_for -----------------------------
+
+
+@pytest.mark.parametrize("model", sorted(MODEL_PRICING.keys()))
+def test_known_models_have_an_int_default(model):
+    if model == "_default":
+        # Not a real model id; covered by the unknown-model path.
+        return
+    value = default_max_output_tokens_for(model)
+    assert isinstance(value, int)
+    # Embedding models produce no completion tokens (0 ceiling); chat
+    # models must have a positive worst-case ceiling.
+    if model.startswith("text-embedding"):
+        assert value == 0
+    else:
+        assert value > 0
+
+
+def test_unknown_model_falls_back_to_global_default():
+    assert (
+        default_max_output_tokens_for("totally-made-up-model-xyz")
+        == _GLOBAL_DEFAULT_MAX_OUTPUT_TOKENS
+    )
+
+
+def test_global_default_is_a_conservative_ceiling_not_context_window():
+    # Sanity: a few-thousand-token ceiling, not a 100k+ context window.
+    assert 1000 <= _GLOBAL_DEFAULT_MAX_OUTPUT_TOKENS <= 16000

--- a/specs/2026-06-15-ai-dispatch-overspend-gate-design.md
+++ b/specs/2026-06-15-ai-dispatch-overspend-gate-design.md
@@ -1,0 +1,70 @@
+# AI Dispatch Universal Overspend Gate
+
+**Date:** 2026-06-15
+**Status:** design approved (operator + architect-reviewed), building
+**Decision basis:** [[project_ai_dispatch_overspend_gate_decision]] (hard-block, no degrade) + 2026-06-15 operator choice (conservative worst-case estimation) + architect pass.
+
+## Problem
+Today the AI dispatch layer hard-blocks only the EXHAUSTED case (`cost_so_far >= hard_cap` → `AICapExceeded` → 402 `ai_hard_cap_exceeded`), at TWO identical sites: `call_llm` (`ai_dispatch.py:747-758`) and `_prepare_dispatch` (`:1030-1042`, backing `call_llm_structured` + the stream/embed wrappers). Projected-cost gating exists only for ONE feature (`estimate_refine`, `ai_forecast_refine_service.py:671-786`). So any feature without its own estimate gate can overspend by one final call (or several, via retries). Goal: a UNIVERSAL projected-overspend gate at dispatch, hard-block, conservative.
+
+## Design
+
+### 1. Shared estimator module — `app/services/ai_token_estimate.py` (new, pure)
+- `_PROMPT_CHARS_PER_TOKEN` (move the constant here; `ai_forecast_refine_token_estimate.py` re-exports it so the two heuristics cannot diverge — that module's docstring already prizes non-divergence).
+- `estimate_prompt_tokens_from_messages(messages: list[dict]) -> int` — char heuristic over message `content`. **Defensive for non-string content**: if `content` is a list of parts (multimodal), sum `len` of text parts and ignore non-text; if missing/None, treat as 0. Never raise on shape.
+- `_DEFAULT_MAX_OUTPUT_TOKENS_BY_MODEL: dict[str, int]` keyed by the same model strings as `ai_pricing.MODEL_PRICING`, plus `_GLOBAL_DEFAULT_MAX_OUTPUT_TOKENS` (conservative fallback, e.g. a few-k ceiling — NOT the context window). `default_max_output_tokens_for(model: str) -> int`.
+
+### 2. Projection helper — in `ai_dispatch.py`
+`def _projected_cost_cents(model, messages, max_tokens, *, retry_multiplier=1) -> int`:
+- `prompt_tokens = estimate_prompt_tokens_from_messages(messages)`
+- `completion_tokens = max_tokens if max_tokens else default_max_output_tokens_for(model)`
+- `single = estimate_cost_cents(model, prompt_tokens, completion_tokens)` — `estimate_cost_cents` already handles unknown models via its high `_default` pricing, so projection is always computable.
+- return `single * retry_multiplier`.
+- Wrap the whole computation at the call site in try/except (see §3 fail-closed).
+
+### 3. Gate helper — `_enforce_cap(...)` in `ai_dispatch.py`
+Replaces BOTH inline exhausted blocks. Signature carries what each site has: `resolved`, `cost_so_far`, `model`, `messages`, `max_tokens`, `retry_multiplier`, `org_id`, `feature_key`, `capability=None`.
+- Short-circuit: if `resolved.hard_cap_cents is None`, return (no cap configured).
+- Compute `projected` via `_projected_cost_cents(...)` inside try/except. **Fail-closed**: on ANY exception, set `projected = 0` and `logger.warning("ai.dispatch.cap.projection_failed", ...)` — this degrades to exhausted-only enforcement (never skips the gate, never 500s the hot path).
+- **Block predicate (keep the explicit exhausted arm):**
+  ```python
+  if cost_so_far >= resolved.hard_cap_cents or cost_so_far + projected > resolved.hard_cap_cents:
+      logger.info("ai.dispatch.cap.exceeded", org_id=..., feature_key=..., capability=...,
+                  cost_so_far=cost_so_far, hard_cap_cents=resolved.hard_cap_cents,
+                  projected_cost_cents=projected,
+                  reason=("exhausted" if cost_so_far >= resolved.hard_cap_cents else "projected"))
+      raise AICapExceeded()
+  ```
+  The explicit `cost_so_far >= hard_cap` arm guarantees an at-cap org is blocked even if `projected == 0` (fail-closed / empty messages).
+- **No ledger row, no audit_event at this layer** (matches the existing exhausted block). `AICapExceeded` is caught by the routers and already audits as a success-precondition (`ai_cap_exceeded`) per [[reference_ai_audit_outcome_semantics]] — reusing the same exception inherits correct semantics; do NOT invent a new reason or 500.
+
+### 4. Wiring both sites
+- **`call_llm`** (`:747-758`): it already has `model`, `request_payload` (→ `messages`, `max_tokens`). Replace the inline block with `await _enforce_cap(..., retry_multiplier=1)` (raw chat does not retry).
+- **`_prepare_dispatch`** (`:1027-1042`): currently does NOT receive the request payload. Add params so it can project after resolving `model`: thread `messages`, `max_tokens`, `retry_multiplier` (or a small `projection: _ProjectionInput` dataclass) from its callers. Replace the inline block with `_enforce_cap(...)`.
+  - **Callers of `_prepare_dispatch`** (`call_llm_structured` + the PR3 stream/embed wrappers): pass their `messages`/`max_tokens`. **Retry multiplier:** `call_llm_structured` retries up to `STRUCTURED_OUTPUT_MAX_RETRIES` and aggregates spend, so it passes `retry_multiplier = STRUCTURED_OUTPUT_MAX_RETRIES + 1` (consistent with "prevent overspend"); chat-only / stream pass `1` unless they also retry. Verify the exact constant + caller signatures in code.
+
+### 5. `estimate_refine` stays as the UI preflight
+Unchanged (it gates the UI "Confirm"). Dispatch is now the universal authority its docstring already assumes. Both share the prompt-token heuristic via §1. No unification, no double-ledger (neither writes a ledger row on refusal).
+
+## Accepted tradeoffs (documented, not hidden)
+- **Over-block near the cap:** the conservative `max_tokens`/retry-multiplied estimate over-estimates most calls, so calls that would have fit can be refused right at the cap edge. This is the operator-chosen "prevent overspend" posture.
+- **Concurrency race:** `cost_so_far` is an unlocked `SUM` over the ledger; two concurrent dispatches each individually fitting can jointly overspend. Out of scope (same caveat `estimate_refine` documents); closing it needs a reservation ledger.
+
+## Tests (`-p team-aigate` isolated stack; never default; never ./pfv migrate)
+- **`ai_token_estimate` unit:** prompt heuristic (string + list/multimodal content + missing content → no raise); `default_max_output_tokens_for` (known model → its map value, unknown → global fallback); `estimate_prompt_tokens_from_messages` non-string safety.
+- **Gate at BOTH entry points:** `call_llm` and `call_llm_structured`/`_prepare_dispatch`:
+  - projected block: `cost_so_far` under cap but `cost_so_far + projected > hard_cap` → `AICapExceeded` (402), NO adapter call, NO ledger row.
+  - exhausted block still fires (`cost_so_far >= hard_cap`, `projected == 0`) — the explicit-arm regression.
+  - under cap with headroom → call proceeds.
+  - `hard_cap_cents is None` → no gate.
+  - fail-closed: a payload that makes projection throw → degrades to exhausted-only (warning logged), does not 500.
+  - retry multiplier: a structured call whose single-projection fits but `×(retries+1)` exceeds → blocked.
+  - unknown model → projects via `_default` pricing (still gates).
+- **Router-level:** the projected 402 surfaces as `ai_hard_cap_exceeded` and audits as a success-precondition (spot-check one router, e.g. `ai_categorize`).
+- No em-dashes in any user-facing copy ([[feedback_no_em_dashes]]). Follow [[reference_ai_feature_pr_checklist]] + [[reference_ai_dispatch_session_isolation]].
+
+## Files
+`app/services/ai_token_estimate.py` (new), `app/services/ai_forecast_refine_token_estimate.py` (re-export the shared constant/heuristic), `app/services/ai_dispatch.py` (`_projected_cost_cents`, `_enforce_cap`, wire `call_llm` + `_prepare_dispatch` + its callers), tests. **No migration.**
+
+## Process
+Subagent-driven build with a review gate, then a fleet review before the PR (the established "ship clean" bar). Backend tests in `-p team-aigate`.


### PR DESCRIPTION
## What
Adds a UNIVERSAL projected-overspend gate at the AI dispatch layer, closing the gap where an org just under its hard cap could overspend by one final call. Implements the locked 2026-06-10 decision (hard-block, no degrade) with the 2026-06-15 conservative-worst-case estimation choice.

## Before
Dispatch hard-blocked only the EXHAUSTED case (`cost_so_far >= hard_cap`) at two separate sites; projected-cost gating existed only for one feature (`estimate_refine`). Any other feature could overspend by a final call (or several, via retries).

## How
- **One shared `_enforce_cap`** called from BOTH dispatch entry points (`call_llm` and `_prepare_dispatch`, which backs structured/embed/function/stream). Blocks when `cost_so_far >= hard_cap OR cost_so_far + projected > hard_cap` (the explicit exhausted arm keeps an at-cap org blocked even if projection is 0). Reuses `AICapExceeded` → existing 402 `ai_hard_cap_exceeded` (routers already audit it as a success-precondition).
- **Conservative projection:** new pure `ai_token_estimate.py` (char heuristic over messages, defensive for multimodal/None content; per-model default output ceiling). `projected = estimate_cost_cents(model, prompt_tokens, max_tokens-or-ceiling) * retry_multiplier`; the structured path uses `retry_multiplier = STRUCTURED_OUTPUT_MAX_RETRIES + 1` since it retries and aggregates spend. The forecast-refine token module re-exports the shared constant so the heuristics cannot diverge.
- **Embeddings:** project the input `texts` as prompt tokens (completion ceiling 0 for embedding models) so bulk-embed batches are gated too.
- **Fail-closed:** if projection throws, degrade to exhausted-only (warning logged), never 500 the hot path. Unknown models project via the high `_default` pricing (never under-meter). No ledger row / no new audit on a block.
- `estimate_refine` stays as the UI preflight; dispatch is now the universal authority its docstring already assumed.

## Accepted tradeoffs (documented)
Conservative `max_tokens` estimate over-blocks some affordable calls right at the cap edge (the price of 'prevent overspend'); concurrent calls racing the unlocked spend SUM can still jointly overspend (out of scope, same caveat `estimate_refine` documents).

## Tests
666 AI/dispatch tests green. Gate verified at all entry points (chat/structured/embed/stream): projected-block (no adapter call, no ledger row), exhausted arm with projected==0, fail-closed, retry-multiplier, unknown-model, multimodal/None content no-raise. Adapters mocked throughout (session isolation). **No migration.**

Built subagent-driven → combined review (APPROVED) → 4-dimension adversarial fleet (4 findings, all fixed). Spec: `specs/2026-06-15-ai-dispatch-overspend-gate-design.md`.