### PR TITLE
feat(landing): publish PocketSmith + Monarch /vs pages

### DIFF
--- a/frontend/app/compare/page.tsx
+++ b/frontend/app/compare/page.tsx
@@ -90,6 +90,14 @@ export default async function ComparePage() {
         ·{" "}
         <Link href="/vs/ynab" className="underline hover:text-text-primary">
           vs YNAB
+        </Link>{" "}
+        ·{" "}
+        <Link href="/vs/pocketsmith" className="underline hover:text-text-primary">
+          vs PocketSmith
+        </Link>{" "}
+        ·{" "}
+        <Link href="/vs/monarch" className="underline hover:text-text-primary">
+          vs Monarch
         </Link>
         .
       </p>

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -43,8 +43,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.7,
     },
-    // /vs/spreadsheets and /vs/ynab are indexable (robots index:true). The
-    // other two /vs pages (pocketsmith, monarch) are noindex and stay out.
+    // All four /vs pages are indexable (robots index:true).
     {
       url: `${siteUrl}/vs/spreadsheets`,
       lastModified,
@@ -53,6 +52,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
     {
       url: `${siteUrl}/vs/ynab`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
+      url: `${siteUrl}/vs/pocketsmith`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
+      url: `${siteUrl}/vs/monarch`,
       lastModified,
       changeFrequency: "monthly",
       priority: 0.6,

--- a/frontend/app/vs/monarch/page.tsx
+++ b/frontend/app/vs/monarch/page.tsx
@@ -1,5 +1,4 @@
 // frontend/app/vs/monarch/page.tsx
-// NOTE: noindex until the publish PR (staggered launch).
 import type { Metadata } from "next";
 import { readNonce } from "@/lib/nonce";
 import { apexCanonical, pageSocialMeta, siteName } from "@/lib/site";
@@ -17,7 +16,7 @@ export const metadata: Metadata = {
     description,
     path: apexCanonical("/vs/monarch"),
   }),
-  robots: { index: false, follow: false },
+  robots: { index: true, follow: true },
 };
 
 const faq = [

--- a/frontend/app/vs/pocketsmith/page.tsx
+++ b/frontend/app/vs/pocketsmith/page.tsx
@@ -1,8 +1,7 @@
 // frontend/app/vs/pocketsmith/page.tsx
-// NOTE: noindex until the publish PR (staggered launch). Do NOT add to sitemap,
-// llms.txt, or internal links until then. Honesty: PocketSmith's headline is
-// forecasting and it is NZ (EU adequacy), so this page leads with simplicity and
-// household sharing, NOT "we forecast better" or a hard EU-privacy claim.
+// Honesty: PocketSmith's headline is forecasting and it is NZ (EU adequacy), so
+// this page leads with simplicity and household sharing, NOT "we forecast
+// better" or a hard EU-privacy claim.
 import type { Metadata } from "next";
 import { readNonce } from "@/lib/nonce";
 import { apexCanonical, pageSocialMeta, siteName } from "@/lib/site";
@@ -20,7 +19,7 @@ export const metadata: Metadata = {
     description,
     path: apexCanonical("/vs/pocketsmith"),
   }),
