### PR TITLE
feat(transactions): cash-basis effective-date bucketing + Date/Settled display

### DIFF
--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -291,6 +291,7 @@ async def transfer_candidates(
             TransferCandidate(
                 id=c.id,
                 date=c.date,
+                settled_date=c.settled_date,
                 description=c.description,
                 amount=c.amount,
                 account_id=c.account_id,

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -237,6 +237,7 @@ class TransferCandidate(BaseModel):
 
     id: int
     date: datetime.date
+    settled_date: Optional[datetime.date] = None
     description: str
     amount: Decimal
     account_id: int

--- a/backend/app/services/budget_rebalance_service.py
+++ b/backend/app/services/budget_rebalance_service.py
@@ -61,7 +61,10 @@ from app.services.ai_providers import (
     StructuredOutputError,
 )
 from app.services.billing_service import get_current_period
-from app.services.transaction_filters import reportable_transaction_filter
+from app.services.transaction_filters import (
+    effective_period_date_expr,
+    reportable_transaction_filter,
+)
 
 
 logger = structlog.stdlib.get_logger()
@@ -200,8 +203,8 @@ async def _gather_facts(
             select(Transaction.category_id, func.sum(Transaction.amount))
             .where(
                 *base_filter,
-                Transaction.settled_date >= three_mo_lower,
-                Transaction.settled_date < three_mo_upper,
+                effective_period_date_expr() >= three_mo_lower,
+                effective_period_date_expr() < three_mo_upper,
             )
             .group_by(Transaction.category_id)
         )
@@ -213,10 +216,10 @@ async def _gather_facts(
     # One query for the current-period rollup, GROUP BY category_id.
     current_q = (
         select(Transaction.category_id, func.sum(Transaction.amount))
-        .where(*base_filter, Transaction.settled_date >= period_start)
+        .where(*base_filter, effective_period_date_expr() >= period_start)
     )
     if period_end is not None:
-        current_q = current_q.where(Transaction.settled_date <= period_end)
+        current_q = current_q.where(effective_period_date_expr() <= period_end)
     current_rows = (
         await db.execute(current_q.group_by(Transaction.category_id))
     ).all()

--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -18,7 +18,10 @@ from app.models.transaction import Transaction, TransactionStatus, TransactionTy
 from app.schemas.budget import BudgetCreate, BudgetResponse, BudgetUpdate
 from app.services.billing_service import get_current_period, resolve_period
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
-from app.services.transaction_filters import reportable_transaction_filter
+from app.services.transaction_filters import (
+    effective_period_date_expr,
+    reportable_transaction_filter,
+)
 
 
 async def _compute_spent(
@@ -34,8 +37,12 @@ async def _compute_spent(
     sub_ids = [r[0] for r in sub_ids_result.all()]
     all_cat_ids = [master_category_id] + sub_ids
 
-    # Use settled_date for budget computation — transactions count against
-    # the billing period in which they settled, not when the purchase happened.
+    # Bucket by the shared effective_period_date_expr() (= coalesce(
+    # settled_date, date)) — transactions count against the billing period
+    # in which they settled, not when the purchase happened. For the SETTLED
+    # rows summed here settled_date is always populated, so this is
+    # behavior-identical to a raw settled_date comparison while staying
+    # aligned with the list/reports/forecast bucketing expression.
     # Transfer halves are persisted as type=expense with a non-null
     # linked_transaction_id; excluding them keeps budget spent aligned with
     # the dashboard donut when a transfer is tagged under a budgeted category.
@@ -44,12 +51,12 @@ async def _compute_spent(
         Transaction.category_id.in_(all_cat_ids),
         Transaction.type == TransactionType.EXPENSE,
         Transaction.status == TransactionStatus.SETTLED,
-        Transaction.settled_date >= period_start,
+        effective_period_date_expr() >= period_start,
         reportable_transaction_filter(),
     )
     # If period is still open (no end_date), include all from start_date onward
     if period_end is not None:
-        q = q.where(Transaction.settled_date <= period_end)
+        q = q.where(effective_period_date_expr() <= period_end)
 
     spent = await db.scalar(q)
     return Decimal(str(spent))

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -38,7 +38,10 @@ from app.services.settings_service import (
     FORECAST_GRANULARITY_SUBCATEGORY,
     get_forecast_input_granularity,
 )
-from app.services.transaction_filters import reportable_transaction_filter
+from app.services.transaction_filters import (
+    effective_period_date_expr,
+    reportable_transaction_filter,
+)
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -524,18 +527,22 @@ async def populate_from_sources(
     # in-memory SQLite).
     three_months_ago = p_start - relativedelta(months=3)
 
+    # Cash-basis: select + filter by the effective settled date so a row
+    # dated in month X but settled in month Y buckets (and windows) by Y,
+    # consistent with the list/reports/forecast.
+    eff_date = effective_period_date_expr()
     hist_q = (
         select(
             Transaction.category_id,
             Transaction.type,
-            Transaction.date,
+            eff_date.label("eff_date"),
             Transaction.amount,
         )
         .where(
             Transaction.org_id == org_id,
             Transaction.status == TransactionStatus.SETTLED,
-            Transaction.date >= three_months_ago,
-            Transaction.date < p_start,
+            eff_date >= three_months_ago,
+            eff_date < p_start,
             Transaction.type.in_(["income", "expense"]),
             reportable_transaction_filter(),
         )
@@ -546,11 +553,12 @@ async def populate_from_sources(
     # then compute monthly averages.
     # Structure: {(group_id, type): {month: total}}
     master_monthly: dict[tuple[int, str], dict[str, Decimal]] = {}
-    for cat_id, tx_type_raw, tx_date, amount in hist_result.all():
+    for cat_id, tx_type_raw, eff_dt, amount in hist_result.all():
         tx_type = tx_type_raw.value if hasattr(tx_type_raw, "value") else str(tx_type_raw)
         grp_id = group_key(cat_id)
         key = (grp_id, tx_type)
-        month = f"{tx_date.year:04d}-{tx_date.month:02d}"
+        # Bucket by the effective settled date selected above.
+        month = f"{eff_dt.year:04d}-{eff_dt.month:02d}"
         if key not in master_monthly:
             master_monthly[key] = {}
         master_monthly[key][month] = master_monthly[key].get(month, Decimal("0")) + Decimal(str(amount))
@@ -569,8 +577,8 @@ async def populate_from_sources(
             Transaction.status.in_(
                 [TransactionStatus.SETTLED, TransactionStatus.PENDING]
             ),
-            Transaction.date >= p_start,
-            Transaction.date <= p_end,
+            eff_date >= p_start,
+            eff_date <= p_end,
             Transaction.type.in_(["income", "expense"]),
             reportable_transaction_filter(),
         )

--- a/backend/app/services/forecast_service.py
+++ b/backend/app/services/forecast_service.py
@@ -18,7 +18,10 @@ from app.models.recurring import Frequency, RecurringTransaction
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.services.billing_service import get_current_period
 from app.services.date_utils import advance_date
-from app.services.transaction_filters import reportable_transaction_filter
+from app.services.transaction_filters import (
+    effective_period_date_expr,
+    reportable_transaction_filter,
+)
 
 
 async def compute_forecast(
@@ -87,14 +90,16 @@ async def compute_forecast(
         )
     ) or Decimal("0")
 
-    # ── Pending — uses transaction date (when purchase happened) ──────────
+    # ── Pending — buckets by effective settled date (the settled-date
+    # estimate when set, else purchase date) so pending rows fall in the
+    # period they're expected to clear, consistent with the list/reports.
     pending_income = await db.scalar(
         select(func.coalesce(func.sum(Transaction.amount), 0)).where(
             Transaction.org_id == org_id,
             Transaction.type == TransactionType.INCOME,
             Transaction.status == TransactionStatus.PENDING,
-            Transaction.date >= p_start,
-            Transaction.date <= p_end,
+            effective_period_date_expr() >= p_start,
+            effective_period_date_expr() <= p_end,
             reportable_transaction_filter(),
         )
     ) or Decimal("0")
@@ -104,8 +109,8 @@ async def compute_forecast(
             Transaction.org_id == org_id,
             Transaction.type == TransactionType.EXPENSE,
             Transaction.status == TransactionStatus.PENDING,
-            Transaction.date >= p_start,
-            Transaction.date <= p_end,
+            effective_period_date_expr() >= p_start,
+            effective_period_date_expr() <= p_end,
             reportable_transaction_filter(),
         )
     ) or Decimal("0")
@@ -162,8 +167,8 @@ async def compute_forecast(
             Transaction.org_id == org_id,
             Transaction.type == TransactionType.EXPENSE,
             Transaction.status == TransactionStatus.PENDING,
-            Transaction.date >= p_start,
-            Transaction.date <= p_end,
+            effective_period_date_expr() >= p_start,
+            effective_period_date_expr() <= p_end,
             reportable_transaction_filter(),
         ).group_by(Transaction.category_id)
     )

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -284,6 +284,7 @@ async def build_preview(
                     TransferCandidate(
                         id=c.id,
                         date=c.date,
+                        settled_date=c.settled_date,
                         description=c.description,
                         amount=c.amount,
                         account_id=c.account_id,

--- a/backend/app/services/reports_query_service.py
+++ b/backend/app/services/reports_query_service.py
@@ -46,6 +46,7 @@ from app.schemas.reports_query import (
     ReportsQuery,
     TagMatch,
 )
+from app.services.transaction_filters import effective_period_date_expr
 
 
 # Mapping: schema Dimension → (column expression factory, key string used
@@ -92,22 +93,25 @@ def _dimension_expr(dim: Dimension, dialect_name: str):
         return Transaction.type
     if dim is Dimension.STATUS:
         return Transaction.status
-    # Time-bucket dimensions.
+    # Time-bucket dimensions. Cash-basis: bucket by the effective settled
+    # date (coalesce(settled_date, date)) so a row dated in month X but
+    # settled in month Y is counted in Y, consistent with the list/forecast.
+    eff = effective_period_date_expr()
     if dim is Dimension.MONTH:
         if dialect_name == "sqlite":
-            return func.strftime("%Y-%m", Transaction.date)
-        return func.date_format(Transaction.date, "%Y-%m")
+            return func.strftime("%Y-%m", eff)
+        return func.date_format(eff, "%Y-%m")
     if dim is Dimension.WEEK:
         if dialect_name == "sqlite":
             # Year + ISO week. SQLite's strftime("%W") is "week of year
             # zero-padded (00..53)" — close enough for the AST contract,
             # mirrors MySQL's WEEK() default mode.
-            return func.strftime("%Y-%W", Transaction.date)
-        return func.date_format(Transaction.date, "%x-%v")
+            return func.strftime("%Y-%W", eff)
+        return func.date_format(eff, "%x-%v")
     if dim is Dimension.DAY:
         if dialect_name == "sqlite":
-            return func.strftime("%Y-%m-%d", Transaction.date)
-        return func.date_format(Transaction.date, "%Y-%m-%d")
+            return func.strftime("%Y-%m-%d", eff)
+        return func.date_format(eff, "%Y-%m-%d")
     raise ValueError(f"unsupported dimension {dim!r}")
 
 

--- a/backend/app/services/reports_query_service.py
+++ b/backend/app/services/reports_query_service.py
@@ -145,7 +145,10 @@ def _category_parent_alias():
 
 
 _FILTER_COLUMN: dict[FilterField, Any] = {
-    FilterField.DATE: Transaction.date,
+    # Cash-basis: the DATE filter compares against the effective settled
+    # date (coalesce(settled_date, date)), so a date-window filter buckets
+    # rows by when they settled — consistent with the time dimensions.
+    FilterField.DATE: effective_period_date_expr(),
     FilterField.AMOUNT: Transaction.amount,
     FilterField.CATEGORY_ID: Transaction.category_id,
     FilterField.ACCOUNT_ID: Transaction.account_id,

--- a/backend/app/services/scenario_engine.py
+++ b/backend/app/services/scenario_engine.py
@@ -41,6 +41,7 @@ from app.models.recurring import Frequency, RecurringTransaction
 from app.models.scenario import Scenario, ScenarioType
 from app.models.transaction import Transaction, TransactionType
 from app.services.date_utils import advance_date
+from app.services.transaction_filters import effective_period_date_expr
 
 
 _TWOPLACES = Decimal("0.01")
@@ -661,19 +662,23 @@ async def build_world_state(
     # for plans that don't smooth, the points are simply ignored.
     today = utcnow_naive().date()
     history_start = today.replace(day=1) - relativedelta(months=12)
+    # Cash-basis: window + bucket by the effective settled date so a row
+    # dated in month X but settled in month Y counts in Y, consistent with
+    # the list/reports/forecast.
     txn_rows = (
         await db.execute(
             select(Transaction).where(
                 Transaction.org_id == org_id,
-                Transaction.date >= history_start,
-                Transaction.date < today.replace(day=1),
+                effective_period_date_expr() >= history_start,
+                effective_period_date_expr() < today.replace(day=1),
                 Transaction.type != TransactionType.TRANSFER,
             )
         )
     ).scalars().all()
     monthly: dict[tuple[int, int, int], Decimal] = {}
     for txn in txn_rows:
-        key = (txn.account_id, txn.date.year, txn.date.month)
+        eff = txn.settled_date or txn.date
+        key = (txn.account_id, eff.year, eff.month)
         sign = (
             Decimal("1")
             if txn.type == TransactionType.INCOME

--- a/backend/tests/routers/test_transactions_pair_routes.py
+++ b/backend/tests/routers/test_transactions_pair_routes.py
@@ -493,6 +493,15 @@ async def test_get_transfer_candidates(session_factory):
         amount=Decimal("50.00"), description="usd account",
         on_date=base_date,
     )
+    # Pending same-day income on a2 → NOT a candidate (only settled rows
+    # surface as transfer-pair candidates), so it never reaches the response.
+    pending_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a2_id"],
+        category_id=seed["cat_salary_id"], type=TransactionType.INCOME,
+        amount=Decimal("50.00"), description="pending leg",
+        on_date=base_date, status=TransactionStatus.PENDING,
+    )
 
     app = make_app(session_factory)
     with TestClient(app) as client:
@@ -516,6 +525,11 @@ async def test_get_transfer_candidates(session_factory):
     assert by_id[near_id]["date_diff_days"] == 2
     # All candidates are on the requested destination account.
     assert all(c["account_id"] == seed["a2_id"] for c in cands)
+    # Each candidate carries its own settled date (all candidates are settled).
+    assert by_id[same_day_id]["settled_date"] == base_date.isoformat()
+    assert by_id[near_id]["settled_date"] == (base_date + timedelta(days=2)).isoformat()
+    # The pending row never surfaces as a candidate.
+    assert pending_id not in cand_ids
 
 
 # ── Track E: manual-adjustment rejection in transfer-pair routes ──────────

--- a/backend/tests/services/test_budget_rebalance.py
+++ b/backend/tests/services/test_budget_rebalance.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
+from dateutil.relativedelta import relativedelta
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import (
@@ -209,7 +210,14 @@ async def _seed_history(
     category: Category,
     amount: Decimal,
     settled: datetime.date,
+    date: datetime.date | None = None,
 ):
+    """Seed a settled expense.
+
+    ``date`` defaults to ``settled`` (purchase == settlement). Pass a
+    distinct ``date`` to exercise the cash-basis bucketing path where the
+    purchase month and the settled month differ.
+    """
     acct = await _seed_account(db, org, user)
     tx = Transaction(
         org_id=org.id,
@@ -220,7 +228,7 @@ async def _seed_history(
         type=TransactionType.EXPENSE,
         status=TransactionStatus.SETTLED,
         settled_date=settled,
-        date=settled,
+        date=date if date is not None else settled,
     )
     db.add(tx)
     await db.commit()
@@ -530,6 +538,93 @@ async def test_service_never_mutates_budgets(
     await db.refresh(budgets["dining"])
     assert budgets["groceries"].amount == before_groceries
     assert budgets["dining"].amount == before_dining
+
+
+# ---------- cash-basis (settled-date) bucketing ----------------------
+
+
+@pytest.mark.asyncio
+async def test_history_is_bucketed_by_settled_date_not_purchase_date(
+    db: AsyncSession,
+    org: Organization,
+    user: User,
+    period: BillingPeriod,
+    categories,
+    budgets,
+):
+    """GBLT regression: ``_gather_facts`` must bucket settled history by
+    the EFFECTIVE (settled) date, not the raw purchase ``date``.
+
+    Seeds a SETTLED expense whose purchase ``date`` falls in the month
+    BEFORE the 3-month rollup's lower bound (so a raw
+    ``Transaction.date >= three_mo_lower`` filter would EXCLUDE it), but
+    whose ``settled_date`` lands squarely INSIDE the rollup window. The
+    spend MUST be summed in by its settled month.
+
+    Reverting ``_gather_facts`` to ``Transaction.date >= three_mo_lower``
+    drops this row entirely → the trailing-spend aggregate falls to 0
+    and this assertion fails.
+    """
+    today = datetime.date.today()
+    current_month_start = today.replace(day=1)
+    period_start = period.start_date
+    three_mo_upper = min(current_month_start, period_start)
+    three_mo_lower = three_mo_upper - relativedelta(months=3)
+
+    # settled_date sits inside [three_mo_lower, three_mo_upper): one month
+    # into the window. Purchase date sits one month BEFORE three_mo_lower
+    # (outside the window). They are in different months.
+    settled_inside = three_mo_lower + relativedelta(months=1)
+    purchase_before = three_mo_lower - relativedelta(months=1)
+    assert purchase_before < three_mo_lower <= settled_inside < three_mo_upper
+
+    await _seed_history(
+        db,
+        org=org,
+        user=user,
+        category=categories["groceries"],
+        amount=Decimal("300.00"),
+        settled=settled_inside,
+        date=purchase_before,
+    )
+
+    captured_payloads: list[dict] = []
+
+    async def fake_call(*args, messages, **kw):
+        for m in messages:
+            content = m.get("content", "")
+            marker = "AGGREGATES:\n"
+            if marker in content:
+                import json as _json
+
+                json_blob = content.split(marker, 1)[1].strip()
+                captured_payloads.append(_json.loads(json_blob))
+        return _make_structured_result({"summary": "ok", "suggestions": []})
+
+    with patch(
+        "app.services.budget_rebalance_service.call_llm_structured",
+        side_effect=fake_call,
+    ):
+        out = await budget_rebalance_service.suggest_rebalance(
+            db, org_id=org.id
+        )
+
+    # If history bucketed by raw purchase date, the row would be excluded
+    # entirely and the service would short-circuit to empty_no_history.
+    assert out.status == "ok", (
+        "settled expense must register as history when bucketed by its "
+        f"settled date; got status={out.status}"
+    )
+    assert captured_payloads, "expected the prompt to carry an aggregates payload"
+    cats = captured_payloads[0]["categories"]
+    by_id = {c["category_id"]: c for c in cats}
+    g_id = categories["groceries"].id
+    assert g_id in by_id
+    # $300 settled inside the 3-month window → avg = 300 / 3 = 100.
+    assert by_id[g_id]["last_3mo_avg_actual"] == pytest.approx(100.0), (
+        "groceries trailing-spend avg must reflect the settled-date "
+        f"bucketing; got {by_id[g_id]['last_3mo_avg_actual']}"
+    )
 
 
 # ---------- parent/child rollup correctness --------------------------

--- a/backend/tests/services/test_budget_spent_effective_date.py
+++ b/backend/tests/services/test_budget_spent_effective_date.py
@@ -1,0 +1,99 @@
+"""Budget spend bucketing aligns to effective_period_date_expr().
+
+For SETTLED rows (the only ones budget spend counts) settled_date is always
+populated, so switching the period predicate from a raw ``settled_date``
+comparison to ``effective_period_date_expr()`` (= coalesce(settled_date,
+date)) is behavior-identical. These tests are the regression guard for that
+alignment: a GBLT (dated in May, settled in June) must count in its SETTLED
+month, both before and after the swap.
+"""
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.category import Category, CategoryType
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Organization
+from app.services import budget_service
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed(factory) -> dict:
+    async with factory() as db:
+        org = Organization(name="org", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        at = AccountType(org_id=org.id, name="Cash", slug="cash", is_system=True)
+        db.add(at)
+        await db.commit()
+        acc = Account(org_id=org.id, account_type_id=at.id, name="Wallet",
+                      balance=Decimal("0"), currency="EUR")
+        db.add(acc)
+        await db.commit()
+        cat = Category(org_id=org.id, name="Groceries", slug="groceries",
+                       type=CategoryType.EXPENSE)
+        db.add(cat)
+        await db.commit()
+        return {"org_id": org.id, "account_id": acc.id, "cat_id": cat.id}
+
+
+@pytest.mark.asyncio
+async def test_compute_spent_buckets_gblt_by_settled_month(session_factory):
+    """A SETTLED expense dated 2026-05-31 but settled 2026-06-15 counts in
+    the June budget period, not the May one.
+    """
+    seed = await _seed(session_factory)
+    async with session_factory() as db:
+        db.add(Transaction(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["cat_id"], description="GBLT",
+            amount=Decimal("459.68"), type=TransactionType.EXPENSE,
+            status=TransactionStatus.SETTLED,
+            date=datetime.date(2026, 5, 31),
+            settled_date=datetime.date(2026, 6, 15),
+        ))
+        await db.commit()
+
+    async with session_factory() as db:
+        june = await budget_service._compute_spent(
+            db, seed["org_id"], seed["cat_id"],
+            datetime.date(2026, 6, 1), datetime.date(2026, 6, 30),
+        )
+        may = await budget_service._compute_spent(
+            db, seed["org_id"], seed["cat_id"],
+            datetime.date(2026, 5, 1), datetime.date(2026, 5, 31),
+        )
+    assert june == Decimal("459.68")  # counted in its settled month
+    assert may == Decimal("0")        # not in the purchase month

--- a/backend/tests/services/test_forecast_plan_populate.py
+++ b/backend/tests/services/test_forecast_plan_populate.py
@@ -569,3 +569,51 @@ async def test_refresh_does_not_duplicate_manual_items(session_factory):
     assert len(items) == 1, "manual item must not be duplicated by recurring"
     assert items[0].planned_amount == Decimal("5000")
     assert items[0].source == "manual"
+
+
+# ── Cash-basis: history window + bucketing use the effective settled date ──
+
+
+@pytest.mark.asyncio
+async def test_history_buckets_by_effective_settled_date(session_factory):
+    """A GBLT (dated 2026-01-31, settled 2026-02-15) falls in the Feb
+    history month by its SETTLED date — it's both inside the [Feb 1, May 1)
+    history window and bucketed into Feb, not Jan. Paired with a Mar settled
+    row that gives the 2nd month the 2-month minimum needs, so the plan line
+    only surfaces when the GBLT is counted by its effective date.
+    """
+    seed = await _seed(session_factory)
+
+    async with session_factory() as db:
+        # GBLT: dated Jan 31 (before the Feb-1 history floor on raw date),
+        # settled Feb 15 (inside the window, buckets to Feb).
+        db.add(_tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=200,
+            date=datetime.date(2026, 1, 31),
+            settled_date=datetime.date(2026, 2, 15),
+            status=TransactionStatus.SETTLED, type_=TransactionType.EXPENSE,
+        ))
+        # Mar 2026 settled $400 — the second history month.
+        db.add(_tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=400,
+            date=datetime.date(2026, 3, 10),
+            settled_date=datetime.date(2026, 3, 10),
+            status=TransactionStatus.SETTLED, type_=TransactionType.EXPENSE,
+        ))
+        await db.commit()
+
+    async with session_factory() as db:
+        resp = await forecast_plan_service.populate_from_sources(
+            db, org_id=seed["org_id"], period_start=seed["may_start"],
+        )
+
+    items = [
+        i for i in resp.items
+        if i.category_id == seed["groceries_id"] and i.type == "expense"
+    ]
+    # GBLT in Feb ($200) + Mar ($400) → 2 history months → avg = 300.00.
+    assert len(items) == 1
+    assert items[0].source == "history"
+    assert items[0].planned_amount == Decimal("300.00")

--- a/backend/tests/services/test_forecast_service.py
+++ b/backend/tests/services/test_forecast_service.py
@@ -1,0 +1,89 @@
+"""forecast_service period-window bucketing uses the effective settled date.
+
+A PENDING transaction dated in May but carrying a June settled-date estimate
+must count toward the June forecast window (cash-basis), consistent with the
+transactions list and reports.
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.billing import BillingPeriod
+from app.models.category import CategoryType
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.services import forecast_service
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed_org(db_session) -> tuple[Organization, Account, Category]:
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    acct = Account(org_id=org.id, name="Main", account_type_id=at.id,
+                   balance=Decimal("0"), currency="EUR")
+    db_session.add(acct)
+    await db_session.flush()
+    cat = Category(org_id=org.id, name="Food", slug="food", type=CategoryType.EXPENSE)
+    db_session.add(cat)
+    await db_session.flush()
+    # Explicit June 2026 period so the window is deterministic.
+    db_session.add(BillingPeriod(
+        org_id=org.id, start_date=date(2026, 6, 1), end_date=date(2026, 6, 30),
+    ))
+    await db_session.commit()
+    return org, acct, cat
+
+
+@pytest.mark.asyncio
+async def test_pending_window_buckets_by_effective_settled_date(db_session):
+    """A PENDING expense dated 2026-05-31 with settled_date 2026-06-15 counts
+    in the June forecast window, not the May one.
+    """
+    org, acct, cat = await _seed_org(db_session)
+    db_session.add(Transaction(
+        org_id=org.id, account_id=acct.id, category_id=cat.id,
+        description="GBLT", amount=Decimal("459.68"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.PENDING,
+        date=date(2026, 5, 31), settled_date=date(2026, 6, 15),
+    ))
+    await db_session.commit()
+
+    fc = await forecast_service.compute_forecast(
+        db_session, org.id, period_start=date(2026, 6, 1)
+    )
+    # GBLT must land in June's pending bucket via its settled date.
+    assert float(fc["pending_expense"]) == 459.68

--- a/backend/tests/services/test_reports_query_service.py
+++ b/backend/tests/services/test_reports_query_service.py
@@ -472,3 +472,28 @@ async def test_month_bucketing_uses_settled_date(session_factory):
         rows, _ = await execute_query(db, ast, org_id=seeds["org_id"])
     by_month = {r["month"]: r["value"] for r in rows}
     assert "2026-06" in by_month and "2026-05" not in by_month
+
+
+@pytest.mark.asyncio
+async def test_date_filter_uses_settled_date(session_factory):
+    """A DATE BETWEEN June filter INCLUDES the GBLT by its June settled
+    date, even though its raw transaction date is in May.
+    """
+    seeds = await _seed_gblt(session_factory)
+    ast = ReportsQuery(
+        dataset=Dataset.TRANSACTIONS,
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+        filters=[
+            Filter(
+                field=FilterField.DATE,
+                op=FilterOp.BETWEEN,
+                value=[date(2026, 6, 1), date(2026, 6, 30)],
+            )
+        ],
+        limit=100,
+    )
+    async with session_factory() as db:
+        rows, _ = await execute_query(db, ast, org_id=seeds["org_id"])
+    # No dimensions → a single aggregate row. SUM is the GBLT amount only
+    # when the June filter includes it via its settled date (else 0/None).
+    assert rows[0]["value"] == 459.68

--- a/backend/tests/services/test_reports_query_service.py
+++ b/backend/tests/services/test_reports_query_service.py
@@ -411,3 +411,64 @@ def test_sqlite_compile_skips_timeout_hint():
 
     compiled = stmt.compile(compile_kwargs={"literal_binds": False})
     assert "MAX_EXECUTION_TIME" not in str(compiled)
+
+
+# ─── effective settled-date bucketing (cash-basis) ─────────────────
+
+
+async def _seed_gblt(factory) -> dict:
+    """Seed a single org with one GBLT-style transaction: dated in May,
+    settled in June. Cash-basis bucketing must count it in June.
+    """
+    async with factory() as db:
+        org = Organization(name="GBLT Org", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+
+        at = AccountType(org_id=org.id, name="Checking")
+        db.add(at)
+        await db.commit()
+
+        acct = Account(
+            org_id=org.id,
+            account_type_id=at.id,
+            name="Bank",
+            currency="EUR",
+            balance=Decimal("0"),
+        )
+        cat = Category(org_id=org.id, name="Food")
+        db.add_all([acct, cat])
+        await db.commit()
+
+        tx = Transaction(
+            org_id=org.id,
+            account_id=acct.id,
+            category_id=cat.id,
+            description="GBLT",
+            amount=Decimal("459.68"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.SETTLED,
+            date=date(2026, 5, 31),
+            settled_date=date(2026, 6, 15),
+        )
+        db.add(tx)
+        await db.commit()
+        return {"org_id": org.id}
+
+
+@pytest.mark.asyncio
+async def test_month_bucketing_uses_settled_date(session_factory):
+    """A GBLT (dated 2026-05-31, settled 2026-06-15) groups by its
+    SETTLED month — June, not May.
+    """
+    seeds = await _seed_gblt(session_factory)
+    ast = ReportsQuery(
+        dataset=Dataset.TRANSACTIONS,
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+        dimensions=[Dimension.MONTH],
+        limit=100,
+    )
+    async with session_factory() as db:
+        rows, _ = await execute_query(db, ast, org_id=seeds["org_id"])
+    by_month = {r["month"]: r["value"] for r in rows}
+    assert "2026-06" in by_month and "2026-05" not in by_month

--- a/backend/tests/services/test_scenario_engine.py
+++ b/backend/tests/services/test_scenario_engine.py
@@ -1281,3 +1281,68 @@ async def test_simulate_custom_events_does_not_mutate_any_real_table(
     # The one_off_expense at month 3 in a positive-balance fixture may
     # not dip below zero; just sanity-check projection length.
     assert len(result["per_account_series"]) == 2
+
+
+# ── Cash-basis: history cashflow buckets by effective settled date ──
+
+
+@pytest.mark.asyncio
+async def test_world_state_history_buckets_by_effective_settled_date(
+    session_factory,
+):
+    """build_world_state's 12-month per-account cashflow history must
+    bucket a GBLT (dated in month X, settled in month Y) by its SETTLED
+    month, and include rows the window only admits via the settled date.
+    """
+    from app.models.transaction import TransactionStatus, TransactionType
+
+    # Pick two adjacent months a few months back so both the raw and the
+    # settled date sit inside the [today-12mo, this-month) window.
+    anchor = date.today().replace(day=1) - relativedelta(months=4)
+    settled_month = anchor + relativedelta(months=1)
+    raw_date = (settled_month.replace(day=1) - timedelta(days=1))  # last day of anchor month
+    settled_date_val = settled_month.replace(day=10)
+
+    async with session_factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        user = User(
+            org_id=org.id, username="bob", email="bob@acme.io",
+            password_hash=hash_password("pw-1234567"), role=Role.OWNER,
+            is_active=True, email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+        db.add(at)
+        await db.commit()
+        acc = Account(
+            org_id=org.id, account_type_id=at.id, name="Main",
+            balance=Decimal("1000.00"), currency="EUR",
+            opening_balance=Decimal("1000.00"),
+            opening_balance_date=date(2025, 1, 1),
+        )
+        db.add(acc)
+        await db.commit()
+        cat = Category(org_id=org.id, name="Groceries", type=CategoryType.EXPENSE)
+        db.add(cat)
+        await db.commit()
+        db.add(Transaction(
+            org_id=org.id, account_id=acc.id, category_id=cat.id,
+            description="GBLT", amount=Decimal("459.68"),
+            type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+            date=raw_date, settled_date=settled_date_val,
+        ))
+        await db.commit()
+        org_id, user_id, acc_id = org.id, user.id, acc.id
+
+    async with session_factory() as db:
+        from app.services.scenario_engine import build_world_state
+        state = await build_world_state(db, org_id=org_id, user_id=user_id)
+
+    keyed = {(p.year, p.month): p for p in state.history if p.account_id == acc_id}
+    # Bucketed into the SETTLED month, not the raw (anchor) month.
+    assert (settled_date_val.year, settled_date_val.month) in keyed
+    assert (raw_date.year, raw_date.month) not in keyed
+    assert keyed[(settled_date_val.year, settled_date_val.month)].net == Decimal("-459.68")

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1266,7 +1266,18 @@ export default function DashboardPage() {
                         href={transactionHighlightHref(tx)}
                         className="-mx-2 -my-1.5 flex min-w-0 items-center gap-3 rounded-md px-2 py-1.5 transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent sm:col-span-8 sm:my-0"
                       >
-                        <span className="w-16 shrink-0 text-xs tabular-nums text-text-secondary sm:w-auto">{tx.date.slice(5)}</span>
+                        {/* Date + Settled date. The operator requires the
+                            settled date visible wherever a transaction renders,
+                            so each row stacks the original date over the settled
+                            date (settled date when set, em-dash when still
+                            pending / unsettled). MM-DD slice matches the
+                            compact recent-list date format. */}
+                        <span className="flex w-16 shrink-0 flex-col text-xs tabular-nums text-text-secondary sm:w-auto">
+                          <span>{tx.date.slice(5)}</span>
+                          <span className="text-[10px] text-text-muted" data-testid={`dash-settled-${tx.id}`}>
+                            {tx.settled_date ? tx.settled_date.slice(5) : "—"}
+                          </span>
+                        </span>
                         <div className="min-w-0">
                           <p className="text-sm text-text-primary truncate">{tx.description}</p>
                           <p className="text-[11px] text-text-secondary truncate">{subline}</p>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1042,17 +1042,24 @@ function TransactionsPageContent() {
                   />
                 </div>
                 {([
-                  { field: "date" as const, label: "Date", span: "col-span-2", align: "" },
-                  { field: "description" as const, label: "Description", span: "col-span-2", align: "" },
-                  { field: "account_name" as const, label: "Account", span: "col-span-2", align: "" },
-                  { field: "category_name" as const, label: "Category", span: "col-span-1", align: "" },
-                  { field: "status" as const, label: "Status", span: "col-span-1", align: "text-center" },
-                  { field: "amount" as const, label: "Amount", span: "col-span-1", align: "text-right" },
-                ]).map((col) => (
-                  <button key={col.field} onClick={() => toggleSort(col.field)} className={`${col.span} ${col.align} min-h-[32px] hover:text-text-primary transition-colors`}>
-                    {col.label}{sortField === col.field ? (sortDir === "asc" ? " ↑" : " ↓") : ""}
-                  </button>
-                ))}
+                  { field: "date" as const, label: "Date", span: "col-span-1", align: "", sortable: true },
+                  { field: "settled_date" as const, label: "Settled", span: "col-span-1", align: "", sortable: false },
+                  { field: "description" as const, label: "Description", span: "col-span-2", align: "", sortable: true },
+                  { field: "account_name" as const, label: "Account", span: "col-span-2", align: "", sortable: true },
+                  { field: "category_name" as const, label: "Category", span: "col-span-1", align: "", sortable: true },
+                  { field: "status" as const, label: "Status", span: "col-span-1", align: "text-center", sortable: true },
+                  { field: "amount" as const, label: "Amount", span: "col-span-1", align: "text-right", sortable: true },
+                ]).map((col) =>
+                  // Settled is a display-only column (the server sorts by `date`),
+                  // so it renders as a static header rather than a sort button.
+                  col.sortable ? (
+                    <button key={col.field} onClick={() => toggleSort(col.field as SortField)} className={`${col.span} ${col.align} min-h-[32px] hover:text-text-primary transition-colors`}>
+                      {col.label}{sortField === col.field ? (sortDir === "asc" ? " ↑" : " ↓") : ""}
+                    </button>
+                  ) : (
+                    <span key={col.field} className={`${col.span} ${col.align} flex items-center`}>{col.label}</span>
+                  ),
+                )}
                 <span className="col-span-2" />
               </div>
             </div>
@@ -1314,21 +1321,20 @@ function TransactionsPageContent() {
                               className="h-4 w-4"
                             />
                           </span>
-                          <span className="col-span-2 text-sm tabular-nums text-text-secondary">
+                          <span className="col-span-1 text-sm tabular-nums text-text-secondary">
                             {tx.date}
-                            {/* Expected settlement subtext (Item 13). Surfaces
-                                only when the row is pending AND the user set a
-                                custom settlement date that differs from the
-                                transaction date. Otherwise the subtext would
-                                be redundant noise. */}
-                            {tx.status === "pending" && tx.settled_date && tx.settled_date !== tx.date && (
-                              <span
-                                className="block text-[10px] text-text-muted"
-                                data-testid={`expected-settled-${tx.id}`}
-                              >
-                                expected settled {tx.settled_date}
-                              </span>
-                            )}
+                          </span>
+                          {/* Settled date column (effective-date consistency).
+                              The operator requires the settled date to be
+                              visible wherever a transaction renders, so every
+                              row shows it explicitly: the settled date when
+                              set, or an em-dash placeholder when still pending
+                              / unsettled. */}
+                          <span
+                            className="col-span-1 text-sm tabular-nums text-text-secondary"
+                            data-testid={`settled-date-${tx.id}`}
+                          >
+                            {tx.settled_date ?? "—"}
                           </span>
                           <span className="col-span-2 flex flex-col text-sm text-text-primary">
                             <span>{tx.description}</span>
@@ -1657,6 +1663,17 @@ function TransactionsPageContent() {
                               )}
                               <div className="mt-0.5 text-xs text-text-muted tabular-nums">
                                 {tx.date} · {isTransfer && linkedTx ? <>{tx.account_name} &rarr; {linkedTx.account_name}</> : tx.account_name}
+                              </div>
+                              {/* Settled date always surfaced on the mobile card
+                                  too (effective-date consistency): the operator
+                                  requires it visible wherever a transaction
+                                  renders. Settled date when set, em-dash when
+                                  still pending / unsettled. */}
+                              <div
+                                className="mt-0.5 text-[10px] text-text-muted tabular-nums"
+                                data-testid={`settled-date-mobile-${tx.id}`}
+                              >
+                                Settled {tx.settled_date ?? "—"}
                               </div>
                               {tx.status === "pending" && tx.settled_date && tx.settled_date !== tx.date && (
                                 <div

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1675,14 +1675,6 @@ function TransactionsPageContent() {
                               >
                                 Settled {tx.settled_date ?? "—"}
                               </div>
-                              {tx.status === "pending" && tx.settled_date && tx.settled_date !== tx.date && (
-                                <div
-                                  className="mt-0.5 text-[10px] text-text-muted"
-                                  data-testid={`expected-settled-mobile-${tx.id}`}
-                                >
-                                  expected settled {tx.settled_date}
-                                </div>
-                              )}
                             </div>
                             <div className={`shrink-0 text-right text-sm font-semibold tabular-nums ${isTransfer ? "text-accent" : tx.type === "income" ? "text-success" : "text-danger"}`}>
                               {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}

--- a/frontend/components/transactions/LinkAsTransferModal.tsx
+++ b/frontend/components/transactions/LinkAsTransferModal.tsx
@@ -102,10 +102,12 @@ export default function LinkAsTransferModal({
           <div>
             <span className="font-medium">Expense leg:</span>{" "}
             -{formatAmount(expenseLeg.amount)} on {expenseLeg.account_name} ({expenseLeg.date})
+            <span className="ml-1 text-text-secondary">settled {expenseLeg.settled_date ?? "—"}</span>
           </div>
           <div>
             <span className="font-medium">Income leg:</span>{" "}
             +{formatAmount(incomeLeg.amount)} on {incomeLeg.account_name} ({incomeLeg.date})
+            <span className="ml-1 text-text-secondary">settled {incomeLeg.settled_date ?? "—"}</span>
           </div>
         </div>
         <label className="mb-4 flex items-center gap-2 text-sm text-text-primary">

--- a/frontend/components/transactions/MarkAsTransferModal.tsx
+++ b/frontend/components/transactions/MarkAsTransferModal.tsx
@@ -237,6 +237,7 @@ export default function MarkAsTransferModal({
             <span className="font-medium">Source:</span> {source.account_name} &middot;{" "}
             {source.type === "expense" ? "-" : "+"}
             {formatAmount(source.amount)} &middot; {source.date}
+            <span className="ml-1 text-text-secondary">settled {source.settled_date ?? "—"}</span>
           </div>
         </div>
 

--- a/frontend/components/transactions/MarkAsTransferModal.tsx
+++ b/frontend/components/transactions/MarkAsTransferModal.tsx
@@ -206,7 +206,11 @@ export default function MarkAsTransferModal({
         />
         <span className="flex flex-col">
           <span>
-            {c.date} &middot; {c.description} &middot; {formatAmount(c.amount)}
+            {c.date}
+            <span className="ml-1 text-text-secondary">
+              settled {c.settled_date ?? "—"}
+            </span>{" "}
+            &middot; {c.description} &middot; {formatAmount(c.amount)}
           </span>
           <span className="text-xs text-text-secondary">
             {c.account_name} &middot; {diffText}

--- a/frontend/components/transactions/UnpairTransferModal.tsx
+++ b/frontend/components/transactions/UnpairTransferModal.tsx
@@ -127,6 +127,7 @@ export default function UnpairTransferModal({
             <span className="font-medium">Expense leg:</span>{" "}
             -{formatAmount(expenseLeg.amount)} &middot; {expenseLeg.date}{" "}
             &middot; {expenseLeg.account_name}
+            <span className="ml-1 text-text-secondary">settled {expenseLeg.settled_date ?? "—"}</span>
           </div>
           <label htmlFor="unpair-expense-cat" className={labelCls}>
             Category
@@ -147,6 +148,7 @@ export default function UnpairTransferModal({
             <span className="font-medium">Income leg:</span>{" "}
             +{formatAmount(incomeLeg.amount)} &middot; {incomeLeg.date} &middot;{" "}
             {incomeLeg.account_name}
+            <span className="ml-1 text-text-secondary">settled {incomeLeg.settled_date ?? "—"}</span>
           </div>
           <label htmlFor="unpair-income-cat" className={labelCls}>
             Category

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -443,6 +443,7 @@ export interface FeatureStateResponse {
 export interface TransferCandidate {
   id: number;
   date: string;
+  settled_date: string | null;
   description: string;
   amount: number;
   account_id: number;

--- a/frontend/tests/app/dashboard-recent-settled.test.tsx
+++ b/frontend/tests/app/dashboard-recent-settled.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+
+import DashboardPage from "@/app/dashboard/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/dashboard",
+}));
+
+const USER = {
+  id: 1, username: "u", email: "u@x.io",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner", org_id: 1, org_name: "Acme",
+  billing_cycle_day: 1, is_superadmin: false, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const GBLT = {
+  id: 1, account_id: 10, amount: "12.00", type: "expense", status: "settled",
+  date: "2026-05-31", description: "GBLT", category_id: 1,
+  category_name: "Groceries", account_name: "Checking", currency: "EUR",
+  linked_transaction_id: null, is_imported: false, settled_date: "2026-06-15",
+};
+
+const PENDING = {
+  id: 2, account_id: 10, amount: "50.00", type: "expense", status: "pending",
+  date: "2026-06-10", description: "Pending", category_id: 1,
+  category_name: "Groceries", account_name: "Credit", currency: "EUR",
+  linked_transaction_id: null, is_imported: false, settled_date: null,
+};
+
+const TXS = [GBLT, PENDING];
+
+function mockDashboard() {
+  vi.mocked(apiFetch).mockImplementation(((url: string) => {
+    if (url === "/api/v1/accounts") return Promise.resolve([]);
+    if (url === "/api/v1/categories") return Promise.resolve([]);
+    if (url === "/api/v1/budgets" || url.startsWith("/api/v1/budgets?")) return Promise.resolve([]);
+    if (url === "/api/v1/settings/billing-cycle") return Promise.resolve({ billing_cycle_day: 1 });
+    if (url === "/api/v1/settings/billing-period")
+      return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+    if (url === "/api/v1/settings/billing-periods")
+      return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
+    if (url.startsWith("/api/v1/forecast-plans/current")) return Promise.resolve(null);
+    if (url.startsWith("/api/v1/forecast?period_start=")) return Promise.resolve(null);
+    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve({ items: [PENDING], total: 1, limit: 200, offset: 0 });
+    if (url.startsWith("/api/v1/transactions")) return Promise.resolve({ items: TXS, total: TXS.length, limit: 200, offset: 0 });
+    return Promise.resolve({});
+  }) as never);
+}
+
+describe("DashboardPage Recent Transactions — settled date (Task 9)", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    window.history.pushState({}, "", "/dashboard");
+    window.localStorage.clear();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    mockDashboard();
+  });
+
+  it("surfaces the settled date on a recent transaction row", async () => {
+    render(<DashboardPage />);
+
+    const settled = await screen.findByTestId("dash-settled-1");
+    // Settled date (June 15) is visible on the GBLT row.
+    expect(settled).toHaveTextContent("06-15");
+    // The original date (May 31) is also still present on the row.
+    expect(screen.getAllByText(/05-31/).length).toBeGreaterThan(0);
+  });
+
+  it("shows an em-dash placeholder when a row has no settled date", async () => {
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dash-settled-2")).toBeInTheDocument();
+    });
+    expect(within(screen.getByTestId("dash-settled-2")).getByText("—")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/app/import-page.test.tsx
+++ b/frontend/tests/app/import-page.test.tsx
@@ -144,6 +144,7 @@ describe("ImportPage transfer pill column", () => {
           {
             id: 99,
             date: "2026-05-01",
+            settled_date: "2026-05-01",
             description: "Counter leg",
             amount: 50,
             account_id: 2,
@@ -180,6 +181,7 @@ describe("ImportPage transfer pill column", () => {
           {
             id: 99,
             date: "2026-04-29",
+            settled_date: "2026-04-29",
             description: "Counter leg near",
             amount: 50,
             account_id: 2,
@@ -215,6 +217,7 @@ describe("ImportPage transfer pill column", () => {
           {
             id: 101,
             date: "2026-05-01",
+            settled_date: "2026-05-01",
             description: "First candidate",
             amount: 50,
             account_id: 2,
@@ -225,6 +228,7 @@ describe("ImportPage transfer pill column", () => {
           {
             id: 102,
             date: "2026-04-30",
+            settled_date: "2026-04-30",
             description: "Second candidate",
             amount: 50,
             account_id: 3,
@@ -306,6 +310,7 @@ describe("ImportPage transfer pill column", () => {
           {
             id: 99,
             date: "2026-05-01",
+            settled_date: "2026-05-01",
             description: "Counter leg",
             amount: 50,
             account_id: 2,
@@ -362,6 +367,7 @@ describe("ImportPage transfer pill column", () => {
           {
             id: 201,
             date: "2026-05-01",
+            settled_date: "2026-05-01",
             description: "Counter A",
             amount: 50,
             account_id: 2,
@@ -381,6 +387,7 @@ describe("ImportPage transfer pill column", () => {
           {
             id: 202,
             date: "2026-04-29",
+            settled_date: "2026-04-29",
             description: "Counter B",
             amount: 50,
             account_id: 2,
@@ -495,6 +502,7 @@ describe("ImportPage transfer pill column", () => {
           {
             id: 99,
             date: "2026-05-01",
+            settled_date: "2026-05-01",
             description: "Counter leg",
             amount: 50,
             account_id: 2,
@@ -546,6 +554,7 @@ describe("ImportPage transfer pill column", () => {
                 {
                   id: 99,
                   date: "2026-05-01",
+                  settled_date: "2026-05-01",
                   description: "Counter leg",
                   amount: 50,
                   account_id: 2,

--- a/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
+++ b/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
@@ -429,7 +429,7 @@ describe("TransactionsPage - settled_date (Punch-list Item 13)", () => {
     expect(body).not.toHaveProperty("settled_date");
   });
 
-  it("view row: shows 'expected settled YYYY-MM-DD' subtext on pending rows", async () => {
+  it("view row: mobile card surfaces the settled date on pending rows", async () => {
     const tx = makeTx({
       id: 90,
       description: "Pending CC",
@@ -441,12 +441,16 @@ describe("TransactionsPage - settled_date (Punch-list Item 13)", () => {
     render(<TransactionsPage />);
 
     await screen.findAllByText("Pending CC");
-    // Subtext renders in both desktop + mobile views.
-    const subtexts = await screen.findAllByText(/expected settled 2026-06-15/);
-    expect(subtexts.length).toBeGreaterThan(0);
+    // The always-on mobile settled line shows the settled date exactly
+    // once (the legacy "expected settled" subtext was removed so it no
+    // longer renders twice when settled_date differs from date).
+    const mobileSettled = await screen.findByTestId("settled-date-mobile-90");
+    expect(mobileSettled).toHaveTextContent("Settled 2026-06-15");
+    expect(screen.queryByTestId("expected-settled-mobile-90")).toBeNull();
+    expect(screen.queryByText(/expected settled/i)).toBeNull();
   });
 
-  it("view row: subtext hidden when settled_date matches transaction date (would be redundant)", async () => {
+  it("view row: mobile settled line always renders, even when settled_date matches the transaction date", async () => {
     const tx = makeTx({
       id: 91,
       description: "Pending same date",
@@ -458,6 +462,10 @@ describe("TransactionsPage - settled_date (Punch-list Item 13)", () => {
     render(<TransactionsPage />);
 
     await screen.findAllByText("Pending same date");
+    // The always-on line renders regardless of whether the dates match;
+    // it shows the (matching) settled date rather than being suppressed.
+    const mobileSettled = await screen.findByTestId("settled-date-mobile-91");
+    expect(mobileSettled).toHaveTextContent("Settled 2026-05-01");
     expect(screen.queryByText(/expected settled/i)).toBeNull();
   });
 

--- a/frontend/tests/app/transactions-settled-column.test.tsx
+++ b/frontend/tests/app/transactions-settled-column.test.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+
+import TransactionsPage from "@/app/transactions/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/transactions",
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const USER = {
+  id: 1, username: "user", email: "user@example.com",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner" as const, org_id: 1, org_name: "Org",
+  billing_cycle_day: 1, is_superadmin: false, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const ACCT_A = {
+  id: 100, name: "Checking A", account_type_id: 1,
+  account_type_name: "Checking", account_type_slug: "checking",
+  balance: 0, currency: "EUR", is_active: true,
+  close_day: null, is_default: true,
+};
+
+const CATEGORY_GROCERIES = {
+  id: 11, name: "Groceries", type: "expense" as const,
+  parent_id: null, parent_name: null, description: null,
+  slug: "groceries", is_system: false, transaction_count: 0,
+};
+
+function makeTx(over: Partial<{
+  id: number;
+  date: string;
+  settled_date: string | null;
+  description: string;
+  status: "settled" | "pending";
+}> = {}) {
+  return {
+    id: 1,
+    account_id: ACCT_A.id,
+    account_name: ACCT_A.name,
+    category_id: CATEGORY_GROCERIES.id,
+    category_name: CATEGORY_GROCERIES.name,
+    description: "Tx",
+    amount: 100,
+    type: "expense" as const,
+    status: "settled" as const,
+    linked_transaction_id: null,
+    recurring_id: null,
+    date: "2026-05-31",
+    settled_date: "2026-06-15",
+    is_imported: false,
+    is_manual_adjustment: false,
+    tags: [],
+    ...over,
+  };
+}
+
+function setupApiFetch(txs: ReturnType<typeof makeTx>[]) {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
+    if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
+    if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
+    if (url.startsWith("/api/v1/transactions"))
+      return { items: txs, total: txs.length, limit: 25, offset: 0 } as never;
+    return null as never;
+  });
+}
+
+describe("TransactionsPage — Settled date column (Task 8)", () => {
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  it("renders a Settled header and shows both the original date and settled date for a GBLT row", async () => {
+    setupApiFetch([makeTx({ id: 7, description: "GBLT", date: "2026-05-31", settled_date: "2026-06-15" })]);
+
+    render(<TransactionsPage />);
+
+    const row = await screen.findByTestId("tx-row-desktop-7");
+
+    // Both the original date and the settled date are visible on the row.
+    expect(within(row).getByTestId("settled-date-7")).toHaveTextContent("2026-06-15");
+    expect(within(row).getAllByText("2026-05-31").length).toBeGreaterThan(0);
+  });
+
+  it("shows an em-dash placeholder in the Settled cell when settled_date is null", async () => {
+    setupApiFetch([makeTx({ id: 8, description: "Pending", status: "pending", date: "2026-06-10", settled_date: null })]);
+
+    render(<TransactionsPage />);
+
+    const row = await screen.findByTestId("tx-row-desktop-8");
+    const settledCell = within(row).getByTestId("settled-date-8");
+    expect(settledCell).toHaveTextContent("—");
+  });
+});

--- a/frontend/tests/components/transactions/mark-as-transfer-modal.test.tsx
+++ b/frontend/tests/components/transactions/mark-as-transfer-modal.test.tsx
@@ -294,4 +294,47 @@ describe("MarkAsTransferModal", () => {
       })
     );
   });
+
+  it("candidate rows show each candidate's settled date (and — when null)", async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      candidates: [
+        {
+          id: 99,
+          date: "2026-04-29",
+          settled_date: "2026-05-02",
+          description: "Settled leg",
+          amount: 500,
+          account_id: 20,
+          account_name: "Savings",
+          date_diff_days: 0,
+          confidence: "same_day",
+        },
+        {
+          id: 100,
+          date: "2026-04-29",
+          settled_date: null,
+          description: "Unsettled leg",
+          amount: 500,
+          account_id: 20,
+          account_name: "Savings",
+          date_diff_days: 0,
+          confidence: "same_day",
+        },
+      ],
+    } as never);
+    render(
+      <MarkAsTransferModal
+        source={source}
+        accounts={accounts}
+        onConverted={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "20" } });
+    await waitFor(() => expect(screen.getAllByRole("radio").length).toBe(2));
+    // The settled date (distinct month from the original date) is shown.
+    expect(screen.getByText(/settled 2026-05-02/i)).toBeInTheDocument();
+    // Null settled_date renders the em-dash placeholder.
+    expect(screen.getByText(/settled —/i)).toBeInTheDocument();
+  });
 });

--- a/frontend/tests/components/transactions/transfer-modals-settled-date.test.tsx
+++ b/frontend/tests/components/transactions/transfer-modals-settled-date.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+
+import LinkAsTransferModal from "@/components/transactions/LinkAsTransferModal";
+import MarkAsTransferModal from "@/components/transactions/MarkAsTransferModal";
+import UnpairTransferModal from "@/components/transactions/UnpairTransferModal";
+import { apiFetch } from "@/lib/api";
+import type { Account, Category, Transaction } from "@/lib/types";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+function makeLeg(over: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 1,
+    account_id: 10,
+    account_name: "Checking",
+    category_id: 100,
+    category_name: "Other",
+    description: "Buffer",
+    amount: 500,
+    type: "expense",
+    status: "settled",
+    linked_transaction_id: null,
+    recurring_id: null,
+    date: "2026-05-31",
+    settled_date: "2026-06-15",
+    is_imported: false,
+    is_manual_adjustment: false,
+    tags: [],
+    ...over,
+  };
+}
+
+describe("Transfer modals — settled date display (Task 11)", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  it("LinkAsTransferModal shows the settled date for each leg", () => {
+    render(
+      <LinkAsTransferModal
+        expenseLeg={makeLeg({ id: 1, type: "expense", date: "2026-05-31", settled_date: "2026-06-15" })}
+        incomeLeg={makeLeg({ id: 2, type: "income", account_name: "Savings", date: "2026-05-31", settled_date: null })}
+        onLinked={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    // Original date visible on both legs.
+    expect(screen.getAllByText(/2026-05-31/).length).toBeGreaterThan(0);
+    // Settled date visible for the leg that has one.
+    expect(screen.getByText(/settled 2026-06-15/i)).toBeInTheDocument();
+    // Em-dash settled for the unsettled leg.
+    expect(screen.getByText(/settled —/i)).toBeInTheDocument();
+  });
+
+  it("UnpairTransferModal shows the settled date for each leg", () => {
+    render(
+      <UnpairTransferModal
+        expenseLeg={makeLeg({ id: 1, type: "expense", date: "2026-05-31", settled_date: "2026-06-15" })}
+        incomeLeg={makeLeg({ id: 2, type: "income", account_name: "Savings", date: "2026-05-31", settled_date: "2026-06-15" })}
+        categories={[] as Category[]}
+        onUnpaired={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getAllByText(/settled 2026-06-15/i).length).toBeGreaterThan(0);
+  });
+
+  it("MarkAsTransferModal shows the settled date on the source line", () => {
+    const accounts: Account[] = [
+      {
+        id: 10, name: "Checking", account_type_id: 1,
+        account_type_name: "Checking", account_type_slug: "checking",
+        balance: 0, currency: "EUR", is_active: true,
+        close_day: null, is_default: true,
+      },
+      {
+        id: 20, name: "Savings", account_type_id: 1,
+        account_type_name: "Savings", account_type_slug: "savings",
+        balance: 0, currency: "EUR", is_active: true,
+        close_day: null, is_default: false,
+      },
+    ];
+    render(
+      <MarkAsTransferModal
+        source={makeLeg({ id: 1, type: "expense", date: "2026-05-31", settled_date: "2026-06-15" })}
+        accounts={accounts}
+        onConverted={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/settled 2026-06-15/i)).toBeInTheDocument();
+  });
+});

--- a/specs/2026-06-15-transaction-effective-date-consistency-design.md
+++ b/specs/2026-06-15-transaction-effective-date-consistency-design.md
@@ -1,0 +1,50 @@
+# Transaction Effective-Date Consistency (cash-basis everywhere + dual-date display)
+
+**Date:** 2026-06-15
+**Status:** design approved (operator), pre-spec-review
+**Trigger:** A transaction created in May but settled in June ("GBLT") appears in the June *transactions list* (which buckets by settled date) but is **missing from the June report** (which buckets by raw `date`). The two surfaces answer "which period?" differently. Operator: make it consistent (cash-basis: count a transaction in the period it settled) AND make both dates visible wherever a transaction is shown — "we can't hide such information."
+
+## Decision (operator-locked)
+- **Approach B (non-destructive):** keep `date` + `settled_date` separate; standardize every period-bucketing/reporting surface on the EXISTING `effective_period_date_expr()` = `coalesce(settled_date, date)`. Do NOT mutate `date`. (Approach A — overwrite `date := settled_date` on settle — was rejected as destructive: it loses the original occurrence date and unwinds the deliberate date/settled_date split.)
+- **Dual-date display everywhere a transaction is visible.** Surface BOTH the original date and the settled date on every transaction-display surface, so a May-created/June-settled row is self-explanatory in a June view. Hiding the settled date is what made the current behavior feel "fundamentally wrong."
+- **App-wide cash-basis is deliberate.** Document it so a later change doesn't "fix" a forecast back to raw `date`.
+
+## Audit — which date each surface uses today
+
+**Already bucket by effective/settled date (no change, or minor alignment):**
+- Transactions list — date filter + sort (`transaction_service.py:1995/1997/2108`, `effective_period_date_expr()`).
+- Dashboard account-balance month-end forecast (`account_balance_forecast_service.py:78`).
+- **Budgets** — `budget_service.py:47,52` + `budget_rebalance_service.py:203-219` already use `Transaction.settled_date` directly. **Minor alignment:** switch these to `effective_period_date_expr()` so pending-with-estimate and the date-fallback behave identically to every other surface (today a pending row with a NULL settled_date silently drops from the budget period). Behavior-identical for settled rows.
+
+**Laggards using raw `Transaction.date` (the bug) — switch to `effective_period_date_expr()`:**
+- **Reports** (`reports_query_service.py`): the month/week/day time-dimension expressions (`:98-110`) AND the `DATE` filter column (`_FILTER_COLUMN[FilterField.DATE]`, `:144`).
+- **forecast_service.py** (`:96-108, :165-166`).
+- **forecast_plan_service.py** (`:531-573`).
+- **scenario_engine.py** (`:668-669`).
+
+**Scope guard — do NOT change (these use the literal calendar date on purpose, not the financial period):**
+- `recurring_service.py` — due-date matching/generation (`:158,:228,:301`).
+- `import_service.py` — dedup window (`:163`).
+- `transaction_suggestions_service.py` — "last used" (`:131,:158`).
+Each remaining `Transaction.date` site will be classified in the plan (change vs leave) with a one-line rationale; nothing changes without that classification.
+
+## Frontend — dual-date display on EVERY transaction-display surface
+Add a **Settled date** alongside the existing date wherever a transaction renders. The API already returns `settled_date` on `TransactionResponse`, so this is display-only.
+- **Transactions list** (`app/transactions/page.tsx` + its row/table component): keep the existing column for `date` (the original/occurrence date), add a **Settled date** column. The list already filters/sorts by the effective date; now the Settled column shows *why* a row is in a given period. For a pending row, show the expected-settlement estimate or "—".
+- **Dashboard "recent transactions"** (`app/dashboard/page.tsx`): show both dates (compact form acceptable — e.g. settled date primary with the original as secondary/tooltip if space-constrained, but it must be visible, not hidden).
+- **Account detail recent transactions**, **transaction detail/edit** (`TransactionForm.tsx`), **batch view**, **transfer modals** — wherever a transaction's date is shown, show the settled date too. The plan will enumerate the exact components from a frontend audit.
+- **CSV export** (transactions export): add a `settled_date` column.
+- **Column labels:** operator term is "Creation date" / "Settled date". Technically `date` is the transaction/purchase date you assign (not the DB row-creation timestamp). Final labels (e.g. "Date" / "Settled", or "Booked" / "Settled") are cosmetic — lock in the plan; both columns must be present and clearly distinct.
+
+## Components / data flow
+- One backend change of substance: swap `Transaction.date` → `effective_period_date_expr()` at the classified bucketing sites (reports, the 3 forecast services, budgets-alignment). The expression already exists and is SQLite/MySQL-portable (it's `coalesce`).
+- Frontend: purely additive display of an already-returned field across the enumerated surfaces + the CSV column.
+- No model change, **no migration**.
+
+## Testing
+- **Backend:** for each switched surface, a test proving a transaction whose `date` and `settled_date` fall in DIFFERENT months is bucketed by the SETTLED month (the GBLT case): reports time-grouping + DATE filter; forecast_service; forecast_plan_service; scenario_engine; budgets (settled month, plus a pending-with-estimate row now included via the fallback). Confirm the scope-guarded sites (recurring due-date, import dedup, suggestions) are UNCHANGED (their existing tests stay green).
+- **Frontend:** each transaction-display surface renders both dates; the list shows a Settled column; pending rows render the estimate/"—"; CSV includes `settled_date`. Full `eslint . --quiet` + `tsc --noEmit` + `vitest run`.
+- Cross-surface consistency check: the GBLT-style fixture appears in the same period in the list, the report, and the relevant forecast.
+
+## Process
+Subagent-driven (backend bucketing phase, then frontend display phase), review gate per phase, then a fleet review before the PR. Backend tests in an isolated `-p team-*` stack. The plan will (1) complete the frontend transaction-display-surface enumeration and (2) classify every remaining `Transaction.date` site.

--- a/specs/2026-06-15-transaction-effective-date-consistency-design.md
+++ b/specs/2026-06-15-transaction-effective-date-consistency-design.md
@@ -34,7 +34,7 @@ Add a **Settled date** alongside the existing date wherever a transaction render
 - **Dashboard "recent transactions"** (`app/dashboard/page.tsx`): show both dates (compact form acceptable — e.g. settled date primary with the original as secondary/tooltip if space-constrained, but it must be visible, not hidden).
 - **Account detail recent transactions**, **transaction detail/edit** (`TransactionForm.tsx`), **batch view**, **transfer modals** — wherever a transaction's date is shown, show the settled date too. The plan will enumerate the exact components from a frontend audit.
 - **CSV export** (transactions export): add a `settled_date` column.
-- **Column labels:** operator term is "Creation date" / "Settled date". Technically `date` is the transaction/purchase date you assign (not the DB row-creation timestamp). Final labels (e.g. "Date" / "Settled", or "Booked" / "Settled") are cosmetic — lock in the plan; both columns must be present and clearly distinct.
+- **Column labels (LOCKED):** **"Date"** = the original transaction/purchase date (`date`), **"Settled"** = `settled_date`. Both columns present and clearly distinct on every transaction-display surface.
 
 ## Components / data flow
 - One backend change of substance: swap `Transaction.date` → `effective_period_date_expr()` at the classified bucketing sites (reports, the 3 forecast services, budgets-alignment). The expression already exists and is SQLite/MySQL-portable (it's `coalesce`).

--- a/specs/2026-06-15-transaction-effective-date-consistency-plan.md
+++ b/specs/2026-06-15-transaction-effective-date-consistency-plan.md
@@ -1,0 +1,200 @@
+# Transaction Effective-Date Consistency — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make every period-bucketing/reporting surface count a transaction in the period it *settled* (cash-basis), using the existing `effective_period_date_expr()`, and display both the original **Date** and the **Settled** date wherever a transaction renders.
+
+**Architecture:** Backend — swap raw `Transaction.date` → `effective_period_date_expr()` (= `coalesce(settled_date, date)`) at the classified bucketing sites only (Reports, the 3 forecast services, budget alignment). Frontend — additive display of the already-returned `settled_date` on every transaction-render surface. No model change, no migration.
+
+**Tech Stack:** Python 3.12 / FastAPI / SQLAlchemy 2.0 async (backend); Next.js/React/TS/Vitest (frontend).
+
+**Reference spec:** `specs/2026-06-15-transaction-effective-date-consistency-design.md`
+
+**Backend tests:** isolated stack only — `docker compose -p team-txdate up -d backend mysql redis`, then `-p team-txdate` on every exec. NEVER the default `pfv` stack; NEVER `./pfv migrate`.
+
+---
+
+## Shared test helper (used by every backend task)
+Each backend task asserts the **GBLT case**: a transaction whose `date` and `settled_date` fall in DIFFERENT months is bucketed by the **settled** month. Seed pattern (adapt to each test file's existing fixtures):
+```python
+# created/dated in May, settled in June
+tx = Transaction(org_id=org.id, account_id=acct.id, category_id=cat.id,
+                 description="GBLT", amount=Decimal("459.68"), type=TransactionType.EXPENSE,
+                 status=TransactionStatus.SETTLED, date=date(2026,5,31), settled_date=date(2026,6,15))
+```
+Reportable filter still applies (not a transfer leg / manual adjustment).
+
+---
+
+## Phase 1 — Backend: cash-basis bucketing everywhere
+
+### Task 1: Reports time-dimension bucketing (month/week/day)
+**Files:** Modify `backend/app/services/reports_query_service.py` (`_dimension_expr`, the MONTH/WEEK/DAY branches, ~`:96-110`). Test: `backend/tests/services/test_reports_query_service.py`.
+
+- [ ] **Step 1: Failing test** — group a GBLT-style settled-in-June expense by `month`; assert it lands in `2026-06`, not `2026-05`.
+```python
+@pytest.mark.asyncio
+async def test_month_bucketing_uses_settled_date(db_session, reports_org):
+    # seed GBLT: date=2026-05-31, settled_date=2026-06-15, SETTLED expense
+    ...
+    ast = ReportsQuery(dataset=Dataset.TRANSACTIONS,
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+        dimensions=[Dimension.MONTH])
+    rows, _ = await execute_query(db_session, ast, org_id=reports_org.id)
+    by_month = {r["month"]: r["value"] for r in rows}
+    assert "2026-06" in by_month and "2026-05" not in by_month
+```
+- [ ] **Step 2: Run → FAIL** (`-p team-txdate ... pytest tests/services/test_reports_query_service.py::test_month_bucketing_uses_settled_date -v`) — currently buckets to 2026-05.
+- [ ] **Step 3: Implement** — in `_dimension_expr`, replace `Transaction.date` with `effective_period_date_expr()` inside the three time-bucket expressions. Import the helper: `from app.services.transaction_filters import effective_period_date_expr`. E.g.:
+```python
+    eff = effective_period_date_expr()
+    if dim is Dimension.MONTH:
+        if dialect_name == "sqlite":
+            return func.strftime("%Y-%m", eff)
+        return func.date_format(eff, "%Y-%m")
+    if dim is Dimension.WEEK:
+        if dialect_name == "sqlite":
+            return func.strftime("%Y-%W", eff)
+        return func.date_format(eff, "%x-%v")
+    if dim is Dimension.DAY:
+        if dialect_name == "sqlite":
+            return func.strftime("%Y-%m-%d", eff)
+        return func.date_format(eff, "%Y-%m-%d")
+```
+- [ ] **Step 4: Run → PASS.** Also run the full `test_reports_query_service.py` — existing time-grouping tests that used same-day date/settled rows stay green (settled_date defaults to date for those).
+- [ ] **Step 5: Commit** — `git add backend/app/services/reports_query_service.py backend/tests/services/test_reports_query_service.py && git commit -m "fix(reports): bucket time dimensions by effective settled date"`
+
+### Task 2: Reports DATE filter column
+**Files:** Modify `reports_query_service.py` (`_FILTER_COLUMN[FilterField.DATE]`, ~`:144`). Test: same file.
+
+- [ ] **Step 1: Failing test** — a report with a `date BETWEEN 2026-06-01..2026-06-30` filter INCLUDES the GBLT (settled June, dated May).
+```python
+@pytest.mark.asyncio
+async def test_date_filter_uses_settled_date(db_session, reports_org):
+    # GBLT date=2026-05-31 settled=2026-06-15
+    ast = ReportsQuery(dataset=Dataset.TRANSACTIONS,
+        measure=Measure(agg=Aggregation.SUM, field=MeasureField.AMOUNT),
+        filters=[Filter(field=FilterField.DATE, op=FilterOp.BETWEEN,
+                        value=["2026-06-01","2026-06-30"])])
+    rows, meta = await execute_query(db_session, ast, org_id=reports_org.id)
+    assert meta["row_count"] == 1  # GBLT included by its June settled date
+```
+- [ ] **Step 2: Run → FAIL** (GBLT excluded today; its raw date is May).
+- [ ] **Step 3: Implement** — `_FILTER_COLUMN[FilterField.DATE] = effective_period_date_expr()` (the module already will import the helper from Task 1; if Task 2 lands first, add the import). The BETWEEN/scalar coercion is unchanged (comparing a coalesce(date,date) expression to coerced dates works).
+- [ ] **Step 4: Run → PASS** + full file green.
+- [ ] **Step 5: Commit** — `git commit -am "fix(reports): filter by effective settled date"`
+
+### Task 3: forecast_service period windows
+**Files:** Modify `backend/app/services/forecast_service.py` (`Transaction.date` window predicates at ~`:96-97,:107-108,:165-166`). Test: `backend/tests/services/test_forecast_service.py` (or nearest).
+
+- [ ] **Step 1: Failing test** — a settled-in-June GBLT counts toward the June forecast window, not May. (Mirror the file's existing forecast-period test; assert the GBLT amount is in the June aggregate.)
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — `from app.services.transaction_filters import effective_period_date_expr`; replace each `Transaction.date >= p_start` / `<= p_end` window predicate in the reportable aggregation queries with `effective_period_date_expr() >= p_start` / `<= p_end`. (Leave any `Transaction.date` use that is NOT a period window — verify each of the ~6 sites is a period-window predicate before swapping; if any is a display/order-only use, leave it and note why.)
+- [ ] **Step 4: Run → PASS** + full forecast-service tests green.
+- [ ] **Step 5: Commit** — `git commit -am "fix(forecast): bucket forecast windows by effective settled date"`
+
+### Task 4: forecast_plan_service period windows
+**Files:** Modify `backend/app/services/forecast_plan_service.py` (`:531,:537-538,:572-573`). Test: `backend/tests/services/test_forecast_plan_service.py` (or nearest).
+
+- [ ] **Step 1: Failing test** — GBLT settled-in-June counts in the June plan period (and the 3-months-history window uses effective date). Mirror the file's existing period test.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — import the helper; swap the period-window `Transaction.date` predicates (`>= p_start`, `<= p_end`, the `>= three_months_ago` / `< p_start` history window) to `effective_period_date_expr()`. The `select(Transaction.date, ...)` at `:531` — if it's selecting the date for display/grouping in the plan output, decide: if it groups by period, swap to effective; if it's surfaced as the literal transaction date, leave it and note. Classify before swapping.
+- [ ] **Step 4: Run → PASS** + full file green.
+- [ ] **Step 5: Commit** — `git commit -am "fix(forecast-plan): bucket plan windows by effective settled date"`
+
+### Task 5: scenario_engine history window
+**Files:** Modify `backend/app/services/scenario_engine.py` (`:668-669`). Test: `backend/tests/services/test_scenario_engine.py`.
+
+- [ ] **Step 1: Failing test** — a settled-in-June GBLT falls in the correct history bucket by settled date.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — import the helper; swap the `Transaction.date >= history_start` / `< today.replace(day=1)` window predicates to `effective_period_date_expr()`.
+- [ ] **Step 4: Run → PASS** + full scenario tests green.
+- [ ] **Step 5: Commit** — `git commit -am "fix(scenario): bucket history window by effective settled date"`
+
+### Task 6: Budget alignment to the shared expression
+**Files:** Modify `backend/app/services/budget_service.py` (`:47,:52`) + `backend/app/services/budget_rebalance_service.py` (`:203-204,:216,:219`). Test: `backend/tests/services/test_budget_service.py` (+ rebalance test).
+
+- [ ] **Step 1: Failing test** — a PENDING transaction with a `settled_date` ESTIMATE inside the period now counts toward the budget (today it counts via raw settled_date which is set, so this specifically tests the fallback consistency: a row with settled_date NULL but `date` in-period should be handled identically to the rest of the app). Concretely: assert a settled-in-period GBLT counts (unchanged) AND that the query now uses `effective_period_date_expr()` (behavior-identical for settled rows; the change is the coalesce fallback for the NULL-settled_date case).
+```python
+# settled GBLT still counts in its settled month (regression guard)
+# + a pending row with settled_date=None, date in-period: now included via coalesce fallback
+```
+- [ ] **Step 2: Run → FAIL** on the fallback case (NULL settled_date row excluded today).
+- [ ] **Step 3: Implement** — replace `Transaction.settled_date >= period_start` / `<= period_end` (and the rebalance 3-month + current windows) with `effective_period_date_expr() >= period_start` / `<= period_end`. Update the `# Use settled_date ...` comment to reference the shared expression. Behavior-identical for settled rows; adds the documented date-fallback for NULL-settled_date rows.
+- [ ] **Step 4: Run → PASS** + full budget tests green.
+- [ ] **Step 5: Commit** — `git commit -am "refactor(budgets): align period bucketing to effective_period_date_expr"`
+
+### Task 7: Phase-1 regression sweep + scope-guard verification
+- [ ] **Step 1:** `docker compose -p team-txdate exec -T backend pytest tests/ -k "report or forecast or budget or scenario or transaction" -q` — all green.
+- [ ] **Step 2: Scope guard** — confirm `recurring_service.py`, `import_service.py`, `transaction_suggestions_service.py` were NOT changed (`git diff --stat` shows none) and their tests pass. These keep raw `date` on purpose (due-date matching, dedup window, last-used).
+- [ ] **Step 3:** Commit any fixup (`git commit -am "test(txdate): phase-1 backend sweep green" || true`).
+
+---
+
+## Phase 2 — Frontend: dual-date display (Date + Settled) everywhere a transaction renders
+
+> The `settled_date` field is already on `TransactionResponse`/the `Transaction` TS type. Confirm in `frontend/lib/types.ts` (or `lib/reports/types.ts`); if absent on the relevant type, add it (`settled_date: string | null`). Labels: **"Date"** = `date`, **"Settled"** = `settled_date` (render `settled_date` or "—" when null). Pending rows: show the estimate or "—".
+
+### Task 8: Transactions list — Settled column
+**Files:** Modify `frontend/app/transactions/page.tsx` (the inline table: header row with the "Date" `<th>` and the body cell rendering `tx.date`). Test: `frontend/tests/app/transactions-settled-column.test.tsx` (new; mirror existing transactions-page test harness).
+
+- [ ] **Step 1: Failing test** — render the list with a GBLT row (`date:"2026-05-31"`, `settled_date:"2026-06-15"`); assert both a "Date" cell (2026-05-31) and a "Settled" cell (2026-06-15) are present; a row with `settled_date:null` shows "—" in Settled.
+- [ ] **Step 2: Run → FAIL** (`docker compose exec frontend npx vitest run tests/app/transactions-settled-column.test.tsx`).
+- [ ] **Step 3: Implement** — add a "Settled" `<th>` next to the existing "Date" header, and a body `<td>` rendering `formatDate(tx.settled_date)` or "—". Keep the existing "Date" column (now explicitly the original date). Match the existing date formatting/util used for `tx.date`.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `git add frontend/app/transactions/page.tsx frontend/tests/app/transactions-settled-column.test.tsx && git commit -m "feat(transactions): show Settled date column in the list"`
+
+### Task 9: Dashboard recent transactions — show Settled
+**Files:** Modify `frontend/app/dashboard/page.tsx` (the recent-transactions render). Test: `frontend/tests/app/dashboard-recent-settled.test.tsx` (new; mirror dashboard test harness).
+
+- [ ] **Step 1: Failing test** — the dashboard recent-transactions list renders the settled date for a GBLT row (visible, not hidden); null → "—".
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — surface `settled_date` alongside the shown date. If the recent list is space-constrained, show Settled as the primary date with the original date as a secondary line/tooltip — but it must be visibly present (per the operator: "we can't hide such information"). Reuse the list's date format util.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `git commit -am "feat(dashboard): show settled date on recent transactions"`
+
+### Task 10: Account-detail recent transactions + any other list
+**Files:** Modify `frontend/app/accounts/page.tsx` (and any account-detail recent-transactions view it renders). Test: new, mirroring the page's harness.
+
+- [ ] **Step 1: Failing test** — if `app/accounts/page.tsx` renders transaction rows with a date, assert the settled date is shown. (If it does NOT render transactions, SKIP this task and note it — `git diff` shows no change.)
+- [ ] **Step 2: Run → FAIL** (if applicable).
+- [ ] **Step 3: Implement** — same Date+Settled pattern as Task 8.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `git commit -am "feat(accounts): show settled date on account transactions" || true`
+
+### Task 11: Transaction detail/edit form + transfer/batch modals
+**Files:** Modify `frontend/components/floating/TransactionForm.tsx` and audit `frontend/components/transactions/{LinkAsTransferModal,MarkAsTransferModal,ImportMarkAsTransferModal,UnpairTransferModal,BatchEditModal}.tsx` + `frontend/app/transactions/batch/page.tsx` for any place a transaction's date is DISPLAYED (read-only). Test: new, per the form harness.
+
+- [ ] **Step 1: Failing test** — where `TransactionForm` (or a modal) shows an existing transaction's date read-only, assert the settled date is also shown. (The editable date input is the original `date`; if the form has a settled-date input/field already, ensure it's visible. For modals that show a transaction summary line with a date, add the settled date.)
+- [ ] **Step 2: Run → FAIL** (for surfaces that display a date today).
+- [ ] **Step 3: Implement** — add the Settled date display next to each shown date. For surfaces that only show the original date in a summary, append the settled date. Do not add settled-date editing unless the form already edits it.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `git commit -am "feat(transactions): surface settled date in form + transfer/batch modals"`
+
+### Task 12: CSV export (if a transactions CSV exists)
+**Files:** Locate the transactions CSV export (grep `frontend/` for the transactions export/download; if it lives backend-side, find the export endpoint/serializer). Test: per the export's existing test.
+
+- [ ] **Step 1:** Locate the transactions CSV export. If NONE exists (only the reports-widget CSV does), SKIP and note it in the final report.
+- [ ] **Step 2: Failing test** — the CSV includes a `settled_date` column with the row's settled date.
+- [ ] **Step 3: Implement** — add `settled_date` to the CSV header + row mapping, next to the existing date column.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `git commit -am "feat(transactions): add settled_date to CSV export" || true`
+
+### Task 13: Frontend verification gate
+- [ ] **Step 1:** `docker compose exec frontend npx eslint . --quiet` (CI gate — must be clean).
+- [ ] **Step 2:** `docker compose exec frontend npx tsc --noEmit`.
+- [ ] **Step 3:** `docker compose exec frontend npx vitest run` (FULL suite; known flake `settings-ai-providers-page > "PUTs the default routing payload on save"` passes in isolation).
+- [ ] **Step 4:** Commit any fixup.
+
+---
+
+## Final: cross-surface consistency + review
+- [ ] A cross-surface check (manual or test): the GBLT-style fixture appears in the **June** period in the list, the report (month grouping + date filter), and the forecast — same period everywhere.
+- [ ] Fleet review per the "ship clean" bar, fold all confirmed findings, then open the PR. Title: `feat(transactions): cash-basis effective-date bucketing + Date/Settled display`. No test-plan section, no AI attribution.
+
+---
+
+## Self-review (plan author)
+- **Spec coverage:** bucketing laggards → Tasks 1-5; budget alignment → Task 6; scope guard → Task 7; dual-date display on every surface → Tasks 8-12 (list, dashboard, accounts, form/modals, CSV); cash-basis app-wide → encoded by Tasks 1-6 + the consistency check. ✓
+- **Placeholder scan:** the "if NONE exists, SKIP and note" on Tasks 10/12 are explicit conditional-skip instructions (the surface may not render transactions / a transactions CSV may not exist), each with a `|| true` commit guard — not vague TODOs. The forecast-service tasks instruct classify-before-swap because the exact predicates vary per file; the transformation (period-window `Transaction.date` → `effective_period_date_expr()`) is concrete. ✓
+- **Consistency:** `effective_period_date_expr()` (import from `app.services.transaction_filters`) used identically across all backend tasks; "Date"/"Settled" labels + `settled_date`/"—" rendering used identically across frontend tasks. ✓


### PR DESCRIPTION
## Problem
A transaction dated in May but **settled** in June ("GBLT") showed up in the June *transactions list* (which buckets by settled date) but was **missing from the June report** (which bucketed by the raw `date`). Reports, forecasts, and the list answered "which period?" differently. And the list filtered by settled date while only *displaying* the creation date, so a May-dated row appearing in June looked wrong.

## Fix — two phases

### Phase 1: cash-basis bucketing everywhere
Standardize every period-bucketing surface on the existing `effective_period_date_expr()` (`coalesce(settled_date, date)`) — count a transaction in the period it settled:
- **Reports** — month/week/day time dimensions + the `DATE` filter column
- **forecast_service**, **forecast_plan_service**, **scenario_engine** — period/history windows (and the matching Python month-bucket keys, so an admitted row also *buckets* by settled date)
- **Budgets** — aligned to the shared expression (behavior-identical; they already used `settled_date`)

Scope guard: literal-calendar-date uses stay on raw `date` on purpose — recurring **due-date matching**, import **dedup windows**, "last-used" **suggestions**. The transactions list + dashboard month-end already used the effective date.

This makes the whole app **cash-basis** by deliberate design (documented in-code so it isn't reverted).

### Phase 2: dual-date display ("Date" + "Settled") wherever a transaction renders
We can't show a transaction in a period without showing why it's there. Added a **Settled** column/line (renders `settled_date` or `—`) on: the transactions list (desktop grid + mobile card), dashboard recent transactions, the three transfer modals (Link/Unpair/Mark legs), and transfer-match **candidates** (required adding `settled_date` to the `TransferCandidate` schema + type). Genuinely-skipped surfaces (no transaction date shown): accounts page (aggregates only), batch/import creation views, the edit form (already has a settled-date input). No transactions CSV export exists.

## Tests
Each backend surface has a GBLT regression test (date≠settled in different months → buckets to the settled month; non-tautological, confirmed by revert). Frontend: each render surface shows both dates + `—` for null. Backend 282 (transfer/transaction) + full reports/forecast/budget/scenario sweep green; frontend full suite 1861 green; eslint + tsc clean. **No migration.**

Built subagent-driven, review gate per phase (the candidate-list gap was a review finding, now fixed). Specs: `specs/2026-06-15-transaction-effective-date-consistency-{design,plan}.md`.