-  robots: { index: false, follow: false },
+  robots: { index: true, follow: true },
 };
 
 const faq = [

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -16,5 +16,7 @@ The Better Decision tracks accounts, transactions, budgets, and forecasts, all s
 - [Compare](https://thebetterdecision.com/compare/): How The Better Decision compares with YNAB, PocketSmith, Monarch, and spreadsheets.
 - [vs Spreadsheets](https://thebetterdecision.com/vs/spreadsheets/): Why a forecasting app beats a manual budgeting spreadsheet, and where spreadsheets still win.
 - [vs YNAB](https://thebetterdecision.com/vs/ynab/): A YNAB alternative built around forecasting and EU data residency, and where YNAB still wins.
+- [vs PocketSmith](https://thebetterdecision.com/vs/pocketsmith/): Cash-flow forecasting in a simpler, household-shared app, and where PocketSmith goes deeper.
+- [vs Monarch](https://thebetterdecision.com/vs/monarch/): Forecasting-first planning with no bank linking required, and where Monarch's aggregation wins.
 - [Privacy](https://thebetterdecision.com/privacy/): How personal and financial data is handled.
 - [Terms](https://thebetterdecision.com/terms/): Terms of use.

--- a/frontend/scripts/build-apex.sh
+++ b/frontend/scripts/build-apex.sh
@@ -309,6 +309,8 @@ cat > "${FRONTEND_DIR}/out-apex/sitemap.xml" <<EOF
   <url><loc>${APEX_URL}/compare/</loc><lastmod>${BUILD_TIME%T*}</lastmod></url>
   <url><loc>${APEX_URL}/vs/spreadsheets/</loc><lastmod>${BUILD_TIME%T*}</lastmod></url>
   <url><loc>${APEX_URL}/vs/ynab/</loc><lastmod>${BUILD_TIME%T*}</lastmod></url>
+  <url><loc>${APEX_URL}/vs/pocketsmith/</loc><lastmod>${BUILD_TIME%T*}</lastmod></url>
+  <url><loc>${APEX_URL}/vs/monarch/</loc><lastmod>${BUILD_TIME%T*}</lastmod></url>
 </urlset>
 EOF
 

--- a/frontend/tests/build-apex.test.ts
+++ b/frontend/tests/build-apex.test.ts
@@ -198,7 +198,14 @@ describe("apex build allowlist covers new marketing routes", () => {
   it.each(["features", "compare", "vs"])("ALLOWED_OUTPUT_GLOBS includes %s", (d) => {
     expect(script).toMatch(new RegExp(`ALLOWED_OUTPUT_GLOBS=\\([^)]*"${d}"`, "s"));
   });
-  it.each(["/features/", "/compare/", "/vs/spreadsheets/", "/vs/ynab/"])(
+  it.each([
+    "/features/",
+    "/compare/",
+    "/vs/spreadsheets/",
+    "/vs/ynab/",
+    "/vs/pocketsmith/",
+    "/vs/monarch/",
+  ])(
     "apex sitemap heredoc lists %s",
     (route) => {
       expect(script).toContain(`${"${APEX_URL}"}${route}</loc>`);

--- a/frontend/tests/seo-public-routes-indexable.test.tsx
+++ b/frontend/tests/seo-public-routes-indexable.test.tsx
@@ -42,16 +42,9 @@ describe("published /vs pages are indexable", () => {
   it.each([
     ["/vs/spreadsheets", vsSpreadsheetsMetadata],
     ["/vs/ynab", vsYnabMetadata],
-  ] as const)("%s indexes", (_r, meta) => {
-    expect(meta.robots).toEqual({ index: true, follow: true });
-  });
-});
-
-describe("staggered /vs pages stay out of the index until launch", () => {
-  it.each([
     ["/vs/pocketsmith", vsPocketsmithMetadata],
     ["/vs/monarch", vsMonarchMetadata],
-  ] as const)("%s is noindex", (_r, meta) => {
-    expect(meta.robots).toEqual({ index: false, follow: false });
+  ] as const)("%s indexes", (_r, meta) => {
+    expect(meta.robots).toEqual({ index: true, follow: true });
   });
 });

--- a/frontend/tests/sitemap-includes-docs.test.ts
+++ b/frontend/tests/sitemap-includes-docs.test.ts
@@ -21,14 +21,14 @@ describe("sitemap.ts", () => {
     expect(urls).not.toContain("/login");
   });
 
-  it("includes the indexable marketing pages and omits the noindex /vs pages", () => {
+  it("includes the indexable marketing pages and all four /vs pages", () => {
     const urls = sitemap().map((entry) => new URL(entry.url).pathname);
     expect(urls).toContain("/features");
     expect(urls).toContain("/compare");
     expect(urls).toContain("/vs/spreadsheets");
     expect(urls).toContain("/vs/ynab");
-    // /vs/pocketsmith and /vs/monarch are noindex (staggered for a later PR).
-    expect(urls).not.toContain("/vs/pocketsmith");
-    expect(urls).not.toContain("/vs/monarch");
+    // PocketSmith and Monarch are now published (staggered launch complete).
+    expect(urls).toContain("/vs/pocketsmith");
+    expect(urls).toContain("/vs/monarch");
   });
 });


### PR DESCRIPTION
## Summary

Completes the staggered launch of the PocketSmith and Monarch competitor comparison pages (Task 12 of `specs/2026-06-09-landing-features-compare-vs-seo-plan.md`). These two `/vs/*` pages shipped as code in PR #421 but were held `noindex`/unlinked pending Google Search Console confirmation that `/vs/spreadsheets` and `/vs/ynab` were indexed. That gate is now satisfied, so both pages are flipped to fully published, mirroring exactly how spreadsheets/ynab are already published.

## Changes

- **robots:** flip `/vs/pocketsmith` + `/vs/monarch` from `index:false` to `index:true, follow:true`; drop the "noindex until launch" comments.
- **App SSR sitemap** (`app/sitemap.ts`): add both routes.
- **Apex static host** (`scripts/build-apex.sh`): add both routes to the apex sitemap heredoc (the two-host consistency trap — both sitemaps now in lockstep).
- **`public/llms.txt`:** add both pages under `## Pages`.
- **`/compare`:** link both pages alongside the existing spreadsheets/YNAB links, matching the existing inline-underline treatment.
- **Tests:** `seo-public-routes-indexable.test.tsx` (move both into the indexable group, delete the now-empty staggered block), `build-apex.test.ts` (heredoc assertion now covers all four /vs routes), and `sitemap-includes-docs.test.ts` (updated the stale "omits the noindex /vs pages" assertion to assert all four are present).

## Honesty check

Re-reviewed `lib/comparison.ts` for both competitors. All claims are defensible:
- PocketSmith `privacyFirstAi` = "Opt-in AI beta, no bring-your-own or local" (already corrected from the earlier false "No AI features" per the prior wave).
- PocketSmith `euResidency` = "New Zealand, with EU adequacy" (NZ has an EU adequacy decision).
- Monarch `privacyFirstAi` = "Built-in assistant, no bring-your-own or local" (Monarch ships its own assistant without BYOK).
- Monarch US-based / paid-subscription — defensible.

No false or unverifiable claims found; nothing changed in the comparison data.

## Verification

- `eslint . --quiet` → clean (exit 0)
- `tsc --noEmit` → clean (exit 0)
- `vitest run` (full suite) → **247 files / 1863 tests passed**

Run natively in the worktree (fresh `npm ci`) so the suite sees the actual edited `scripts/` files rather than the dev container's stale baked copies.